### PR TITLE
feat(nexus): add SSD RAID 1 and storage performance tuning

### DIFF
--- a/hosts/Nexus/default.nix
+++ b/hosts/Nexus/default.nix
@@ -9,6 +9,7 @@
     ./services
     ./snapraid.nix
     ./mdadm.nix
+    ./storage-tuning.nix
   ];
 
   custom.kernel.enable = true;

--- a/hosts/Nexus/storage-tuning.nix
+++ b/hosts/Nexus/storage-tuning.nix
@@ -1,0 +1,26 @@
+{
+  # Periodic TRIM for SSDs — prevents write amplification degradation
+  services.fstrim.enable = true;
+
+  # noatime on root XFS — eliminates unnecessary access-time writes
+  fileSystems."/".options = [ "noatime" ];
+
+  # Noop scheduler for SSDs — bypass kernel I/O scheduling overhead
+  services.udev.extraRules = ''
+    ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="none"
+  '';
+
+  # VM subsystem tuning for a storage server
+  boot.kernel.sysctl = {
+    "vm.dirty_ratio" = 10;
+    "vm.dirty_background_ratio" = 5;
+    "vm.swappiness" = 10;
+    "vm.vfs_cache_pressure" = 50;
+  };
+
+  # Nix build parallelism — dual Xeon E5-2697 v4 (36C/72T)
+  nix.settings = {
+    max-jobs = 8;
+    cores = 8;
+  };
+}


### PR DESCRIPTION
## Summary

- Enable weekly `fstrim` and `noatime` on root XFS to fix SSD write amplification degradation
- Set I/O scheduler to `none` for SSDs via udev rule (HDDs keep their default)
- Add VM sysctl tuning (`dirty_ratio`, `dirty_background_ratio`, `swappiness`, `vfs_cache_pressure`) for storage server workload
- Set Nix build parallelism to 8 jobs × 8 cores (64/72 threads) instead of defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)