### PR TITLE
refactor: tune claude-code shared overlay env vars

### DIFF
--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -5,17 +5,15 @@
   # and adds procps/bubblewrap/socat to PATH).
   #
   # Relevant issues & references:
-  #   - Quality / thinking regression:  https://github.com/anthropics/claude-code/issues/42796
-  #   - Autocompact window regression:  https://github.com/anthropics/claude-code/issues/43989
   #   - Effort level ignored (>=113):   https://github.com/anthropics/claude-code/issues/50099
-  #   - Reddit investigation:           https://www.reddit.com/r/ClaudeCode/comments/1sj10ou/
+  #   - Autocompact window regression:  https://github.com/anthropics/claude-code/issues/43989
+  #   - 1h cache TTL vs telemetry:      https://github.com/anthropics/claude-code/issues/45381
   claude-code = super.claude-code.overrideAttrs (old: {
     postInstall = old.postInstall + ''
       wrapProgram $out/bin/claude \
         --set CLAUDE_CODE_EFFORT_LEVEL max \
-        --set CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING 1 \
-        --set MAX_THINKING_TOKENS 63999 \
-        --set CLAUDE_CODE_AUTO_COMPACT_WINDOW 400000
+        --set CLAUDE_CODE_AUTO_COMPACT_WINDOW 400000 \
+        --set ENABLE_PROMPT_CACHING_1H 1
     '';
   });
 })


### PR DESCRIPTION
- Drop `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1` — no-op on Opus 4.7 (always adaptive); tracking issue #42796 closed without rollback.
- Drop `MAX_THINKING_TOKENS=63999` — deprecated on Opus 4.7, now gated by `CLAUDE_CODE_EFFORT_LEVEL`.
- Add `ENABLE_PROMPT_CACHING_1H=1` (v2.1.108+) — extends prompt-cache TTL from 5 min to 1 h; lowers token spend on long sessions.
- Keep `CLAUDE_CODE_EFFORT_LEVEL=max` (#50099 still open) and `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000` (#43989 still open).
- Refresh comment refs: drop fixed #42796 and its Reddit investigation, add #45381 noting the 1h-cache-vs-telemetry interaction.