### PR TITLE
fix: clean up claude-code shared overlay

### DIFF
--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -1,13 +1,17 @@
 (self: super: {
-  # https://github.com/anthropics/claude-code/issues/46917
-  # https://github.com/anthropics/claude-code/issues/42796
+  # Claude Code wrapper: env vars to tune behaviour under Nix.
+  # Appends to upstream postInstall (which sets DISABLE_AUTOUPDATER,
+  # FORCE_AUTOUPDATE_PLUGINS, DISABLE_INSTALLATION_CHECKS, unsets DEV,
+  # and adds procps/bubblewrap/socat to PATH).
+  #
+  # Relevant issues & references:
+  #   - Quality / thinking regression:  https://github.com/anthropics/claude-code/issues/42796
+  #   - Autocompact window regression:  https://github.com/anthropics/claude-code/issues/43989
+  #   - Effort level ignored (>=113):   https://github.com/anthropics/claude-code/issues/50099
+  #   - Reddit investigation:           https://www.reddit.com/r/ClaudeCode/comments/1sj10ou/
   claude-code = super.claude-code.overrideAttrs (old: {
-    postInstall = ''
+    postInstall = old.postInstall + ''
       wrapProgram $out/bin/claude \
-        --set DISABLE_AUTOUPDATER 1 \
-        --unset DEV \
-        --set ANTHROPIC_CUSTOM_HEADERS "User-Agent: claude-cli/2.1.98 (external, sdk-cli)" \
-        --set CLAUDE_CODE_ALWAYS_ENABLE_EFFORT 1 \
         --set CLAUDE_CODE_EFFORT_LEVEL max \
         --set CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING 1 \
         --set MAX_THINKING_TOKENS 63999 \


### PR DESCRIPTION
- Remove stale UA spoof workaround (fixed server-side in v2.1.108+)
- Remove `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` which breaks Haiku subagents (#47175)
- Append to upstream `postInstall` instead of replacing it, preserving `FORCE_AUTOUPDATE_PLUGINS`, `DISABLE_INSTALLATION_CHECKS`, and PATH deps