### PR TITLE
feat: add qemu-3dfx package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -425,5 +425,22 @@
       homeManagerModules = {
         xcodes = import ./modules/home-manager/darwin/xcodes.nix;
       };
+
+      packages =
+        let
+          forSystem =
+            system:
+            let
+              pkgs = import inputs.nixpkgs { inherit system; };
+            in
+            {
+              qemu-3dfx = pkgs.callPackage ./packages/qemu-3dfx.nix { };
+            };
+        in
+        {
+          x86_64-linux = forSystem "x86_64-linux";
+          x86_64-darwin = forSystem "x86_64-darwin";
+          aarch64-darwin = forSystem "aarch64-darwin";
+        };
     };
 }

--- a/packages/qemu-3dfx-mesa-glide.patch
+++ b/packages/qemu-3dfx-mesa-glide.patch
@@ -1,0 +1,757 @@
+diff -Nru ../orig/qemu-9.2.2/accel/kvm/kvm-all.c ./accel/kvm/kvm-all.c
+--- ../orig/qemu-9.2.2/accel/kvm/kvm-all.c
++++ ./accel/kvm/kvm-all.c
+@@ -1676,6 +1676,43 @@
+     return 0;
+ }
+
++void kvm_update_guest_pa_range(uint64_t start_pa, uint64_t size, void *host_va, int readonly, int add)
++{
++    KVMState *s = kvm_state;
++    KVMMemoryListener *kml = &s->memory_listener;
++
++    MemoryRegion mr;
++    MemoryRegionSection section;
++    RAMBlock ram_block;
++
++    memset(&ram_block, 0, sizeof(RAMBlock));
++    ram_block.mr = &mr;
++    ram_block.used_length = REAL_HOST_PAGE_ALIGN(size);
++    ram_block.max_length = REAL_HOST_PAGE_ALIGN(size);
++    ram_block.fd = -1;
++    ram_block.guest_memfd = -1;
++    ram_block.page_size = getpagesize();
++    ram_block.host = host_va;
++    ram_block.flags |= RAM_PREALLOC;
++
++    memory_region_init(&mr, NULL, NULL, REAL_HOST_PAGE_ALIGN(size));
++    mr.ram = true;
++    mr.ram_block = &ram_block;
++    mr.readonly = readonly;
++    mr.nonvolatile = false;
++
++    section.mr = &mr;
++    section.fv = 0;
++    section.offset_within_region = 0;
++    section.size = mr.size;
++    section.offset_within_address_space = start_pa;
++    section.readonly = mr.readonly;
++    section.nonvolatile = mr.nonvolatile;
++
++    kvm_set_phys_mem(kml, &section, add);
++    object_unref(OBJECT(&mr));
++}
++
+ static void kvm_region_add(MemoryListener *listener,
+                            MemoryRegionSection *section)
+ {
+diff -Nru ../orig/qemu-9.2.2/hw/i386/pc.c ./hw/i386/pc.c
+--- ../orig/qemu-9.2.2/hw/i386/pc.c
++++ ./hw/i386/pc.c
+@@ -1233,6 +1233,10 @@
+             ? ON_OFF_AUTO_OFF : ON_OFF_AUTO_ON;
+     }
+
++    /* Glide pass-through */
++    glidept_mm_init();
++    /* MESA pass-through */
++    mesapt_mm_init();
+     /* Super I/O */
+     pc_superio_init(isa_bus, create_fdctrl, pcms->i8042_enabled,
+                     pcms->vmport != ON_OFF_AUTO_ON, &error_fatal);
+@@ -1261,6 +1265,23 @@
+     rom_reset_order_override();
+ }
+
++void glidept_mm_init(void)
++{
++    DeviceState *glidept_dev = NULL;
++
++    glidept_dev = qdev_new(TYPE_GLIDEPT);
++    sysbus_realize(SYS_BUS_DEVICE(glidept_dev), &error_fatal);
++    sysbus_mmio_map(SYS_BUS_DEVICE(glidept_dev), 0, GLIDEPT_MM_BASE);
++}
++void mesapt_mm_init(void)
++{
++    DeviceState *mesapt_dev = NULL;
++
++    mesapt_dev = qdev_new(TYPE_MESAPT);
++    sysbus_realize(SYS_BUS_DEVICE(mesapt_dev), &error_fatal);
++    sysbus_mmio_map(SYS_BUS_DEVICE(mesapt_dev), 0, MESAPT_MM_BASE);
++}
++
+ void pc_i8259_create(ISABus *isa_bus, qemu_irq *i8259_irqs)
+ {
+     qemu_irq *i8259;
+diff -Nru ../orig/qemu-9.2.2/include/hw/i386/pc.h ./include/hw/i386/pc.h
+--- ../orig/qemu-9.2.2/include/hw/i386/pc.h
++++ ./include/hw/i386/pc.h
+@@ -204,6 +204,25 @@
+ 
+ #define TYPE_PORT92 "port92"
+ 
++#if (((QEMU_VERSION_MAJOR << 12) | (QEMU_VERSION_MINOR << 8) \
++     | QEMU_VERSION_MICRO) < 0x5100)
++#define qdev_new(x)         qdev_create(NULL,x)
++#define sysbus_realize(x,y) qdev_init_nofail((DeviceState *)x)
++#endif
++#if (((QEMU_VERSION_MAJOR << 12) | (QEMU_VERSION_MINOR << 8) \
++     | QEMU_VERSION_MICRO) < 0x9132)
++#define device_class_set_legacy_reset(x,y) x->reset = y
++#endif
++/* GLIDE pass-through */
++#define TYPE_GLIDEPT "glidept"
++#define GLIDEPT_MM_BASE 0xfbdff000
++void glidept_mm_init(void);
++
++/* MESA pass-through */
++#define TYPE_MESAPT "mesapt"
++#define MESAPT_MM_BASE 0xefffe000
++void mesapt_mm_init(void);
++
+ /* pc_sysfw.c */
+ void pc_system_flash_create(PCMachineState *pcms);
+ void pc_system_flash_cleanup_unused(PCMachineState *pcms);
+diff -Nru ../orig/qemu-9.2.2/include/sysemu/kvm.h ./include/sysemu/kvm.h
+--- ../orig/qemu-9.2.2/include/sysemu/kvm.h
++++ ./include/sysemu/kvm.h
+@@ -478,6 +478,8 @@
+ 
+ #endif /* COMPILING_PER_TARGET */
+ 
++void kvm_update_guest_pa_range(uint64_t start_pa, uint64_t size, void *host_va, int readonly, int add);
++
+ void kvm_cpu_synchronize_state(CPUState *cpu);
+ 
+ void kvm_init_cpu_signals(CPUState *cpu);
+diff -Nru ../orig/qemu-9.2.2/include/sysemu/whpx.h ./include/sysemu/whpx.h
+--- ../orig/qemu-9.2.2/include/sysemu/whpx.h
++++ ./include/sysemu/whpx.h
+@@ -19,6 +19,8 @@
+
+ #ifdef CONFIG_WHPX
+
++void whpx_update_guest_pa_range(uint64_t start_pa, uint64_t size, void *host_va, int readonly, int add);
++
+ int whpx_enabled(void);
+ bool whpx_apic_in_platform(void);
+ 
+diff -Nru ../orig/qemu-9.2.2/include/ui/console.h ./include/ui/console.h
+--- ../orig/qemu-9.2.2/include/ui/console.h
++++ ./include/ui/console.h
+@@ -153,6 +153,8 @@
+     uint32_t  width;
+     uint32_t  height;
+     uint32_t  refresh_rate;
++    /* passthrough */
++    bool passthrough;
+ } QemuUIInfo;
+
+ /* cursor data format is 32bit RGBA */
+@@ -381,6 +383,7 @@
+                                void *opaque);
+ void graphic_console_close(QemuConsole *con);
+
++void graphic_hw_passthrough(QemuConsole *con, bool passthrough);
+ void graphic_hw_update(QemuConsole *con);
+ void graphic_hw_update_done(QemuConsole *con);
+ void graphic_hw_invalidate(QemuConsole *con);
+@@ -475,4 +478,19 @@
+                                       size_t size,
+                                       Error **errp);
+ 
++/* glidewnd.c */
++void glide_prepare_window(uint32_t, int, void *, void *);
++void glide_release_window(void *, void *);
++int glide_window_stat(const int);
++int glide_gui_fullscreen(int *, int *);
++void glide_renderer_stat(const int);
++
++/* mglcntx.c */
++void mesa_renderer_stat(const int);
++void mesa_prepare_window(int, int, int, void *);
++void mesa_release_window(void);
++void mesa_cursor_define(int, int, int, int, const void *);
++void mesa_mouse_warp(int, int, const int);
++int mesa_gui_fullscreen(int *);
++
+ #endif
+diff -Nru ../orig/qemu-9.2.2/meson.build ./meson.build
+--- ../orig/qemu-9.2.2/meson.build
++++ ./meson.build
+@@ -1561,6 +1561,7 @@
+     error('sdl-image required, but SDL was @0@'.format(
+           get_option('sdl').disabled() ? 'disabled' : 'not found'))
+   endif
++  error('Featuring qemu-3dfx required SDL2')
+   sdl_image = not_found
+ endif
+
+@@ -3706,6 +3707,8 @@
+                          arguments: ['@INPUT@', '@EXTRA_ARGS@', '-o', '@OUTPUT@'])
+   subdir('libdecnumber')
+   subdir('target')
++  subdir('hw/3dfx')
++  subdir('hw/mesa')
+ endif
+ 
+ subdir('audio')
+@@ -4124,6 +4127,11 @@
+   target_inc = [include_directories('target' / config_target['TARGET_BASE_ARCH'])]
+   if host_os == 'linux'
+     target_inc += include_directories('linux-headers', is_system: true)
++    link_args += ['-ldl', '-lX11', '-lXxf86vm', '-lGL']
++  endif
++  if host_os == 'darwin'
++    c_args += ['-I/opt/X11/include']
++    link_args += ['-L/opt/X11/lib', '-lX11', '-lXxf86vm', '-lGL', '-Wl,-framework,OpenGL']
+   endif
+   if target.endswith('-softmmu')
+     target_type='system'
+diff -Nru ../orig/qemu-9.2.2/system/vl.c ./system/vl.c
+--- ../orig/qemu-9.2.2/system/vl.c
++++ ./system/vl.c
+@@ -871,6 +871,13 @@
+     return default_machineclass;
+ }
+
++static void feature(void)
++{
++    const char rev_[ALIGNED(1)]
++        ;
++    printf("  featuring qemu-3dfx@%s"__TIME__" "__DATE__" build\n", rev_);
++}
++
+ static void version(void)
+ {
+     printf("QEMU emulator version " QEMU_FULL_VERSION "\n"
+@@ -3004,6 +3011,7 @@
+                 break;
+             case QEMU_OPTION_version:
+                 version();
++                feature();
+                 exit(0);
+                 break;
+             case QEMU_OPTION_m:
+diff -Nru ../orig/qemu-9.2.2/target/i386/whpx/whpx-all.c ./target/i386/whpx/whpx-all.c
+--- ../orig/qemu-9.2.2/target/i386/whpx/whpx-all.c
++++ ./target/i386/whpx/whpx-all.c
+@@ -10,6 +10,7 @@
+
+ #include "qemu/osdep.h"
+ #include "cpu.h"
++#include "exec/ram_addr.h"
+ #include "exec/address-spaces.h"
+ #include "exec/ioport.h"
+ #include "gdbstub/helpers.h"
+@@ -2365,6 +2366,40 @@
+                         memory_region_is_rom(mr), mr->name);
+ }
+
++void whpx_update_guest_pa_range(uint64_t start_pa, uint64_t size, void *host_va, int readonly, int add)
++{
++    MemoryRegion mr;
++    MemoryRegionSection section;
++    RAMBlock ram_block;
++
++    memset(&ram_block, 0, sizeof(RAMBlock));
++    ram_block.mr = &mr;
++    ram_block.used_length = REAL_HOST_PAGE_ALIGN(size);
++    ram_block.max_length = REAL_HOST_PAGE_ALIGN(size);
++    ram_block.fd = -1;
++    ram_block.guest_memfd = -1;
++    ram_block.page_size = getpagesize();
++    ram_block.host = host_va;
++    ram_block.flags |= RAM_PREALLOC;
++
++    memory_region_init(&mr, NULL, NULL, REAL_HOST_PAGE_ALIGN(size));
++    mr.ram = true;
++    mr.ram_block = &ram_block;
++    mr.readonly = readonly;
++    mr.nonvolatile = false;
++
++    section.mr = &mr;
++    section.fv = 0;
++    section.offset_within_region = 0;
++    section.size = mr.size;
++    section.offset_within_address_space = start_pa;
++    section.readonly = mr.readonly;
++    section.nonvolatile = mr.nonvolatile;
++
++    whpx_process_section(&section, add);
++    object_unref(OBJECT(&mr));
++}
++
+ static void whpx_region_add(MemoryListener *listener,
+                            MemoryRegionSection *section)
+ {
+diff -Nru ../orig/qemu-9.2.2/ui/console.c ./ui/console.c
+--- ../orig/qemu-9.2.2/ui/console.c
++++ ./ui/console.c
+@@ -126,6 +126,11 @@
+     }
+ }
+
++void graphic_hw_passthrough(QemuConsole *con, bool passthrough)
++{
++    con->ui_info.passthrough = passthrough;
++}
++
+ void graphic_hw_update_done(QemuConsole *con)
+ {
+     if (con) {
+@@ -140,6 +145,8 @@
+         return;
+     }
+     if (con->hw_ops->gfx_update) {
++        if (con->ui_info.passthrough) { }
++        else
+         con->hw_ops->gfx_update(con->hw);
+         async = con->hw_ops->gfx_update_async;
+     }
+diff -Nru ../orig/qemu-9.2.2/ui/sdl2.c ./ui/sdl2.c
+--- ../orig/qemu-9.2.2/ui/sdl2.c
++++ ./ui/sdl2.c
+@@ -25,6 +25,7 @@
+ 
+ #include "qemu/osdep.h"
+ #include "qemu/module.h"
++#include "qemu/error-report.h"
+ #include "qemu/cutils.h"
+ #include "ui/console.h"
+ #include "ui/input.h"
+@@ -568,6 +569,29 @@
+     qemu_input_event_sync();
+ }
+
++static int fxui_grab_val(const int grab)
++{
++    static int fxui_grab;
++    fxui_grab = (grab & 0x80U)? (grab & 0x01U):fxui_grab;
++    return fxui_grab;
++}
++static int fxui_focus_lost(void)
++{
++    int ret = fxui_grab_val(0);
++    fxui_grab_val(0x80);
++    return ret;
++}
++static void fxui_focus_gained(struct sdl2_console *scon)
++{
++    if (fxui_grab_val(0)) {
++        if (gui_grab) {
++            sdl_grab_end(scon);
++            fxui_grab_val(0x80);
++        }
++        sdl_grab_start(scon);
++    }
++}
++
+ static void handle_windowevent(SDL_Event *ev)
+ {
+     struct sdl2_console *scon = get_scon_from_window(ev->window.windowID);
+@@ -592,6 +616,7 @@
+         sdl2_redraw(scon);
+         break;
+     case SDL_WINDOWEVENT_FOCUS_GAINED:
++        fxui_focus_gained(scon);
+         /* fall through */
+     case SDL_WINDOWEVENT_ENTER:
+         if (!gui_grab && (qemu_input_is_absolute(scon->dcl.con) || absolute_enabled)) {
+@@ -607,7 +632,8 @@
+         scon->ignore_hotkeys = get_mod_state();
+         break;
+     case SDL_WINDOWEVENT_FOCUS_LOST:
+-        if (gui_grab && !gui_fullscreen) {
++        if (!fxui_focus_lost() && gui_grab && !gui_fullscreen) {
++            fxui_grab_val(0x80 | gui_grab);
+             sdl_grab_end(scon);
+         }
+         break;
+@@ -774,6 +800,367 @@
+     SDL_QuitSubSystem(SDL_INIT_VIDEO);
+ }
+ 
++static void sdl_display_valid(const char *feat)
++{
++    if (!sdl2_console) {
++        error_report("%s: invalid sdl display. Use '-display sdl'", feat);
++        exit(1);
++    }
++    if (sdl2_console[0].opengl) {
++        error_report("%s: qemu-3dfx activation conflicts with display 'sdl,gl=on'", feat);
++        exit(1);
++    }
++}
++static void sdl_gui_restart(struct sdl2_console *scon, SDL_Surface *icon)
++{
++    if (!gui_fullscreen)
++        SDL_GetWindowPosition(scon->real_window, &scon->x, &scon->y);
++    fxui_grab_val(0x80 | gui_grab);
++    sdl_grab_end(scon);
++    sdl2_window_destroy(scon);
++    sdl2_window_create(scon);
++    if (icon)
++        SDL_SetWindowIcon(scon->real_window, icon);
++    if (!gui_fullscreen)
++        SDL_SetWindowPosition(scon->real_window, scon->x, scon->y);
++}
++
++static struct sdl_console_cb {
++    QEMUTimer *ts;
++    SDL_Surface *icon;
++    struct sdl2_console *scon;
++    int glide_on_mesa, gui_saved_res, render_pause;
++    int res, msaa, alpha, dtimer, GLon12;
++    void *hnwnd, *opaque;
++    void (*cwnd_fn)(void *, void *, void *);
++} scon_cb;
++static void wndproc_fxui_stat(struct sdl_console_cb *s)
++{
++    if (s->render_pause) {
++        SDL_DestroyTexture(s->scon->texture);
++        s->scon->texture = NULL;
++    }
++    else {
++        if (!s->scon->real_renderer)
++            s->scon->real_renderer = SDL_CreateRenderer(s->scon->real_window, -1 ,0);
++        sdl2_2d_switch(&s->scon->dcl, s->scon->surface);
++        if (!gui_fullscreen)
++            SDL_SetWindowPosition(s->scon->real_window, s->scon->x, s->scon->y);
++    }
++}
++static void wndproc_fxui_prepare(struct sdl_console_cb *s)
++{
++    SDL_GL_SetAttribute(SDL_GL_BUFFER_SIZE, 32);
++    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE,  24);
++    SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
++#ifdef CONFIG_DARWIN
++    if (!s->dtimer)
++        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
++#endif
++    if (s->alpha)
++        SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
++    if (s->msaa) {
++        SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, SDL_TRUE);
++        SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, s->msaa);
++    }
++    const char hint[] = "opengl";
++    if (!SDL_GetHint(SDL_HINT_RENDER_DRIVER) ||
++        memcmp(SDL_GetHint(SDL_HINT_RENDER_DRIVER), hint, sizeof(hint) - 1)) {
++        SDL_SetHint(SDL_HINT_RENDER_DRIVER, hint);
++        sdl_gui_restart(s->scon, s->icon);
++    }
++    SDL_SysWMinfo wmi;
++    SDL_VERSION(&wmi.version);
++    if (SDL_GetWindowWMInfo(s->scon->real_window, &wmi)) {
++        switch(wmi.subsystem) {
++#if defined(SDL_VIDEO_DRIVER_WINDOWS)
++            case SDL_SYSWM_WINDOWS:
++                s->hnwnd = (void *)wmi.info.win.window;
++                break;
++#endif
++#if defined(SDL_VIDEO_DRIVER_X11)
++            case SDL_SYSWM_X11:
++                s->hnwnd = (void *)wmi.info.x11.window;
++                break;
++#endif
++#if defined(SDL_VIDEO_DRIVER_COCOA)
++            case SDL_SYSWM_COCOA:
++                s->hnwnd = (void *)wmi.info.cocoa.window;
++                break;
++#endif
++            default:
++                s->hnwnd = NULL;
++                break;
++        }
++    }
++    SDL_DestroyTexture(s->scon->texture);
++    SDL_DestroyRenderer(s->scon->real_renderer);
++    s->scon->real_renderer = NULL;
++    s->scon->texture = NULL;
++    s->render_pause = 1;
++    s->scon->winctx = SDL_GL_GetCurrentContext();
++    if (!s->scon->winctx)
++        s->scon->winctx = SDL_GL_CreateContext(s->scon->real_window);
++    if (!s->scon->winctx) {
++        error_report("%s", SDL_GetError());
++        exit(1);
++    }
++    if (!s->opaque)
++        s->cwnd_fn(s->scon->real_window, s->hnwnd, s->opaque);
++    SDL_GL_MakeCurrent(s->scon->real_window, NULL);
++}
++static void wndproc_fxui_release(struct sdl_console_cb *s)
++{
++    if (s->GLon12) {
++        if (!s->scon->real_renderer)
++            s->scon->real_renderer = SDL_CreateRenderer(s->scon->real_window, -1 ,0);
++    }
++    else {
++        SDL_GL_DeleteContext(s->scon->winctx);
++        SDL_GL_ResetAttributes();
++        SDL_ResetHint(SDL_HINT_RENDER_DRIVER);
++        s->scon->winctx = NULL;
++        sdl_gui_restart(s->scon, s->icon);
++    }
++    sdl2_2d_switch(&s->scon->dcl, s->scon->surface);
++    s->render_pause = 0;
++    timer_del(s->ts);
++    timer_free(s->ts);
++    s->ts = NULL;
++}
++static void sched_wndproc(void *opaque)
++{
++    struct sdl_console_cb *s = opaque;
++
++    if (s->res == -1)
++        wndproc_fxui_stat(s);
++    else if (s->gui_saved_res)
++        wndproc_fxui_prepare(s);
++    else
++        wndproc_fxui_release(s);
++    if (s->res > 0)
++        SDL_SetWindowSize(s->scon->real_window, (s->res & 0xFFFFU), (s->res >> 0x10));
++    if (s->opaque || !s->render_pause)
++        graphic_hw_passthrough(s->scon->dcl.con, s->render_pause);
++}
++
++static int sdl_gui_fullscreen(int *sizev, const char *feat)
++{
++    struct sdl_console_cb *s = &scon_cb;
++
++    sdl_display_valid(feat);
++    s->scon = &sdl2_console[0];
++    if (sizev) {
++        sizev[0] = surface_width(s->scon->surface);
++        sizev[1] = surface_height(s->scon->surface);
++        if (!memcmp(feat, "mesapt", sizeof("mesapt")))
++            SDL_GL_GetDrawableSize(s->scon->real_window, &sizev[2], &sizev[3]);
++    }
++    return gui_fullscreen;
++}
++
++static void sdl_renderer_stat(const int activate, const char *feat)
++{
++    struct sdl_console_cb *s = &scon_cb;
++
++    if (activate == s->render_pause)
++        return;
++
++    sdl_display_valid(feat);
++    s->scon = &sdl2_console[0];
++    s->res = -1;
++    s->render_pause = activate;
++
++    if (!s->ts)
++        s->ts = timer_new_ms(QEMU_CLOCK_REALTIME, &sched_wndproc, s);
++    timer_mod(s->ts, qemu_clock_get_ms(QEMU_CLOCK_REALTIME));
++}
++
++void glide_prepare_window(uint32_t res, int msaa, void *opaque, void *cwnd_fn)
++{
++    int scr_w, scr_h;
++    struct sdl_console_cb *s = &scon_cb;
++
++    sdl_display_valid("glidept");
++    s->scon = &sdl2_console[0];
++    s->opaque = opaque;
++    s->cwnd_fn = (void (*)(void *, void *, void *))cwnd_fn;
++    if (s->render_pause) {
++        s->glide_on_mesa = 1;
++        s->gui_saved_res = 0;
++    }
++    else {
++        SDL_GetWindowSize(s->scon->real_window, &scr_w, &scr_h);
++        s->gui_saved_res = ((scr_h & 0x7FFFU) << 0x10) | scr_w;
++        s->res = res;
++        s->msaa = msaa;
++        s->alpha = 1;
++#ifdef CONFIG_DARWIN
++        s->dtimer = s->alpha;
++#endif
++        if (!s->ts)
++            s->ts = timer_new_ms(QEMU_CLOCK_REALTIME, &sched_wndproc, s);
++        timer_mod(s->ts, qemu_clock_get_ms(QEMU_CLOCK_REALTIME));
++    }
++}
++
++void glide_release_window(void *opaque, void *cwnd_fn)
++{
++    struct sdl_console_cb *s = &scon_cb;
++
++    sdl_display_valid("glidept");
++    s->scon = &sdl2_console[0];
++    s->opaque = opaque;
++    s->cwnd_fn = (void (*)(void *, void *, void *))cwnd_fn;
++    if (s->gui_saved_res) {
++        s->res = s->gui_saved_res;
++        s->gui_saved_res = 0;
++        if (s->ts)
++            timer_mod(s->ts, qemu_clock_get_ms(QEMU_CLOCK_REALTIME));
++    }
++}
++
++int glide_window_stat(const int activate)
++{
++    int stat;
++    struct sdl_console_cb *s = &scon_cb;
++
++    if (activate) {
++        if (s->scon->winctx) {
++            int scr_w, scr_h;
++            SDL_GetWindowSize(s->scon->real_window, &scr_w, &scr_h);
++#ifdef CONFIG_DARWIN
++            if (SDL_GL_MakeCurrent(s->scon->real_window, s->scon->winctx))
++                fprintf(stderr, "%s\n", SDL_GetError());
++#endif
++            stat = ((scr_h & 0x7FFFU) << 0x10) | scr_w;
++            s->cwnd_fn(s->scon->real_window, s->hnwnd, s->opaque);
++        }
++        else
++            stat = 1;
++    }
++    else {
++        s->cwnd_fn(s->scon->real_window, s->hnwnd, s->opaque);
++        stat = s->glide_on_mesa;
++        s->glide_on_mesa = 0;
++        stat ^= (s->scon->winctx)? 1:0;
++    }
++    return stat;
++}
++
++int glide_gui_fullscreen(int *width, int *height)
++{
++    int ret, v[2];
++    ret = sdl_gui_fullscreen(v, "glidept");
++    if (width)
++        *width = v[0];
++    if (height)
++        *height = v[1];
++    return ret;
++}
++
++void glide_renderer_stat(const int activate)
++{
++    sdl_renderer_stat(activate, "glidept");
++}
++
++void mesa_renderer_stat(const int activate)
++{
++    struct sdl_console_cb *s = &scon_cb;
++    sdl_renderer_stat(activate, "mesapt");
++    if (s->glide_on_mesa && !activate)
++        glide_renderer_stat(1);
++}
++
++void mesa_prepare_window(int msaa, int alpha, int scale_x, void *cwnd_fn)
++{
++    int scr_w, scr_h;
++    struct sdl_console_cb *s = &scon_cb;
++
++    sdl_display_valid("mesapt");
++    s->scon = &sdl2_console[0];
++    s->msaa = msaa;
++    s->alpha = alpha;
++#ifdef CONFIG_WIN32
++    s->GLon12 = s->alpha;
++    s->alpha = 1;
++#endif
++#ifdef CONFIG_DARWIN
++    s->dtimer = s->alpha;
++    s->alpha = 1;
++#endif
++    s->opaque = 0;
++    s->cwnd_fn = (void (*)(void *, void *, void *))cwnd_fn;
++
++    SDL_GetWindowSize(s->scon->real_window, &scr_w, &scr_h);
++    s->gui_saved_res = ((scr_h & 0x7FFFU) << 0x10) | scr_w;
++    s->res = (((int)(scale_x * ((1.f * scr_h) / scr_w)) & 0x7FFFU) << 0x10) | scale_x;
++
++    if (!s->ts)
++        s->ts = timer_new_ms(QEMU_CLOCK_REALTIME, &sched_wndproc, s);
++    timer_mod(s->ts, qemu_clock_get_ms(QEMU_CLOCK_REALTIME));
++}
++
++void mesa_release_window(void)
++{
++    struct sdl_console_cb *s = &scon_cb;
++
++    sdl_display_valid("mesapt");
++    s->scon = &sdl2_console[0];
++    s->res = 0;
++    s->opaque = 0;
++    s->cwnd_fn = 0;
++    s->gui_saved_res = 0;
++
++    if (guest_sprite)
++        SDL_FreeCursor(guest_sprite);
++    guest_sprite = SDL_CreateSystemCursor(0);
++
++    if (s->ts)
++        timer_mod(s->ts, qemu_clock_get_ms(QEMU_CLOCK_REALTIME));
++}
++
++void mesa_cursor_define(int hot_x, int hot_y, int width, int height, const void *data)
++{
++    struct sdl_console_cb *s = &scon_cb;
++
++    QemuConsole *con = s->scon ? s->scon->dcl.con : NULL;
++    if (con) {
++        QEMUCursor *c = cursor_alloc(width, (height & 1)? (height >> 1):height);
++        c->hot_x = hot_x;
++        c->hot_y = hot_y;
++        if (height &  1) {
++            uint8_t *and_mask = (uint8_t *)data,
++                    *xor_mask = and_mask + cursor_get_mono_bpl(c) * c->height;
++            cursor_set_mono(c, 0xffffff, 0x000000, xor_mask, 1, and_mask);
++        }
++        else
++            memcpy(c->data, data, (width * height * sizeof(uint32_t)));
++        dpy_cursor_define(con, c);
++        cursor_unref(c);
++    }
++}
++
++void mesa_mouse_warp(int x, int y, const int on)
++{
++    struct sdl_console_cb *s = &scon_cb;
++
++    QemuConsole *con = s->scon ? s->scon->dcl.con : NULL;
++    if (con /*&& !qemu_input_is_absolute(con)*/) {
++        static int64_t last_update;
++        int64_t curr_time = qemu_clock_get_ms(QEMU_CLOCK_REALTIME);
++        if (!on || (curr_time >= (last_update + GUI_REFRESH_INTERVAL_DEFAULT))) {
++            last_update = curr_time;
++            dpy_mouse_set(con, x, y, on);
++        }
++    }
++}
++
++int mesa_gui_fullscreen(int *sizev)
++{
++    return sdl_gui_fullscreen(sizev, "mesapt");
++}
++
+ static const DisplayChangeListenerOps dcl_2d_ops = {
+     .dpy_name             = "sdl2-2d",
+     .dpy_gfx_update       = sdl2_2d_update,
+@@ -834,6 +1221,10 @@
+
+     assert(o->type == DISPLAY_TYPE_SDL);
+
++#ifdef __linux__
++    if (!display_opengl && !g_getenv("SDL_VIDEODRIVER"))
++        SDL_SetHint(SDL_HINT_VIDEODRIVER, "x11");
++#endif
+     if (SDL_GetHintBoolean("QEMU_ENABLE_SDL_LOGGING", SDL_FALSE)) {
+         SDL_LogSetAllPriority(SDL_LOG_PRIORITY_VERBOSE);
+     }
+@@ -926,6 +1317,7 @@
+     g_free(dir);
+     if (icon) {
+         SDL_SetWindowIcon(sdl2_console[0].real_window, icon);
++        scon_cb.icon = icon;
+     }
+
+     mouse_mode_notifier.notify = sdl_mouse_mode_change;

--- a/packages/qemu-3dfx.nix
+++ b/packages/qemu-3dfx.nix
@@ -1,0 +1,346 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchFromGitHub,
+  fetchpatch,
+  # Build tools
+  python3Packages,
+  pkg-config,
+  flex,
+  bison,
+  meson,
+  ninja,
+  perl,
+  makeWrapper,
+  removeReferencesTo,
+  buildPackages,
+  # Core libs
+  glib,
+  gnutls,
+  zlib,
+  pixman,
+  vde2,
+  lzo,
+  snappy,
+  libtasn1,
+  libslirp,
+  curl,
+  dtc,
+  ncurses,
+  # Display / Graphics
+  SDL2,
+  SDL2_image,
+  libjpeg,
+  libpng,
+  libGL,
+  mesa,
+  libx11,
+  libxxf86vm,
+  # Darwin
+  darwin ? { },
+  # Linux
+  libcap ? null,
+  libcap_ng ? null,
+  attr ? null,
+  libaio ? null,
+  libseccomp ? null,
+  # Guest wrappers (mingw cross-compilation)
+  pkgsCross,
+  gendef,
+  tinyxxd,
+}:
+
+let
+  qemu3dfxRev = "8c35ed82d6ca6907a4b0bcc27c23785ad10562c4";
+  qemu3dfxShortRev = builtins.substring 0 7 qemu3dfxRev;
+
+  qemu3dfxSrc = fetchFromGitHub {
+    owner = "kjliew";
+    repo = "qemu-3dfx";
+    rev = qemu3dfxRev;
+    hash = "sha256-iZiyED+JyVRvvtWmlQGglwmVhbiBruHvblZ3/fLjjsk=";
+  };
+
+  # Override gendef to build on Darwin (upstream restricts to Linux)
+  gendef' = gendef.overrideAttrs (old: {
+    meta = old.meta // {
+      platforms = lib.platforms.unix;
+    };
+  });
+
+  mingwGcc = pkgsCross.mingw32.buildPackages.gcc;
+  mingwBintools = pkgsCross.mingw32.buildPackages.binutils;
+  mingwPrefix = "i686-w64-mingw32-";
+  mcfgthreads = pkgsCross.mingw32.windows.mcfgthreads;
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qemu-3dfx";
+  version = "9.2.2";
+
+  src = fetchurl {
+    url = "https://download.qemu.org/qemu-${finalAttrs.version}.tar.xz";
+    hash = "sha256-dS6u63cpI6c9U2sjHgW8wJybH1FpCkGtmXPZAOTsn78=";
+  };
+
+  patches = [
+    # Nested virtualisation fix (from nixpkgs 9.2.2)
+    (fetchpatch {
+      url = "https://gitlab.com/qemu-project/qemu/-/commit/3e4546d5bd38a1e98d4bd2de48631abf0398a3a2.diff";
+      sha256 = "sha256-oC+bRjEHixv1QEFO9XAm4HHOwoiT+NkhknKGPydnZ5E=";
+      revert = true;
+    })
+
+    # 3Dfx Glide / Mesa passthrough (pinned to qemu-3dfx rev)
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/kjliew/qemu-3dfx/${qemu3dfxRev}/00-qemu92x-mesa-glide.patch";
+      hash = "sha256-6xYZ0gFhPUni61dU9o0HMLAl0WA5vtRU9lp3n41njhc=";
+    })
+  ];
+
+  postPatch = ''
+    # --- Copy 3dfx overlay files into QEMU source tree ---
+    cp -r ${qemu3dfxSrc}/qemu-0/hw/3dfx hw/3dfx
+    cp -r ${qemu3dfxSrc}/qemu-1/hw/mesa hw/mesa
+    chmod -R u+w hw/3dfx hw/mesa
+
+    # --- Replicate scripts/sign_commit ---
+    # 1. Inject git rev into source files
+    sed -i "s/\(rev_\[\).*\].*/\1\] = \"${qemu3dfxShortRev}-\"/" \
+      hw/3dfx/g2xfuncs.h hw/mesa/mglfuncs.h $(find . -maxdepth 2 -name vl.c)
+
+    # 2. Replace HASH_ALGO if present (QEMU 9.2.x already uses the correct constant)
+    CRYP=$(grep HASH_ALG qapi/crypto.json | sed "s/.*:\ //;s/.*\(HASH_[A-Z]*\).*/\1/" || true)
+    if [ -n "$CRYP" ]; then
+      sed -i "s/HASH_ALGO/$CRYP/" hw/mesa/mesagl_pfn.h
+    fi
+
+    # 3. Fix include paths for QEMU 9.2.2 (address-spaces.h is in exec/, not sysemu/)
+    sed -i 's|"sysemu/address-spaces.h"|"exec/address-spaces.h"|' \
+      $(grep -rl '"sysemu/address-spaces.h"' hw/3dfx hw/mesa) || true
+
+    # 4. Read module variable name from target/i386/meson.build and patch
+    MODS=$(tail -n 2 target/i386/meson.build | head -n 1 | sed "s/.*:\ //;s/\}//" | tr -d '[:space:]')
+    if [ -n "$MODS" ]; then
+      sed -i "s/i386.*_ss/$MODS/" hw/3dfx/meson.build hw/mesa/meson.build
+    fi
+
+    # 5. Check klass signature for API compatibility
+    if expr "$(grep 'base_init)' include/qom/object.h)" : ".*\*klass,\ void\ " >/dev/null 2>&1; then
+      sed -i -e "s/\*klass,\ const\ void/\*klass,\ void/;s/\"system\(\/address\-\)/\"exec\1/" \
+        $(grep -rl '\*klass,\ const\ void' hw/3dfx hw/mesa) 2>/dev/null || true
+    fi
+
+    # --- Standard nixpkgs QEMU patches ---
+    # Remove /var/run mkdir from guest agent build
+    sed -i "/install_emptydir(get_option('localstatedir') \/ 'run')/d" \
+      qga/meson.build
+
+    # --- Darwin fixes ---
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Remove hardcoded XQuartz paths - Nix provides X11 via buildInputs
+    substituteInPlace meson.build \
+      --replace-fail "c_args += ['-I/opt/X11/include']" "" \
+      --replace-fail "'-L/opt/X11/lib', " ""
+
+    # Use SDL GL context instead of X11/Linux context on Darwin
+    substituteInPlace hw/mesa/meson.build \
+      --replace-fail "'mglcntx_linux.c'," "'mglcntx_sdlgl.c',"
+
+    # Define missing GL extension constants for Darwin/Mesa
+    sed -i '1i\
+    #ifndef GL_TEXTURE_RECTANGLE_NV\
+    #define GL_TEXTURE_RECTANGLE_NV 0x84F5\
+    #endif\
+    #ifndef GL_TEXTURE_BINDING_RECTANGLE_NV\
+    #define GL_TEXTURE_BINDING_RECTANGLE_NV 0x84F6\
+    #endif' hw/mesa/mglcntx_sdlgl.c
+
+    # Remove Rez/SetFile commands from entitlement script (not available in sandbox)
+    substituteInPlace scripts/entitlement.sh \
+      --replace-fail 'Rez -append "$ICON" -o "$SRC"' "" \
+      --replace-fail 'SetFile -a C "$SRC"' ""
+  '';
+
+  preConfigure = ''
+    unset CPP
+    chmod +x ./scripts/shaderinclude.py
+    patchShebangs .
+    # Avoid conflicts with libc++ include for <version>
+    mv VERSION QEMU_VERSION
+    substituteInPlace configure \
+      --replace-warn '$source_path/VERSION' '$source_path/QEMU_VERSION'
+    substituteInPlace meson.build \
+      --replace-warn "'VERSION'" "'QEMU_VERSION'"
+    substituteInPlace python/qemu/machine/machine.py \
+      --replace-fail /var/tmp "$TMPDIR"
+  '';
+
+  dontUseMesonConfigure = true;
+  dontAddStaticConfigureFlags = true;
+
+  configureFlags = [
+    "--disable-strip"
+    "--enable-gnutls"
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+    "--cross-prefix=${stdenv.cc.targetPrefix}"
+    "--target-list=i386-softmmu,x86_64-softmmu"
+    "--enable-sdl"
+    "--enable-vnc"
+    "--enable-tpm"
+    "--disable-docs"
+    "--disable-guest-agent"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "--enable-cocoa"
+    "--enable-hvf"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    "--enable-linux-aio"
+    "--enable-kvm"
+  ];
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    removeReferencesTo
+    pkg-config
+    flex
+    bison
+    meson
+    ninja
+    perl
+    python3Packages.distlib
+    python3Packages.python
+    dtc
+    # Guest wrappers cross-compilation
+    mingwGcc
+    mingwBintools
+    gendef'
+    tinyxxd
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.sigtool ];
+
+  buildInputs = [
+    glib
+    gnutls
+    zlib
+    dtc
+    pixman
+    vde2
+    lzo
+    snappy
+    libtasn1
+    libslirp
+    curl
+    ncurses
+    # Display (SDL required for 3dfx passthrough)
+    SDL2
+    SDL2_image
+    # VNC
+    libjpeg
+    libpng
+    # OpenGL / X11 (needed for 3dfx host-side rendering)
+    libGL
+    mesa.dev
+    libx11
+    libxxf86vm
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libcap_ng
+    libcap
+    attr
+    libaio
+  ];
+
+  preBuild = "cd build";
+
+  # QEMU uses codesign entitlements on Darwin; stripping voids them
+  dontStrip = stdenv.hostPlatform.isDarwin;
+
+  postFixup = ''
+    rm -f $out/share/applications/qemu.desktop
+  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # The 3dfx passthrough links mesa's libGL on Darwin (not done in upstream QEMU).
+    # Mesa's libGL uses @rpath/libgallium, so add the rpath and re-codesign.
+    for f in $out/bin/qemu-system-*; do
+      install_name_tool -add_rpath "${lib.getLib mesa}/lib" "$f" || true
+      codesign --force --sign - "$f"
+    done
+  '';
+
+  postInstall = ''
+    # --- Build guest wrappers (Windows DLLs via mingw cross-compilation) ---
+    wrapperBuildDir=$(mktemp -d)
+    cp -r ${qemu3dfxSrc}/* $wrapperBuildDir/
+    chmod -R u+w $wrapperBuildDir
+    cd $wrapperBuildDir/wrappers/3dfx
+
+    mkdir -p build
+    cd build
+
+    # Generate Makefile from template (replicating conf_wrapper for cross-build)
+    cat ../src/Makefile.in > Makefile
+
+    # Set cross-compiler prefix
+    sed -i "s|^\(CROSS=\).*|\1${mingwPrefix}|" Makefile
+
+    # Prefix RC, STRIP, DLLTOOL with CROSS for cross-build
+    sed -i -e "s/^\(RC=\)/\1\$(CROSS)/" Makefile
+    sed -i -e "s/^\(STRIP=\)/\1\$(CROSS)/" Makefile
+    sed -i -e "s/^\(DLLTOOL=\)/\1\$(CROSS)/" Makefile
+
+    # Remove wglinfo tool target (host-only)
+    sed -i -e "s/^\(TOOLS=\)wglinfo.exe.*/\1/" Makefile
+
+    # Remove MSYSTEM check (only valid in MSYS2)
+    sed -i '/.*MSYSTEM.*!=.*MINGW32.*/d' Makefile
+
+    # Remove DJGPP/DOS32 and driver installer targets (not needed/available)
+    sed -i '/.*make.*-C.*dxe/d' Makefile
+    sed -i '/.*make.*-C.*ovl/d' Makefile
+    sed -i '/.*make.*-C.*drv/d' Makefile
+
+    # Hardcode git rev (no .git in Nix build)
+    sed -i "s|^GIT=.*|GIT=${qemu3dfxShortRev}-|" Makefile
+
+    # Fix CFLAGS for i686 target (upstream uses x86-64-v2 which is invalid for 32-bit)
+    sed -i 's/-march=x86-64-v2/-march=i686 -msse2/' Makefile
+
+    # Provide cross-compiled libraries the GCC wrapper expects
+    # mcfgthreads: thread implementation for mingw
+    # libintl: empty stub - the DLLs don't use gettext, but the GCC wrapper links it
+    ${mingwBintools}/bin/${mingwPrefix}ar rcs libintl.a
+    sed -i "s|^LDFLAGS=-static-libgcc|LDFLAGS=-static-libgcc -L${mcfgthreads}/lib -L.|" Makefile
+
+    # Fix exports-check to use cross-objdump (host objdump can't read PE)
+    sed -i "s|objdump|\$(CROSS)objdump|g" Makefile
+
+    # Build wrappers (sequential to avoid fxlib race condition)
+    make -j1 GENDEF=gendef
+
+    # Install guest wrappers
+    mkdir -p $out/share/qemu-3dfx/wrappers
+    cp -v *.dll $out/share/qemu-3dfx/wrappers/ 2>/dev/null || true
+    cp -v *.dll.a $out/share/qemu-3dfx/wrappers/ 2>/dev/null || true
+    cp -v *.def $out/share/qemu-3dfx/wrappers/ 2>/dev/null || true
+
+    cd /
+    rm -rf $wrapperBuildDir
+  '';
+
+  # Builds in ~3h with 2 cores, ~20m with big-parallel
+  requiredSystemFeatures = [ "big-parallel" ];
+
+  meta = {
+    description = "QEMU with 3Dfx Glide and Mesa/OpenGL passthrough for retro gaming";
+    homepage = "https://github.com/kjliew/qemu-3dfx";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    mainProgram = "qemu-system-x86_64";
+  };
+})

--- a/packages/qemu-3dfx.nix
+++ b/packages/qemu-3dfx.nix
@@ -93,10 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
 
     # 3Dfx Glide / Mesa passthrough (pinned to qemu-3dfx rev)
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/kjliew/qemu-3dfx/${qemu3dfxRev}/00-qemu92x-mesa-glide.patch";
-      hash = "sha256-6xYZ0gFhPUni61dU9o0HMLAl0WA5vtRU9lp3n41njhc=";
-    })
+    ./qemu-3dfx-mesa-glide.patch
   ];
 
   postPatch = ''
@@ -116,9 +113,14 @@ stdenv.mkDerivation (finalAttrs: {
       sed -i "s/HASH_ALGO/$CRYP/" hw/mesa/mesagl_pfn.h
     fi
 
-    # 3. Fix include paths for QEMU 9.2.2 (address-spaces.h is in exec/, not sysemu/)
-    sed -i 's|"sysemu/address-spaces.h"|"exec/address-spaces.h"|' \
-      $(grep -rl '"sysemu/address-spaces.h"' hw/3dfx hw/mesa) || true
+    # 3. Fix include paths (overlay targets newer QEMU where sysemu/ was renamed to system/)
+    #    QEMU 9.2.x still uses sysemu/ for kvm.h and whpx.h, and exec/ for address-spaces.h
+    sed -i 's|"system/kvm.h"|"sysemu/kvm.h"|' \
+      $(grep -rl '"system/kvm.h"' hw/3dfx hw/mesa) 2>/dev/null || true
+    sed -i 's|"system/whpx.h"|"sysemu/whpx.h"|' \
+      $(grep -rl '"system/whpx.h"' hw/3dfx hw/mesa) 2>/dev/null || true
+    sed -i 's|"system/address-spaces.h"|"exec/address-spaces.h"|' \
+      $(grep -rl '"system/address-spaces.h"' hw/3dfx hw/mesa) 2>/dev/null || true
 
     # 4. Read module variable name from target/i386/meson.build and patch
     MODS=$(tail -n 2 target/i386/meson.build | head -n 1 | sed "s/.*:\ //;s/\}//" | tr -d '[:space:]')
@@ -246,10 +248,10 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     # OpenGL / X11 (needed for 3dfx host-side rendering)
     libGL
-    mesa.dev
     libx11
     libxxf86vm
   ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ mesa.dev ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libcap_ng
     libcap


### PR DESCRIPTION
## Summary

- Add `packages/qemu-3dfx.nix`: builds QEMU 9.2.2 with 3Dfx Glide and Mesa/OpenGL passthrough patches from [kjliew/qemu-3dfx](https://github.com/kjliew/qemu-3dfx)
- Includes i686 Windows guest wrapper DLLs (`glide.dll`, `glide2x.dll`, `glide3x.dll`) cross-compiled with mingw, installed to `$out/share/qemu-3dfx/wrappers/`
- Exposed as `packages.{x86_64-linux,x86_64-darwin,aarch64-darwin}.qemu-3dfx` in the flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)