### PR TITLE
feat(ai): migrate from Claude Code to OpenCode

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -184,6 +184,7 @@
           ./modules/home-manager/vscode.nix
           ./modules/home-manager/starship.nix
           ./modules/home-manager/wezterm.nix
+          ./modules/home-manager/opencode.nix
         ];
       };
 

--- a/hosts/Brightfalls/users/matteo/default.nix
+++ b/hosts/Brightfalls/users/matteo/default.nix
@@ -37,6 +37,7 @@
       _1password-gui
       # Development
       opencode
+      tokscale
       gh
       # Other
       nix-output-monitor

--- a/hosts/Brightfalls/users/matteo/default.nix
+++ b/hosts/Brightfalls/users/matteo/default.nix
@@ -36,7 +36,7 @@
       # Security
       _1password-gui
       # Development
-      claude-code
+      opencode
       gh
       # Other
       nix-output-monitor
@@ -68,6 +68,7 @@
   custom.nvf.enable = true;
   custom.tmux.enable = true;
   custom.starship.enable = true;
+  custom.opencode.enable = true;
 
   dracula.eza.enable = true;
   dracula.fzf.enable = true;

--- a/hosts/Nexus/users/matteo/default.nix
+++ b/hosts/Nexus/users/matteo/default.nix
@@ -17,8 +17,6 @@
   dracula.bat.enable = true;
 
   home.packages = with pkgs; [
-    # Development
-    claude-code
   ];
 
   home.stateVersion = "25.11";

--- a/hosts/NightSprings/users/matteo/default.nix
+++ b/hosts/NightSprings/users/matteo/default.nix
@@ -22,6 +22,7 @@
     age
     # Development
     opencode
+    tokscale
     gh
     # Social
     element-desktop

--- a/hosts/NightSprings/users/matteo/default.nix
+++ b/hosts/NightSprings/users/matteo/default.nix
@@ -21,7 +21,7 @@
     # Encription
     age
     # Development
-    claude-code
+    opencode
     gh
     # Social
     element-desktop
@@ -35,6 +35,7 @@
   custom.tmux.enable = true;
   custom.starship.enable = true;
   custom.wezterm.enable = true;
+  custom.opencode.enable = true;
 
   home.stateVersion = "25.11";
 

--- a/hosts/WorkLaptop/users/matteo.pacini/default.nix
+++ b/hosts/WorkLaptop/users/matteo.pacini/default.nix
@@ -21,6 +21,7 @@
     tree
     # Development
     claude-code
+    tokscale
     gh
     # Window Management
     loopwm

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -1,0 +1,86 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.custom.opencode;
+in
+{
+  options.custom.opencode = {
+    enable = lib.mkEnableOption "OpenCode configuration with agent definitions";
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.file.".config/opencode/opencode.json".text = builtins.toJSON {
+      "$schema" = "https://opencode.ai/config.json";
+      model = "openrouter/moonshotai/kimi-k2.6";
+      agent = {
+        build = {
+          description = "Primary coding agent. Full file and bash access. Uses Kimi K2.6 — Tier A in April 2026 benchmarks, best value coding model at ~$0.30/run.";
+          mode = "primary";
+          model = "openrouter/moonshotai/kimi-k2.6";
+          temperature = 0.2;
+          max_iterations = 25;
+        };
+        plan = {
+          description = "Planning and architecture agent. Read-only, no file writes. Uses Kimi K2.6 — same Tier A quality without the extra cost of thinking mode.";
+          mode = "primary";
+          model = "openrouter/moonshotai/kimi-k2.6";
+          temperature = 0.3;
+          max_iterations = 15;
+          permission = {
+            write = { "*" = "deny"; };
+            edit = { "*" = "deny"; };
+            bash = { "*" = "deny"; };
+          };
+        };
+        explore = {
+          description = "Lightweight codebase explorer. Read-only. Uses DeepSeek V4 Flash — $0.01/run, 1M context, cheapest useful model available.";
+          mode = "subagent";
+          model = "openrouter/deepseek/deepseek-v4-flash";
+          temperature = 0.1;
+          max_iterations = 10;
+          permission = {
+            write = { "*" = "deny"; };
+            edit = { "*" = "deny"; };
+            bash = { "*" = "deny"; };
+            read = { "*" = "allow"; };
+            glob = { "*" = "allow"; };
+            grep = { "*" = "allow"; };
+          };
+        };
+        review = {
+          description = "Code review agent. Read-only. Uses Gemini 3 Flash — fast, 1M context, good at spotting issues.";
+          mode = "subagent";
+          model = "openrouter/google/gemini-3-flash-preview";
+          temperature = 0.1;
+          max_iterations = 10;
+          permission = {
+            write = { "*" = "deny"; };
+            edit = { "*" = "deny"; };
+            bash = { "*" = "deny"; };
+            read = { "*" = "allow"; };
+            glob = { "*" = "allow"; };
+            grep = { "*" = "allow"; };
+          };
+        };
+        debug = {
+          description = "Debug agent. Can read files and run bash commands but cannot edit. Uses Kimi K2.6 for reliable reasoning.";
+          mode = "subagent";
+          model = "openrouter/moonshotai/kimi-k2.6";
+          temperature = 0.1;
+          max_iterations = 15;
+          permission = {
+            write = { "*" = "deny"; };
+            edit = { "*" = "deny"; };
+            bash = { "*" = "allow"; };
+            read = { "*" = "allow"; };
+            glob = { "*" = "allow"; };
+            grep = { "*" = "allow"; };
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -17,14 +17,14 @@ in
       model = "openrouter/moonshotai/kimi-k2.6";
       agent = {
         build = {
-          description = "Primary coding agent. Full file and bash access. Uses Kimi K2.6 — Tier A in April 2026 benchmarks, best value coding model at ~$0.30/run.";
+          description = "Full-featured coding agent for implementation and complex changes. Writes code, runs tests, manages files, and executes system commands. Use for: building features, bug fixes, large refactors, dependency updates, and any task requiring code modifications.";
           mode = "primary";
           model = "openrouter/moonshotai/kimi-k2.6";
           temperature = 0.2;
           max_iterations = 25;
         };
         plan = {
-          description = "Planning and architecture agent. Read-only, no file writes. Uses Kimi K2.6 — same Tier A quality without the extra cost of thinking mode.";
+          description = "Architecture and planning specialist. Analyzes code, designs solutions, and creates implementation plans without modifying files. Use for: system design, code review preparation, technical decisions, refactoring strategies, and understanding complex codebases.";
           mode = "primary";
           model = "openrouter/moonshotai/kimi-k2.6";
           temperature = 0.3;
@@ -36,7 +36,7 @@ in
           };
         };
         explore = {
-          description = "Lightweight codebase explorer. Read-only. Uses DeepSeek V4 Flash — $0.01/run, 1M context, cheapest useful model available.";
+          description = "Fast codebase navigator for discovery and analysis. Searches files, finds references, maps dependencies, and answers questions about code structure. Use for: understanding unfamiliar codebases, finding functions/classes, tracing data flows, and locating configuration.";
           mode = "subagent";
           model = "openrouter/deepseek/deepseek-v4-flash";
           temperature = 0.1;
@@ -51,7 +51,7 @@ in
           };
         };
         review = {
-          description = "Code review agent. Read-only. Uses Gemini 3 Flash — fast, 1M context, good at spotting issues.";
+          description = "Code quality and security reviewer. Identifies bugs, security vulnerabilities, performance issues, and style violations. Use for: PR reviews, security audits, best practice enforcement, and spotting potential edge cases or anti-patterns.";
           mode = "subagent";
           model = "openrouter/google/gemini-3-flash-preview";
           temperature = 0.1;
@@ -66,7 +66,7 @@ in
           };
         };
         debug = {
-          description = "Debug agent. Can read files and run bash commands but cannot edit. Uses Kimi K2.6 for reliable reasoning.";
+          description = "Diagnostic specialist for troubleshooting and investigation. Runs tests, inspects logs, reproduces issues, and analyzes error patterns. Use for: debugging failures, investigating performance issues, analyzing test results, and diagnosing system problems.";
           mode = "subagent";
           model = "openrouter/moonshotai/kimi-k2.6";
           temperature = 0.1;

--- a/modules/home-manager/vscode.nix
+++ b/modules/home-manager/vscode.nix
@@ -7,11 +7,6 @@
 let
   cfg = config.custom.vscode;
   targetFolder = if config.programs.vscode.package == pkgs.vscode then "Code" else "VSCodium";
-  clineSettings =
-    if pkgs.stdenv.hostPlatform.isDarwin then
-      "Library/Application Support/${targetFolder}/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
-    else
-      ".config/${targetFolder}/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json";
 in
 {
   options.custom.vscode = {
@@ -77,8 +72,6 @@ in
                 # JS/TS
                 esbenp.prettier-vscode
                 dbaeumer.vscode-eslint
-                # LLMs
-                saoudrizwan.claude-dev
                 # GHA
                 github.vscode-github-actions
                 # Python
@@ -133,18 +126,5 @@ in
         };
       };
     };
-
-    home.file."${clineSettings}".text = ''
-      {
-        "mcpServers": {
-          "github.com/upstash/context7-mcp": {
-            "command": "${pkgs.nodejs}/bin/npx",
-            "args": ["-y", "@upstash/context7-mcp@latest"],
-            "disabled": false,
-            "autoApprove": []
-          }
-        }
-      }
-    '';
   };
 }

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -25,4 +25,7 @@
       wrapProgram $out/bin/gh --set GH_TELEMETRY false
     '';
   });
+
+  # Token usage tracker for AI coding agents
+  tokscale = super.callPackage ../packages/tokscale.nix { };
 })

--- a/packages/tokscale.nix
+++ b/packages/tokscale.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  sqlite,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tokscale";
+  version = "2.0.27";
+
+  src = fetchFromGitHub {
+    owner = "junhoyeo";
+    repo = "tokscale";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mVd7kNjZ9fo/ITwMaLtq7f5uLB/gpwP7Fd+RhAjAq8U=";
+  };
+
+  cargoHash = "sha256-0n/CgX0ccDoHHXRaTDqJb1iEVJ8ZhC5yKe74n6KdIEM=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    sqlite
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+  };
+
+  checkFlags = [
+    # Tries to make network requests to other hosts
+    "--skip=test_graph_single_day_filter_uses_local_timezone_boundaries"
+    "--skip=test_pricing_command_json"
+    "--skip=test_pricing_command_success"
+    "--skip=test_pricing_command_with_provider"
+  ];
+
+  meta = {
+    description = "CLI tool for tracking token usage from various agentic coding tools like Claude Code and OpenCode etc.";
+    downloadPage = "https://github.com/junhoyeo/tokscale";
+    homepage = "https://tokscale.ai";
+    changelog = "https://github.com/junhoyeo/tokscale/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "tokscale";
+  };
+})


### PR DESCRIPTION
## Summary

- Remove claude-code package from BrightFalls, Nexus, NightSprings
- Remove VSCode Claude extension (saoudrizwan.claude-dev) and MCP settings
- Add opencode package to BrightFalls and NightSprings
- Create shared home-manager module for OpenCode configuration
- Configure agent definitions: build, plan, explore, review, debug
- Register opencode module in flake.nix homeManagerModules
- Add tokscale 2.0.27 package derivation
- Register tokscale in shared overlay
- Add tokscale to BrightFalls, NightSprings and WorkLaptop
- Keep claude-code overlay for WorkLaptop