### PR TITLE
feat(opencode): self-install via module + enable on WorkLaptop

### DIFF
--- a/hosts/Brightfalls/users/matteo/default.nix
+++ b/hosts/Brightfalls/users/matteo/default.nix
@@ -36,7 +36,6 @@
       # Security
       _1password-gui
       # Development
-      opencode
       tokscale
       gh
       # Other

--- a/hosts/NightSprings/users/matteo/default.nix
+++ b/hosts/NightSprings/users/matteo/default.nix
@@ -21,7 +21,6 @@
     # Encription
     age
     # Development
-    opencode
     tokscale
     gh
     # Social

--- a/hosts/WorkLaptop/users/matteo.pacini/default.nix
+++ b/hosts/WorkLaptop/users/matteo.pacini/default.nix
@@ -35,6 +35,7 @@
   custom.vscode.enable = true;
   custom.starship.enable = true;
   custom.wezterm.enable = true;
+  custom.opencode.enable = true;
 
   home.stateVersion = "25.11";
 

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 let
@@ -12,6 +13,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    home.packages = [ pkgs.opencode ];
     home.file.".config/opencode/opencode.json".text = builtins.toJSON {
       "$schema" = "https://opencode.ai/config.json";
       model = "openrouter/moonshotai/kimi-k2.6";


### PR DESCRIPTION
## Summary
- `modules/home-manager/opencode.nix` now installs `pkgs.opencode` itself, so `custom.opencode.enable = true;` is sufficient on its own
- Drop the now-redundant manual `opencode` package entries from NightSprings and BrightFalls
- Enable the module on WorkLaptop alongside `claude-code` (both coexist; different binaries, different config dirs)