### PR TITLE
Allow multiple parallel builds in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
-      max-parallel: 1
       matrix:
         include:
           - host: BrightFalls


### PR DESCRIPTION
Removed the max-parallel setting to allow multiple parallel builds.