### PR TITLE
feat(opencode): research-backed agent tuning

### DIFF
--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -28,14 +28,16 @@ in
           description = "Full-featured coding agent for implementation and complex changes. Writes code, runs tests, manages files, and executes system commands. Use for: building features, bug fixes, large refactors, dependency updates, and any task requiring code modifications.";
           mode = "primary";
           model = "openrouter/moonshotai/kimi-k2.6";
-          temperature = 0.2;
+          temperature = 1.0;
+          top_p = 0.95;
           steps = 25;
         };
         plan = {
           description = "Architecture and planning specialist. Analyzes code, designs solutions, and creates implementation plans without modifying files. Use for: system design, code review preparation, technical decisions, refactoring strategies, and understanding complex codebases.";
           mode = "primary";
           model = "openrouter/moonshotai/kimi-k2.6";
-          temperature = 0.1;
+          temperature = 0.6;
+          top_p = 0.95;
           steps = 15;
           permission = {
             write = { "*" = "deny"; };
@@ -47,7 +49,8 @@ in
           description = "Fast codebase navigator for discovery and analysis. Searches files, finds references, maps dependencies, and answers questions about code structure. Use for: understanding unfamiliar codebases, finding functions/classes, tracing data flows, and locating configuration.";
           mode = "subagent";
           model = "openrouter/deepseek/deepseek-v4-flash";
-          temperature = 0.1;
+          temperature = 1.0;
+          top_p = 1.0;
           steps = 10;
           permission = {
             write = { "*" = "deny"; };
@@ -62,7 +65,6 @@ in
           description = "Code quality and security reviewer. Identifies bugs, security vulnerabilities, performance issues, and style violations. Use for: PR reviews, security audits, best practice enforcement, and spotting potential edge cases or anti-patterns.";
           mode = "subagent";
           model = "openrouter/google/gemini-3-flash-preview";
-          temperature = 0.1;
           steps = 10;
           permission = {
             write = { "*" = "deny"; };
@@ -77,7 +79,8 @@ in
           description = "Diagnostic specialist for troubleshooting and investigation. Runs tests, inspects logs, reproduces issues, and analyzes error patterns. Use for: debugging failures, investigating performance issues, analyzing test results, and diagnosing system problems.";
           mode = "subagent";
           model = "openrouter/moonshotai/kimi-k2.6";
-          temperature = 0.1;
+          temperature = 0.6;
+          top_p = 0.95;
           steps = 15;
           permission = {
             write = { "*" = "deny"; };

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -1,3 +1,77 @@
+# OpenCode configuration — research-backed agent tuning.
+# ============================================================================
+#
+# Verification (run after `darwin-rebuild switch` on a host with this enabled):
+#
+#   OPENCODE_LOG_LEVEL=DEBUG opencode run --agent build "say hi" 2>&1 \
+#     | grep -iE 'temperature|top_p|reasoning'
+#
+#   Expect `reasoning: { effort: "..." }` in the outgoing request body.
+#   A bare top-level `reasoningEffort: "..."` is silently DROPPED by OpenRouter
+#   (only the nested `reasoning.effort` shape is recognised).
+#
+# Inspecting merged config:
+#   opencode debug agent build       # resolved per-agent settings
+#   opencode debug config            # merged top-level config
+#
+# ----------------------------------------------------------------------------
+# Primary references:
+#   Schema:           https://opencode.ai/config.json
+#   Agent docs:       https://opencode.ai/docs/agents/
+#   Config docs:      https://opencode.ai/docs/config/
+#   Permission docs:  https://opencode.ai/docs/permissions/
+#   OpenCode source:  https://github.com/sst/opencode
+#                     (packages/opencode/src/provider/transform.ts holds the
+#                      model-specific default temperature/top_p, plus the
+#                      reasoning-passthrough whitelist that excludes Kimi /
+#                      DeepSeek-V4 / MiniMax / GLM / Qwen)
+#   OpenRouter:       https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
+#
+# ----------------------------------------------------------------------------
+# Open issues to monitor (snapshot 2026-04-28):
+#   anomalyco/opencode#24569 + #24722  DeepSeek V4 reasoning_content not
+#                                       round-tripped → 400 on multi-turn
+#                                       tool calls. If `explore` fires this,
+#                                       drop its options.reasoning.effort.
+#   anomalyco/opencode#23334 / PR #23335  Proposes lifting the Kimi/Qwen
+#                                          exclusion from variants() so that
+#                                          the reasoning passthrough actually
+#                                          reaches Kimi via OpenRouter.
+#   anomalyco/opencode#21632  Subagent variants parsed but not applied at
+#                              runtime in v1.4.0+.
+#   anomalyco/opencode#18634  reasoningEffort=xhigh not visible in TUI/export.
+#
+# ----------------------------------------------------------------------------
+# Conventions used below:
+#
+#   * `temperature` and `top_p` for Kimi K2.6 follow Moonshot's thinking-mode
+#     profile (1.0 / 0.95). Moonshot LOCKS the temperature to the active mode
+#     on its official API (thinking=1.0, instant=0.6); OpenRouter relays
+#     without erroring but the recommendation still stands. OpenCode also
+#     auto-injects 1.0/0.95 for any kimi-k2.5/2.6/k2-thinking model in
+#     transform.ts, so the explicit values are documentation-equal-to-default.
+#     https://huggingface.co/moonshotai/Kimi-K2.6
+#     https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
+#
+#   * `options.reasoning.effort` (NOT bare `reasoningEffort`). OpenCode
+#     normalises agent-level `reasoningEffort` into
+#     providerOptions.openrouter.reasoningEffort, which OpenRouter silently
+#     ignores. The nested `options.reasoning.effort` form lands at
+#     providerOptions.openrouter.reasoning.effort — the shape OpenRouter
+#     actually consumes (verified in OpenRouterTeam/ai-sdk-provider source
+#     and tests).
+#
+#   * `steps` defaults to Infinity if unset (`agent.steps ?? Infinity` in
+#     packages/opencode/src/session/prompt.ts). Always cap explicitly.
+#     Community range observed across 12+ public configs: 4 to 400; this
+#     config sits on the conservative side of normal.
+#
+#   * `permission.write` is NOT a canonical permission key per the schema;
+#     it's silently absorbed by additionalProperties and does NOTHING. The
+#     `edit` permission already gates the {edit, write, patch} tool group
+#     per OpenCode docs.
+# ============================================================================
+
 {
   config,
   lib,
@@ -16,27 +90,88 @@ in
   config = lib.mkIf cfg.enable {
     home.packages = [ pkgs.opencode ];
     home.file.".config/opencode/themes/dracula.json".source = "${inputs.opencode-dracula-theme}/dracula.json";
+
+    # tui.json — theme, keybinds, TUI settings.
+    # The root opencode.json schema has additionalProperties:false and rejects
+    # `theme` at top level. Modern strict validators flag it; runtime currently
+    # accepts via fallback but the canonical placement is a sibling tui.json.
     home.file.".config/opencode/tui.json".text = builtins.toJSON {
       theme = "dracula";
     };
+
     home.file.".config/opencode/opencode.json".text = builtins.toJSON {
       "$schema" = "https://opencode.ai/config.json";
+
+      # Nix manages the package version. The nixpkgs derivation does NOT
+      # suppress this on its own — only OPENCODE_DISABLE_MODELS_FETCH is set
+      # there. Without this opt-out, OpenCode tries to self-update its binary
+      # in /nix/store (read-only) and emits "update available" notices.
       autoupdate = false;
+
+      # Default model for any agent that doesn't override.
+      # Kimi K2.6 chosen for long-horizon agentic work — Moonshot's design
+      # target is 200-300 sequential tool calls and a 4000-step horizon, with
+      # benchmark numbers achieved at temp=1.0, top_p=1.0 (build mirrors model
+      # card 0.95 instead of benchmark 1.0; both are valid, 0.95 matches
+      # OpenCode's auto-default).
+      # https://openrouter.ai/moonshotai/kimi-k2.6  (~$0.74 in / $4.65 out per Mtok, 256k ctx)
       model = "openrouter/moonshotai/kimi-k2.6";
+
+      # small_model — title generation, conversation summarisation, lightweight
+      # auxiliary calls. OpenCode schema makes this a STRING ONLY: no per-call
+      # parameter overrides are possible (verified against
+      # https://opencode.ai/config.json — the field is `{type: "string",
+      # $ref: "model-schema.json#/$defs/Model"}`).
+      #
+      # Gemini 2.5 Flash Lite chosen because:
+      #   1. Same provider family as the review agent's Gemini 3 Flash.
+      #   2. No reasoning overhead — using gemini-3-flash-preview here would
+      #      route every 5-token title through thinking_level=high (Gemini 3's
+      #      hardcoded default in OpenCode's transform.ts:875-877), wasteful at
+      #      $3.00 per Mtok output.
+      #   3. GA, not preview. ~$0.10 in / $0.40 out per Mtok.
+      # https://openrouter.ai/google/gemini-2.5-flash-lite
       small_model = "openrouter/google/gemini-2.5-flash-lite";
+
+      # AGENTS.md auto-discovery walks up from cwd anyway; listing it
+      # explicitly documents the dependency for any custom rules in the file.
       instructions = [ "AGENTS.md" ];
+
       agent = {
+
+        # ----------------------------------------------------------------
+        # build — primary implementation agent (full coding/edit/bash).
+        #   Sampling: Kimi K2.6 thinking-mode profile (Moonshot model card).
+        #   steps=50 matches Moonshot's published max-steps multi-step eval
+        #   ceiling. Community precedent: arvinmi=50, pshevche=80, ushiradineth
+        #   builder=80 (Kimi-class build agents typically sit 50-100).
+        # ----------------------------------------------------------------
         build = {
           description = "Full-featured coding agent for implementation and complex changes. Writes code, runs tests, manages files, and executes system commands. Use for: building features, bug fixes, large refactors, dependency updates, and any task requiring code modifications.";
           mode = "primary";
           model = "openrouter/moonshotai/kimi-k2.6";
           temperature = 1.0;
           top_p = 0.95;
+          # KIMI CAVEAT: OpenCode has no client-side thinking-on toggle for
+          # Kimi via OpenRouter — auto-thinking is gated to @ai-sdk/anthropic
+          # only (transform.ts ~lines 914-922). This value propagates as
+          # `reasoning: { effort: "high" }` in the request body; whether
+          # thinking actually engages depends on the OpenRouter→Moonshot
+          # gateway honouring it. See issue #23334 for proposal to lift the
+          # Kimi exclusion in variants().
           options = {
             reasoning = { effort = "high"; };
           };
           steps = 50;
         };
+
+        # ----------------------------------------------------------------
+        # plan — primary, read-only architecture/design.
+        #   Most reasoning-bound role in the config — gets `xhigh` (≈95% of
+        #   max_tokens budget allocated to reasoning per OpenRouter spec).
+        #   Kimi's underlying API is binary thinking on/off, so xhigh likely
+        #   maps to "high" upstream — that's still the right intent.
+        # ----------------------------------------------------------------
         plan = {
           description = "Architecture and planning specialist. Analyzes code, designs solutions, and creates implementation plans without modifying files. Use for: system design, code review preparation, technical decisions, refactoring strategies, and understanding complex codebases.";
           mode = "primary";
@@ -52,12 +187,32 @@ in
             bash = { "*" = "deny"; };
           };
         };
+
+        # ----------------------------------------------------------------
+        # explore — subagent, read-only codebase navigator.
+        #   DeepSeek V4 Flash chosen for cheap fast retrieval ($0.14/$0.28
+        #   per Mtok). Model card mandates temp=1.0, top_p=1.0 across ALL
+        #   modes — explicitly supersedes the legacy V3 per-task table that
+        #   said coding=0.0. Lower values (the GPT/Claude habit) are
+        #   documented anti-patterns for V4.
+        #   https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash
+        # ----------------------------------------------------------------
         explore = {
           description = "Fast codebase navigator for discovery and analysis. Searches files, finds references, maps dependencies, and answers questions about code structure. Use for: understanding unfamiliar codebases, finding functions/classes, tracing data flows, and locating configuration.";
           mode = "subagent";
           model = "openrouter/deepseek/deepseek-v4-flash";
           temperature = 1.0;
           top_p = 1.0;
+          # NOT xhigh — that maps to DeepSeek "Think Max" which requires
+          # ≥384K context (393,216 per the vLLM recipe) and burns ~95% of the
+          # token budget on reasoning. Wrong for a blocking subagent that a
+          # primary is waiting on.
+          #
+          # WATCH-OUT: anomalyco/opencode#24569 + #24722 (open) report 400s
+          # on V4 multi-turn tool calls when reasoning is enabled, because
+          # reasoning_content is not round-tripped via OpenRouter. If this
+          # fires on real usage, drop the options block and accept Non-think
+          # mode for explore.
           options = {
             reasoning = { effort = "high"; };
           };
@@ -70,6 +225,19 @@ in
             grep = { "*" = "allow"; };
           };
         };
+
+        # ----------------------------------------------------------------
+        # review — subagent, code quality + security review.
+        #   No temperature/top_p — Google explicitly warns that any override
+        #   below default 1.0 causes "looping or degraded performance,
+        #   particularly with complex reasoning tasks." Defaults: 1.0/0.95.
+        #   https://ai.google.dev/gemini-api/docs/gemini-3
+        #
+        #   No options.reasoning.effort either — OpenCode's transform.ts
+        #   (~lines 875-877) unconditionally hardcodes
+        #   `reasoning: { effort: "high" }` for any gemini-3* model.
+        #   Setting it here would be silently redundant.
+        # ----------------------------------------------------------------
         review = {
           description = "Code quality and security reviewer. Identifies bugs, security vulnerabilities, performance issues, and style violations. Use for: PR reviews, security audits, best practice enforcement, and spotting potential edge cases or anti-patterns.";
           mode = "subagent";
@@ -83,6 +251,14 @@ in
             grep = { "*" = "allow"; };
           };
         };
+
+        # ----------------------------------------------------------------
+        # debug — subagent, troubleshooting with bash.
+        #   steps=30 sized for diagnostic loops (test → observe →
+        #   re-hypothesise → test). Community qa/diagnostic agents on
+        #   Kimi-class typically 50-80; 30 is conservative within that band
+        #   while still well above plan/build's read-only ceiling.
+        # ----------------------------------------------------------------
         debug = {
           description = "Diagnostic specialist for troubleshooting and investigation. Runs tests, inspects logs, reproduces issues, and analyzes error patterns. Use for: debugging failures, investigating performance issues, analyzing test results, and diagnosing system problems.";
           mode = "subagent";

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -20,6 +20,8 @@ in
       "$schema" = "https://opencode.ai/config.json";
       theme = "dracula";
       model = "openrouter/moonshotai/kimi-k2.6";
+      small_model = "openrouter/google/gemini-3-flash-preview";
+      instructions = [ "AGENTS.md" ];
       agent = {
         build = {
           description = "Full-featured coding agent for implementation and complex changes. Writes code, runs tests, manages files, and executes system commands. Use for: building features, bug fixes, large refactors, dependency updates, and any task requiring code modifications.";
@@ -32,7 +34,7 @@ in
           description = "Architecture and planning specialist. Analyzes code, designs solutions, and creates implementation plans without modifying files. Use for: system design, code review preparation, technical decisions, refactoring strategies, and understanding complex codebases.";
           mode = "primary";
           model = "openrouter/moonshotai/kimi-k2.6";
-          temperature = 0.3;
+          temperature = 0.1;
           steps = 15;
           permission = {
             write = { "*" = "deny"; };

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -26,14 +26,14 @@ in
           mode = "primary";
           model = "openrouter/moonshotai/kimi-k2.6";
           temperature = 0.2;
-          max_iterations = 25;
+          steps = 25;
         };
         plan = {
           description = "Architecture and planning specialist. Analyzes code, designs solutions, and creates implementation plans without modifying files. Use for: system design, code review preparation, technical decisions, refactoring strategies, and understanding complex codebases.";
           mode = "primary";
           model = "openrouter/moonshotai/kimi-k2.6";
           temperature = 0.3;
-          max_iterations = 15;
+          steps = 15;
           permission = {
             write = { "*" = "deny"; };
             edit = { "*" = "deny"; };
@@ -45,7 +45,7 @@ in
           mode = "subagent";
           model = "openrouter/deepseek/deepseek-v4-flash";
           temperature = 0.1;
-          max_iterations = 10;
+          steps = 10;
           permission = {
             write = { "*" = "deny"; };
             edit = { "*" = "deny"; };
@@ -60,7 +60,7 @@ in
           mode = "subagent";
           model = "openrouter/google/gemini-3-flash-preview";
           temperature = 0.1;
-          max_iterations = 10;
+          steps = 10;
           permission = {
             write = { "*" = "deny"; };
             edit = { "*" = "deny"; };
@@ -75,7 +75,7 @@ in
           mode = "subagent";
           model = "openrouter/moonshotai/kimi-k2.6";
           temperature = 0.1;
-          max_iterations = 15;
+          steps = 15;
           permission = {
             write = { "*" = "deny"; };
             edit = { "*" = "deny"; };

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -16,9 +16,11 @@ in
   config = lib.mkIf cfg.enable {
     home.packages = [ pkgs.opencode ];
     home.file.".config/opencode/themes/dracula.json".source = "${inputs.opencode-dracula-theme}/dracula.json";
+    home.file.".config/opencode/tui.json".text = builtins.toJSON {
+      theme = "dracula";
+    };
     home.file.".config/opencode/opencode.json".text = builtins.toJSON {
       "$schema" = "https://opencode.ai/config.json";
-      theme = "dracula";
       autoupdate = false;
       model = "openrouter/moonshotai/kimi-k2.6";
       small_model = "openrouter/google/gemini-2.5-flash-lite";
@@ -29,8 +31,10 @@ in
           mode = "primary";
           model = "openrouter/moonshotai/kimi-k2.6";
           temperature = 1.0;
-          top_p = 1.0;
-          reasoningEffort = "high";
+          top_p = 0.95;
+          options = {
+            reasoning = { effort = "high"; };
+          };
           steps = 50;
         };
         plan = {
@@ -39,10 +43,11 @@ in
           model = "openrouter/moonshotai/kimi-k2.6";
           temperature = 1.0;
           top_p = 0.95;
-          reasoningEffort = "xhigh";
+          options = {
+            reasoning = { effort = "xhigh"; };
+          };
           steps = 20;
           permission = {
-            write = { "*" = "deny"; };
             edit = { "*" = "deny"; };
             bash = { "*" = "deny"; };
           };
@@ -53,10 +58,11 @@ in
           model = "openrouter/deepseek/deepseek-v4-flash";
           temperature = 1.0;
           top_p = 1.0;
-          reasoningEffort = "high";
+          options = {
+            reasoning = { effort = "high"; };
+          };
           steps = 20;
           permission = {
-            write = { "*" = "deny"; };
             edit = { "*" = "deny"; };
             bash = { "*" = "deny"; };
             read = { "*" = "allow"; };
@@ -68,10 +74,8 @@ in
           description = "Code quality and security reviewer. Identifies bugs, security vulnerabilities, performance issues, and style violations. Use for: PR reviews, security audits, best practice enforcement, and spotting potential edge cases or anti-patterns.";
           mode = "subagent";
           model = "openrouter/google/gemini-3-flash-preview";
-          reasoningEffort = "high";
           steps = 20;
           permission = {
-            write = { "*" = "deny"; };
             edit = { "*" = "deny"; };
             bash = { "*" = "deny"; };
             read = { "*" = "allow"; };
@@ -85,10 +89,11 @@ in
           model = "openrouter/moonshotai/kimi-k2.6";
           temperature = 1.0;
           top_p = 0.95;
-          reasoningEffort = "high";
+          options = {
+            reasoning = { effort = "high"; };
+          };
           steps = 30;
           permission = {
-            write = { "*" = "deny"; };
             edit = { "*" = "deny"; };
             bash = { "*" = "allow"; };
             read = { "*" = "allow"; };

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -19,6 +19,7 @@ in
     home.file.".config/opencode/opencode.json".text = builtins.toJSON {
       "$schema" = "https://opencode.ai/config.json";
       theme = "dracula";
+      autoupdate = false;
       model = "openrouter/moonshotai/kimi-k2.6";
       small_model = "openrouter/google/gemini-3-flash-preview";
       instructions = [ "AGENTS.md" ];

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -21,7 +21,7 @@ in
       theme = "dracula";
       autoupdate = false;
       model = "openrouter/moonshotai/kimi-k2.6";
-      small_model = "openrouter/google/gemini-3-flash-preview";
+      small_model = "openrouter/google/gemini-2.5-flash-lite";
       instructions = [ "AGENTS.md" ];
       agent = {
         build = {
@@ -29,16 +29,18 @@ in
           mode = "primary";
           model = "openrouter/moonshotai/kimi-k2.6";
           temperature = 1.0;
-          top_p = 0.95;
-          steps = 25;
+          top_p = 1.0;
+          reasoningEffort = "high";
+          steps = 50;
         };
         plan = {
           description = "Architecture and planning specialist. Analyzes code, designs solutions, and creates implementation plans without modifying files. Use for: system design, code review preparation, technical decisions, refactoring strategies, and understanding complex codebases.";
           mode = "primary";
           model = "openrouter/moonshotai/kimi-k2.6";
-          temperature = 0.6;
+          temperature = 1.0;
           top_p = 0.95;
-          steps = 15;
+          reasoningEffort = "xhigh";
+          steps = 20;
           permission = {
             write = { "*" = "deny"; };
             edit = { "*" = "deny"; };
@@ -51,7 +53,8 @@ in
           model = "openrouter/deepseek/deepseek-v4-flash";
           temperature = 1.0;
           top_p = 1.0;
-          steps = 10;
+          reasoningEffort = "high";
+          steps = 20;
           permission = {
             write = { "*" = "deny"; };
             edit = { "*" = "deny"; };
@@ -65,7 +68,8 @@ in
           description = "Code quality and security reviewer. Identifies bugs, security vulnerabilities, performance issues, and style violations. Use for: PR reviews, security audits, best practice enforcement, and spotting potential edge cases or anti-patterns.";
           mode = "subagent";
           model = "openrouter/google/gemini-3-flash-preview";
-          steps = 10;
+          reasoningEffort = "high";
+          steps = 20;
           permission = {
             write = { "*" = "deny"; };
             edit = { "*" = "deny"; };
@@ -79,9 +83,10 @@ in
           description = "Diagnostic specialist for troubleshooting and investigation. Runs tests, inspects logs, reproduces issues, and analyzes error patterns. Use for: debugging failures, investigating performance issues, analyzing test results, and diagnosing system problems.";
           mode = "subagent";
           model = "openrouter/moonshotai/kimi-k2.6";
-          temperature = 0.6;
+          temperature = 1.0;
           top_p = 0.95;
-          steps = 15;
+          reasoningEffort = "high";
+          steps = 30;
           permission = {
             write = { "*" = "deny"; };
             edit = { "*" = "deny"; };


### PR DESCRIPTION
## Summary

Research-backed pass over the OpenCode home-manager module (7 commits + docs):

- Fix `max_iterations` → `steps` (was an unrecognized field, silently dropped → all agents were running at OpenCode's default of `Infinity` iterations).
- Tune sampling per provider model cards (Kimi K2.6, DeepSeek V4 Flash, Gemini 3 Flash). All three providers explicitly recommend `temperature = 1.0` and warn that lower values cause looping/repetition/degraded reasoning.
- Add per-agent reasoning via `options.reasoning.effort` — the nested form OpenRouter actually consumes. Bare `reasoningEffort` ends up at `providerOptions.openrouter.reasoningEffort` and is silently ignored.
- Switch `small_model` from `gemini-3-flash-preview` to `gemini-2.5-flash-lite`. The schema makes `small_model` a string with no per-call override, so titles would otherwise inherit Gemini 3's hardcoded `thinking_level=high` (~$3/Mtok output, wasteful for 5-token titles).
- Disable runtime `autoupdate` (Nix manages the binary; nixpkgs derivation does not suppress this on its own).
- Move `theme` from `opencode.json` → sibling `tui.json` (root schema has `additionalProperties: false`).
- Drop dead `permission.write` blocks — `write` is not a canonical permission key per the schema; `edit` already gates writes.
- Document all rationale, references, and open issues inline in `opencode.nix` so future readers can audit choices without re-running the research.

🤖 Generated with [Claude Code](https://claude.com/claude-code)