### PR TITLE
fix(nvf): async neo-tree, unfold buffers, ts→typescript

### DIFF
--- a/modules/home-manager/nvf.nix
+++ b/modules/home-manager/nvf.nix
@@ -23,7 +23,11 @@ in
             providers.wl-copy.enable = pkgs.stdenv.hostPlatform.isLinux;
           };
           lineNumberMode = "relNumber";
-          options.mouse = "";
+          options = {
+            mouse = "";
+            foldlevel = 99;
+            foldlevelstart = 99;
+          };
           startPlugins = [
             pkgs.vimPlugins.vim-sleuth
             pkgs.vimPlugins.smear-cursor-nvim
@@ -44,6 +48,7 @@ in
           filetree = {
             neo-tree = {
               enable = true;
+              setupOpts.git_status_async = true;
             };
           };
           telescope.enable = true;
@@ -163,7 +168,7 @@ in
             };
             bash.enable = true;
             markdown.enable = true;
-            ts.enable = true;
+            typescript.enable = true;
             go.enable = true;
             python.enable = true;
             json.enable = true;


### PR DESCRIPTION
## Summary

- **Async neo-tree git_status** — `setupOpts.git_status_async = true`. Default is sync; on a large repo (e.g. a 32 GB RN monorepo) neo-tree blocks the UI for ~5 s while running `git status --porcelain` before it paints. See [nvim-neo-tree/neo-tree.nvim#1519](https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1519) for upstream context.
- **Buffers open unfolded** — `foldlevel = 99`, `foldlevelstart = 99`. With `treesitter.fold = true` the default `foldlevel = 0` forces every buffer fully folded on open. Folds remain available on demand (`zc`/`zo`/`zM`/`zR`).
- **Rename deprecated option** — `vim.languages.ts` → `vim.languages.typescript` clears the nvf deprecation warning at rebuild.

## Test plan

- [ ] `home-manager switch --flake .` rebuilds without the `vim.languages.ts` deprecation warning
- [ ] `nvim .` in a large repo — neo-tree window appears immediately, git markers populate asynchronously
- [ ] Open a TS/TSX or Lua file — buffer is not folded by default
- [ ] `zc` on a function still closes the fold; `zR` still opens all