### PR TITLE
fix(ci): run nothing-but-nix before any nix install in build-package

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -102,13 +102,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
-
-      - name: Evaluate package
-        run: |
-          nix eval ".#${{ matrix.system_attr }}.${{ matrix.host }}.pkgs.${{ inputs.package }}.drvPath" --raw
-
       - uses: wimpysworld/nothing-but-nix@v10
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
         with:
@@ -116,7 +109,7 @@ jobs:
           witness-carnage: true
           nix-permission-edict: true
 
-      - name: Install Nix (with config)
+      - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v34
         with:
           nix_conf: |


### PR DESCRIPTION
## Summary

- Run [25113549946](https://github.com/matteo-pacini/nixos-configs/actions/runs/25113549946) failed for all 5 Linux jobs at the `wimpysworld/nothing-but-nix@v10` step with `❌ This action must be run before Nix is installed`.
- Root cause: `build-package.yml` installed Nix as an early-eval gate **before** `nothing-but-nix`, so `/nix` already existed when the action ran. Commit `dedda1b` only moved the action before the *second* install; the first one was missed.
- Fix: mirror `build.yml`'s working order — `checkout → nothing-but-nix (Linux) → install Nix once → eval → attic → build → push`. Drops the duplicated first install + first eval left over from `43448f3` (eval-job merge).

## Test plan

- [ ] Manually dispatch `Build & Push Package` with one Linux host (e.g. `Nexus`) + one macOS host (e.g. `WorkLaptop`) toggled on, against a known-good `package` input.
- [ ] Confirm `nothing-but-nix` step passes on Linux (no precondition error).
- [ ] Confirm only one `Install Nix` step runs and `Evaluate package` runs once.
- [ ] Confirm macOS job skips `nothing-but-nix` and behaves as before.
- [ ] Re-dispatch with all Linux hosts ticked to confirm parity with the failing run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)