### PR TITLE
fix(ci): run nothing-but-nix before nix installation

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -89,26 +89,8 @@ jobs:
 
           echo "matrix=$(echo "$selected" | jq -c .)" >> "$GITHUB_OUTPUT"
 
-  eval:
-    needs: [prepare]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        include: ${{ fromJson(needs.prepare.outputs.matrix) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
-
-      - name: Evaluate package
-        run: |
-          nix eval ".#${{ matrix.system_attr }}.${{ matrix.host }}.pkgs.${{ inputs.package }}.drvPath" --raw
-
   build:
-    needs: [eval]
+    needs: [prepare]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -120,6 +102,13 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v34
+
+      - name: Evaluate package
+        run: |
+          nix eval ".#${{ matrix.system_attr }}.${{ matrix.host }}.pkgs.${{ inputs.package }}.drvPath" --raw
+
       - uses: wimpysworld/nothing-but-nix@v10
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
         with:
@@ -127,7 +116,7 @@ jobs:
           witness-carnage: true
           nix-permission-edict: true
 
-      - name: Install Nix
+      - name: Install Nix (with config)
         uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -102,13 +102,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
-
-      - name: Evaluate package
-        run: |
-          nix eval ".#${{ matrix.system_attr }}.${{ matrix.host }}.pkgs.${{ inputs.package }}.drvPath" --raw
-
       - uses: wimpysworld/nothing-but-nix@v10
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
         with:
@@ -116,12 +109,16 @@ jobs:
           witness-carnage: true
           nix-permission-edict: true
 
-      - name: Install Nix (with config)
+      - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: |
             keep-outputs = true
             ${{ runner.os == 'Linux' && 'build-dir = /nix/build' || '' }}
+
+      - name: Evaluate package
+        run: |
+          nix eval ".#${{ matrix.system_attr }}.${{ matrix.host }}.pkgs.${{ inputs.package }}.drvPath" --raw
 
       - name: Configure Attic cache
         run: |


### PR DESCRIPTION
## Problem

The `build-package` workflow fails on Linux runners with:
```
Error: This action must be run before Nix is installed
```

## Root Cause

`wimpysworld/nothing-but-nix@v10` must run **before** any Nix installation. In the merged `build` job, Nix was installed first (for the `eval` step), then `nothing-but-nix` ran afterward — which caused it to fail because Nix was already present.

## Fix

Reorder the steps so that `nothing-but-nix` runs **before** the single Nix installation:

1. Checkout
2. `nothing-but-nix` (Linux only) ← **before** Nix is installed
3. Install Nix (all platforms)
4. Evaluate package
5. Configure Attic cache
6. Build package
7. Push to cache

This matches the step ordering in the existing `build.yml` and `pr-build.yml` workflows.
