### PR TITLE
feat(nexus): enable librechat registration

### DIFF
--- a/hosts/Nexus/services/librechat.nix
+++ b/hosts/Nexus/services/librechat.nix
@@ -12,7 +12,7 @@
     };
 
     env = {
-      ALLOW_REGISTRATION = false;
+      ALLOW_REGISTRATION = true;
       HOST = "0.0.0.0";
       PORT = 3080;
       MONGO_URI = lib.mkForce "mongodb://localhost:27017/librechat";


### PR DESCRIPTION
## Summary
- Flip `ALLOW_REGISTRATION` from `false` to `true` on the Nexus LibreChat instance so a user account can be created via the web UI.

## Test plan
- [ ] Deploy to Nexus
- [ ] Register account at `nexus:3080`
- [ ] Follow up with a PR flipping the flag back to `false`