### PR TITLE
fix(nightsprings): fix xcodes module bugs and bump to Xcode 26.3

### DIFF
--- a/hosts/NightSprings/users/matteo/xcodes.nix
+++ b/hosts/NightSprings/users/matteo/xcodes.nix
@@ -3,8 +3,8 @@
   programs.xcodes = {
     enable = true;
     versions = [
-      "26.2"
+      "26.3"
     ];
-    active = "26.2";
+    active = "26.3";
   };
 }

--- a/modules/home-manager/darwin/xcodes.nix
+++ b/modules/home-manager/darwin/xcodes.nix
@@ -25,7 +25,7 @@ let
   # Update xcodes index to fetch latest available versions
   updateScript = ''
     echo "Updating Xcode versions index..."
-    xcodes update 2>&1 > /dev/null
+    xcodes update > /dev/null 2>&1
   '';
 
   # Install each requested Xcode version
@@ -53,14 +53,13 @@ let
 
     if [ -z "$TO_REMOVE" ]; then
       echo "No Xcodes to remove."
-      exit 0
+    else
+      while IFS= read -r version; do
+        echo "Removing Xcode $version..."
+        xcodes uninstall --empty-trash \
+          --directory "${xcodesDir}" "$version"
+      done <<< "$TO_REMOVE"
     fi
-
-    while IFS= read -r version; do
-      echo "Removing Xcode $version..."
-      xcodes uninstall --empty-trash \
-        --directory "${xcodesDir}" "$version"
-    done <<< "$TO_REMOVE"
   '';
 in
 {


### PR DESCRIPTION
## Summary
- Fix `exit 0` in xcodes cleanup script that would terminate the entire HM activation when no Xcodes need removal
- Fix incorrect output redirection (`2>&1 > /dev/null` → `> /dev/null 2>&1`) in update script
- Bump NightSprings Xcode from 26.2 to 26.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)