### PR TITLE
feat(opencode): add dracula theme

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -594,6 +594,22 @@
         "type": "github"
       }
     },
+    "opencode-dracula-theme": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1759476923,
+        "narHash": "sha256-JChZttHoHQ4CU7DsjzOskcz7NLAdZM45yrZdrCssj5E=",
+        "owner": "dracula",
+        "repo": "opencode",
+        "rev": "e7b8ba5bff2eca780c974a241d233230e58c4e0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dracula",
+        "repo": "opencode",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "agenix": "agenix",
@@ -611,6 +627,7 @@
         "nixpkgs": "nixpkgs_5",
         "nur": "nur",
         "nvf": "nvf",
+        "opencode-dracula-theme": "opencode-dracula-theme",
         "sublime-dracula-theme": "sublime-dracula-theme",
         "xcode-dracula-theme": "xcode-dracula-theme"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,10 @@
       url = "github:dracula/wallpaper";
       flake = false;
     };
+    opencode-dracula-theme = {
+      url = "github:dracula/opencode";
+      flake = false;
+    };
     ###############
     # Gnome theme #
     ###############

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  inputs,
   ...
 }:
 let
@@ -14,8 +15,10 @@ in
 
   config = lib.mkIf cfg.enable {
     home.packages = [ pkgs.opencode ];
+    home.file.".config/opencode/themes/dracula.json".source = "${inputs.opencode-dracula-theme}/dracula.json";
     home.file.".config/opencode/opencode.json".text = builtins.toJSON {
       "$schema" = "https://opencode.ai/config.json";
+      theme = "dracula";
       model = "openrouter/moonshotai/kimi-k2.6";
       agent = {
         build = {


### PR DESCRIPTION
Adds the official Dracula theme for OpenCode as a flake input and configures the TUI to use it.