### PR TITLE
chore: rewrite CLAUDE.md with behavioral guidelines and progressive disclosure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,85 +1,168 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Behavioral guidelines and project onboarding for Claude Code. The behavioral
+sections reduce common LLM coding mistakes. The project sections onboard you to
+this specific codebase.
 
-## Repository Overview
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial
+tasks, use judgment.
 
-Multi-host NixOS/nix-darwin configuration repository using Nix flakes. Manages 6 systems across Linux (x86_64, aarch64) and macOS (aarch64-darwin).
+## 1. Think Before Coding
 
-## Build Commands
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes,
+simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+
+- "Add a module" -> "Write the module, enable it in a host, `nix build`
+  succeeds"
+- "Fix the build" -> "Identify the error, apply fix, `nix build` succeeds"
+- "Add a service" -> "Configure the service, verify the build, check firewall
+  rules"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] -> verify: [check]
+2. [Step] -> verify: [check]
+3. [Step] -> verify: [check]
+```
+
+---
+
+## 5. Repository Overview
+
+Multi-host NixOS/nix-darwin configuration repository using Nix flakes. Manages 5
+physical hosts across 3 platforms, producing 7 build configurations.
+
+**Hosts:**
+
+- **BrightFalls** - Gaming PC (x86_64-linux) + two VM variants (x86_64, aarch64)
+- **Nexus** - Home server (x86_64-linux) - storage, media, home automation,
+  backups
+- **CauldronLake** - Laptop (x86_64-linux) - user is `debora`, not `matteo`
+- **NightSprings** - MacBook Pro M1 Max (aarch64-darwin)
+- **WorkLaptop** - Work MacBook M4 (aarch64-darwin) - user is `matteo.pacini`,
+  not `matteo`
+
+**Key architectural decisions:**
+
+- Custom modules use the `custom.X = { enable = true; }` pattern
+  (`mkEnableOption` + `mkIf` + `mkMerge`)
+- `mkBrightFalls` factory function in `flake.nix` creates gaming system variants
+  with an `isVM` flag
+- Per-host CPU optimizations via overlays (znver4, sandybridge, znver2,
+  apple-m1, apple-m4)
+- Shared Home Manager modules in `modules/home-manager/` are loaded on all hosts
+  via `homeManagerModules.default`
+- Secrets managed with agenix (currently only Nexus uses secrets)
+- Dracula theme applied consistently across terminal, editor, and browser via
+  `modules/home-manager/dracula.nix`
+
+## 6. Working on This Repo
 
 **Build a NixOS configuration:**
+
 ```bash
-nix build ".#nixosConfigurations.BrightFalls.config.system.build.toplevel"
-nix build ".#nixosConfigurations.Nexus.config.system.build.toplevel"
+nix build ".#nixosConfigurations.<Host>.config.system.build.toplevel"
 ```
 
-**Build a Darwin configuration:**
+**Build a Darwin configuration (requires macOS):**
+
 ```bash
-nix build ".#darwinConfigurations.NightSprings.config.system.build.toplevel"
+nix build ".#darwinConfigurations.<Host>.config.system.build.toplevel"
 ```
 
-**Apply configuration (NixOS):**
+**Evaluate a Darwin configuration on Linux (can't build, but can check for eval
+errors):**
+
 ```bash
-sudo nixos-rebuild switch --flake .#BrightFalls
+nix eval ".#darwinConfigurations.<Host>.config.system.build.toplevel" --raw 2>&1 | head -5
 ```
 
-**Apply configuration (macOS):**
+**Apply configuration:**
+
 ```bash
-nix run nix-darwin -- switch --flake .#NightSprings
+# NixOS
+sudo nixos-rebuild switch --flake .#<Host>
+# macOS
+nix run nix-darwin -- switch --flake .#<Host>
 ```
 
-**Format Nix files:**
+**Format Nix files (no formatter defined in flake, use nixfmt directly):**
+
 ```bash
-nix fmt
+nix run nixpkgs#nixfmt -- file.nix
 ```
 
-## Architecture
+**Important workflow notes:**
 
-### Hosts
-- **BrightFalls** - Gaming PC (x86_64-linux), has VM variants for testing
-- **Nexus** - Storage server (x86_64-linux), complex storage with agenix secrets
-- **CauldronLake** - Gaming laptop (x86_64-linux), NVIDIA Optimus
-- **NightSprings** - MacBook Pro M1 Max (aarch64-darwin)
-- **WorkLaptop** - Work MacBook M1 (aarch64-darwin)
+- New `.nix` files must be `git add`ed before `nix build` — the flake uses the
+  git store, so untracked files are invisible.
+- Commit style: semantic commits with host scope, e.g. `feat(nexus):`,
+  `fix(brightfalls):`, `chore:`.
+- CI builds all 7 configurations on push to master. Uses Attic binary cache. See
+  `.github/workflows/build.yml`.
+- PR builds run eval + diff against base. See `.github/workflows/pr-build.yml`.
 
-### Directory Structure
-- `hosts/` - Per-host configurations, each host has modular files (networking.nix, services.nix, etc.)
-- `hosts/shared/` - Shared modules across hosts (kernel.nix, home-manager configs)
-- `modules/` - Custom NixOS and Home Manager modules
-- `overlays/` - Per-host package overlays with CPU-specific optimizations
-- `secrets/` - agenix encrypted secrets (.age files)
-- `docs/` - Host-specific documentation (Nexus storage handbook)
+## 7. Where to Find Things
 
-### Key Patterns
+Read these files as needed based on the task at hand. Don't read everything
+upfront.
 
-**Host composition:** Each host imports modular files for subsystems:
-```nix
-imports = [
-  ./networking.nix
-  ./users.nix
-  ./desktop.nix
-  ./services.nix
-  # ...
-];
-```
-
-**mkBrightFalls helper:** Factory function in flake.nix for gaming systems with `isVM` flag for VM-specific tweaks.
-
-**Overlays:** Per-host CPU optimizations (znver4 for BrightFalls, sandybridge for Nexus).
-
-**Secrets:** agenix with age-encrypted files. Identity paths configured per host. Secrets available at `/run/agenix/...` after boot.
-
-**Home Manager:** Integrated into NixOS/Darwin configs. Shared modules in `hosts/shared/home-manager/` work across Linux and macOS.
-
-### Flake Inputs
-- `nixpkgs` (nixos-unstable), `home-manager`, `nix-darwin`, `agenix`, `disko`, `nix-homebrew`, `mac-app-util`
-- Dracula themes, Firefox GNOME theme, BORE scheduler patches
-
-## CI/CD
-
-GitHub Actions builds all 7 configurations on push to master. Uses Attic binary cache at `zpnixcache.fly.dev`.
-
-## Commit Style
-
-Semantic commits with host scope: `feat(nexus):`, `fix(brightfalls):`, etc.
+| What                                                                                                                    | Where                                                                   |
+| ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Flake inputs, outputs, host wiring                                                                                      | `flake.nix`                                                             |
+| Host system config (hardware, networking, services, desktop)                                                            | `hosts/<Host>/` - each has a `default.nix` that imports subsystem files |
+| User-level Home Manager config                                                                                          | `hosts/<Host>/users/<user>/default.nix`                                 |
+| Shared NixOS modules (nix-core, kernel, locale, bluetooth, fonts, apcupsd-multi)                                        | `modules/nixos/`                                                        |
+| Shared Darwin modules (nix-core, system-defaults, fonts)                                                                | `modules/darwin/`                                                       |
+| Shared Home Manager modules (git, zsh, ssh, atuin, firefox, dracula, nvf, tmux, vscode, starship, wezterm, shell-tools) | `modules/home-manager/`                                                 |
+| Xcodes module (Darwin-only, manages Xcode installations)                                                                | `modules/home-manager/darwin/xcodes.nix`                                |
+| Per-host CPU optimization overlays                                                                                      | `overlays/<host>.nix`                                                   |
+| Agenix secret definitions                                                                                               | `secrets/secrets.nix`                                                   |
+| Encrypted secret files                                                                                                  | `secrets/nexus/*.age`                                                   |
+| Nexus storage handbook (disk pool, snapraid, recovery)                                                                  | `docs/nexus/`                                                           |
+| CI/CD pipelines                                                                                                         | `.github/workflows/`                                                    |
+| Custom packages                                                                                                         | `packages/`                                                             |


### PR DESCRIPTION
## Summary

- Restructure CLAUDE.md around Karpathy-style behavioral sections (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution) as a universal base
- Add project-specific onboarding following HumanLayer best practices: concise, universally applicable, progressive disclosure via pointers
- Fix broken `nix fmt` instruction (flake has no formatter — now points to `nix run nixpkgs#nixfmt` directly)
- Add `nix eval` command for verifying Darwin configs on Linux
- Document the `git add` requirement for new files in flake repos
- Replace verbose architecture section with a progressive disclosure "Where to Find Things" table

## Test plan

- [ ] Verify all file paths referenced in the table exist in the repo
- [ ] CI builds pass (CLAUDE.md is not evaluated by Nix, so no build impact)
- [ ] Review that instructions are accurate and universally applicable