### PR TITLE
feat(nvf): add Perl language support

### DIFF
--- a/modules/home-manager/nvf-perl.nix
+++ b/modules/home-manager/nvf-perl.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.custom.nvf;
+in
+{
+  config = lib.mkIf cfg.enable {
+    programs.nvf.settings.vim = {
+      lsp.servers.perlnavigator = {
+        cmd = [
+          (lib.getExe pkgs.perlnavigator)
+          "--stdio"
+        ];
+        filetypes = [ "perl" ];
+        root_markers = [
+          "cpanfile"
+          "Makefile.PL"
+          "Build.PL"
+          ".git"
+        ];
+        settings.perlnavigator = {
+          enableWarnings = true;
+          perlcriticEnabled = true;
+        };
+      };
+
+      treesitter.grammars = [
+        pkgs.vimPlugins.nvim-treesitter.grammarPlugins.perl
+      ];
+
+      formatter.conform-nvim.setupOpts.formatters_by_ft.perl = [ "perltidy" ];
+
+      diagnostics.nvim-lint = {
+        enable = true;
+        linters_by_ft.perl = [ "perlcritic" ];
+      };
+
+      extraPackages = [
+        pkgs.perlPackages.PerlTidy
+        pkgs.perlcritic
+      ];
+    };
+  };
+}

--- a/modules/home-manager/nvf.nix
+++ b/modules/home-manager/nvf.nix
@@ -8,6 +8,8 @@ let
   cfg = config.custom.nvf;
 in
 {
+  imports = [ ./nvf-perl.nix ];
+
   options.custom.nvf = {
     enable = lib.mkEnableOption "Neovim configuration via nvf";
   };


### PR DESCRIPTION
## Summary
- nvf has no built-in `vim.languages.perl` module (verified against upstream: 62 language modules, no `perl.nix`).
- Added `modules/home-manager/nvf-perl.nix` wiring PerlNavigator (LSP via `vim.lsp.servers`), tree-sitter-perl grammar, perltidy (conform.nvim formatter), and perlcritic (nvim-lint linter).
- Main `nvf.nix` imports the sibling file, sharing the `custom.nvf.enable` gate — keeps manual wiring quarantined so it can be collapsed if nvf later ships a native Perl module.