### PR TITLE
feat(opencode): add rtk package to opencode module

### DIFF
--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -105,7 +105,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ pkgs.opencode ];
+    home.packages = [ pkgs.opencode pkgs.rtk ];
     home.file.".config/opencode/themes/dracula.json".source = "${inputs.opencode-dracula-theme}/dracula.json";
 
     # tui.json — theme, keybinds, TUI settings.


### PR DESCRIPTION
Adds rtk to home.packages alongside pkgs.opencode in the shared opencode.nix module.\n\nAll hosts with custom.opencode.enable = true (BrightFalls, NightSprings, WorkLaptop) will now install rtk automatically.\n\nEval-verified on BrightFalls, NightSprings, and WorkLaptop.