### PR TITLE
feat: disable gh telemetry in shared overlay

### DIFF
--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -18,4 +18,13 @@
         --set CLAUDE_CODE_AUTO_COMPACT_WINDOW 400000
     '';
   });
+
+  # gh: disable telemetry (https://cli.github.com/telemetry). Nixpkgs does not
+  # disable it by default; wrap the binary so every invocation has the env var.
+  gh = super.gh.overrideAttrs (old: {
+    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ super.makeWrapper ];
+    postInstall = (old.postInstall or "") + ''
+      wrapProgram $out/bin/gh --set GH_TELEMETRY false
+    '';
+  });
 })


### PR DESCRIPTION
## Summary

- Wrap the `gh` binary in `overlays/shared.nix` so every invocation runs with `GH_TELEMETRY=false` (https://cli.github.com/telemetry).
- Nixpkgs does not disable telemetry by default — confirmed against current `pkgs/by-name/gh/gh/package.nix`.
- Adds `makeWrapper` to the derivation's `nativeBuildInputs`; `installShellFiles` does not bring it in transitively.