### PR TITLE
fix(ci): merge eval into build job to fix dynamic matrix serialization

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -89,26 +89,8 @@ jobs:
 
           echo "matrix=$(echo "$selected" | jq -c .)" >> "$GITHUB_OUTPUT"
 
-  eval:
-    needs: [prepare]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        include: ${{ fromJson(needs.prepare.outputs.matrix) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
-
-      - name: Evaluate package
-        run: |
-          nix eval ".#${{ matrix.system_attr }}.${{ matrix.host }}.pkgs.${{ inputs.package }}.drvPath" --raw
-
   build:
-    needs: [eval]
+    needs: [prepare]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -120,6 +102,13 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v34
+
+      - name: Evaluate package
+        run: |
+          nix eval ".#${{ matrix.system_attr }}.${{ matrix.host }}.pkgs.${{ inputs.package }}.drvPath" --raw
+
       - uses: wimpysworld/nothing-but-nix@v10
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
         with:
@@ -127,7 +116,7 @@ jobs:
           witness-carnage: true
           nix-permission-edict: true
 
-      - name: Install Nix
+      - name: Install Nix (with config)
         uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: |


### PR DESCRIPTION
## Problem

The `build-package` workflow fails with:
```
Error from function 'fromJson': empty input
```

This happens because GitHub Actions cannot reliably pass a dynamic matrix output to a job that `needs` another matrix job. The separate `eval` and `build` jobs both tried to consume `fromJson(needs.prepare.outputs.matrix)`, but the serialization breaks across the dependency boundary.

## Fix

Merge the `eval` step into the `build` job. Each runner now:
1. Evaluates the package attribute first (fast fail on typos)
2. Proceeds to build and push if eval succeeds

This eliminates the dynamic matrix serialization between two dependent matrix jobs.
