### PR TITLE
chore: weekly flake update - 2026-04-30T11:28:20Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -123,11 +123,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776613567,
-        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
+        "lastModified": 1777713215,
+        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
+        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
         "type": "github"
       },
       "original": {
@@ -309,11 +309,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777518431,
-        "narHash": "sha256-SwgiG2T5pbyo33Vz7/vUCAhEMgwCK8Pa2nDSx5a6/WE=",
+        "lastModified": 1777679572,
+        "narHash": "sha256-egYNbRrkn+6SwTHinhdb6WUfzzdC3nXfCRqS321VylY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2e54a938cdd4c8e414b2518edc3d82308027c670",
+        "rev": "9cb587ade2aa1b4a7257f0238d41072690b0ca4f",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1777558748,
-        "narHash": "sha256-jdR8oGiC83u4zE4ninKk4Mikpwl1XLRs2F9gg9Oa+Iw=",
+        "lastModified": 1777708974,
+        "narHash": "sha256-in0dfy/56yFjzFhhkVRxJAuZrpImI1SZxzDQyAz4oNM=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "d574b2d3ddc1f9ca62dc7b83bfad4671442b6b67",
+        "rev": "dd6d4e440eb0bb7e965300bca5275c6f1143e228",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1777556507,
-        "narHash": "sha256-GmdCMjNEm03SJrqbhYSmfcEPrA+EewRilIjuRkdGOGc=",
+        "lastModified": 1777710479,
+        "narHash": "sha256-gLvm6EPhTGx1xSuf8PRQuqsd6XxOkoUJTEjUGzEvhAs=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "6853ee079f35cd170b8f62ac8d0398629b2f485a",
+        "rev": "8a8cfb588e294a3c764817034726f98d8bbed543",
         "type": "github"
       },
       "original": {
@@ -534,11 +534,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777556273,
-        "narHash": "sha256-8YBq8X78DCo7AztvCKOmYmHxbjVaaR0uw7H/aadFl2A=",
+        "lastModified": 1777712567,
+        "narHash": "sha256-HnS+JN7FhBq0dPdigYGE9py3TAMInzRPkVW8mE4qSQE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da20c1536fca004ed9f8bbd1eacb59d1ce13954b",
+        "rev": "5035bb030208b191f464446970df5786f25b7ae9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1774235677,
-        "narHash": "sha256-0ryNYmzDAeRlrzPTAgmzGH/Cgc8iv/LBN6jWGUANvIk=",
+        "lastModified": 1776478798,
+        "narHash": "sha256-ERStG27tf83VbCfYMxtDSs+sa8FUMJ/3jSu/QfX9rKE=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "894a3d23ac0c8aaf561b9874b528b9cb2e839201",
+        "rev": "3aae056b8d072624255bc8fd27febb7f327b2265",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.1",
+        "ref": "5.1.7",
         "repo": "brew",
         "type": "github"
       }
@@ -309,11 +309,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776777932,
-        "narHash": "sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8=",
+        "lastModified": 1777518431,
+        "narHash": "sha256-SwgiG2T5pbyo33Vz7/vUCAhEMgwCK8Pa2nDSx5a6/WE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d5640599a0050b994330328b9fd45709c909720",
+        "rev": "2e54a938cdd4c8e414b2518edc3d82308027c670",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776839947,
-        "narHash": "sha256-AXWzCRMLMrjHAm7PxGqiHbFbm0p54Y4YUkxbJxMaG9M=",
+        "lastModified": 1777558748,
+        "narHash": "sha256-jdR8oGiC83u4zE4ninKk4Mikpwl1XLRs2F9gg9Oa+Iw=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "32f12c76fa73da5142708eb9fdabeaea75ab88e3",
+        "rev": "d574b2d3ddc1f9ca62dc7b83bfad4671442b6b67",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776840796,
-        "narHash": "sha256-4NeqnM4JKnmw3ow0ec0TBTBYFbXbVdvtpqTj+C0sqEs=",
+        "lastModified": 1777556507,
+        "narHash": "sha256-GmdCMjNEm03SJrqbhYSmfcEPrA+EewRilIjuRkdGOGc=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "bcac962a0cb666729b9aac358307c607808883bb",
+        "rev": "6853ee079f35cd170b8f62ac8d0398629b2f485a",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768214250,
-        "narHash": "sha256-hnBZDQWUxJV3KbtvyGW5BKLO/fAwydrxm5WHCWMQTbw=",
+        "lastModified": 1776882296,
+        "narHash": "sha256-DWZozXwMsgvUqfVlL1mQ8dOxW7GJ/8CdyaDN+1niZRg=",
         "owner": "feel-co",
         "repo": "ndg",
-        "rev": "a6bd3c1ce2668d096e4fdaaa03ad7f03ba1fbca8",
+        "rev": "ab7d78d4884b3a34968cf9fa3d16c0c1246d5c6e",
         "type": "github"
       },
       "original": {
@@ -440,11 +440,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1774720267,
-        "narHash": "sha256-YYftFe8jyfpQI649yfr0E+dqEXE2jznZNcYvy/lKV1U=",
+        "lastModified": 1777250621,
+        "narHash": "sha256-WynkkG0hdZ5niYPJUbVg7oMfu8MVwGGzKZ6lKmfa+O8=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "a7760a3a83f7609f742861afb5732210fdc437ed",
+        "rev": "aeb2069920742d0d6570089e8b3b8620050bacf2",
         "type": "github"
       },
       "original": {
@@ -534,11 +534,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776839963,
-        "narHash": "sha256-gDDYO6hUyrIKSITgDP07UdQVAypRQg9vWKRfjN3PrFI=",
+        "lastModified": 1777556273,
+        "narHash": "sha256-8YBq8X78DCo7AztvCKOmYmHxbjVaaR0uw7H/aadFl2A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "403318582e512d3a8b24e54c36697688acf727bc",
+        "rev": "da20c1536fca004ed9f8bbd1eacb59d1ce13954b",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1776807380,
-        "narHash": "sha256-0ER2alMmyCMbq9ke2QrqqEIF4p2lbau0q8nYnSl+pDo=",
+        "lastModified": 1777478067,
+        "narHash": "sha256-2vZnUuv8fg2sIE6pXgGxZQQ3ZhQW1XE7Sxieg8gK2p4=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "0af681507273a8e7d4f18d535744de58cc158991",
+        "rev": "13c4ad4b4bb926c22945e2fb8862769fe51f27f1",
         "type": "github"
       },
       "original": {

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -9,5 +9,22 @@
   });
 
   # Token usage tracker for AI coding agents
+  # TODO: Remove local package + overlay once merged upstream.
+  #   tokscale: init at 2.0.26 (PR aims to add to nixpkgs)
+  #   https://github.com/NixOS/nixpkgs/pull/510494
   tokscale = super.callPackage ../packages/tokscale.nix { };
+
+  # Workaround: openldap 2.6.13 test017-syncreplication-refresh is flaky in the
+  # Nix sandbox and fails on x86_64-linux, breaking anything depending on wine
+  # (e.g. bottles, lutris).
+  # Affected hosts in this flake: CauldronLake, BrightFalls (x86_64)
+  # Upstream issues:
+  #   - openldap: test checks won't let it compile on x86_64
+  #     https://github.com/NixOS/nixpkgs/issues/514113
+  #   - Build failure: lutris-free
+  #     https://github.com/NixOS/nixpkgs/issues/513245
+  # TODO: Remove once upstream disables the flaky test or releases a fix.
+  openldap = super.openldap.overrideAttrs (old: {
+    doCheck = false;
+  });
 })

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -51,4 +51,17 @@
   xdg-desktop-portal = super.xdg-desktop-portal.overrideAttrs (old: {
     doCheck = false;
   });
+
+  # Workaround: rusty-v8 147.2.1 `tests/slots.rs` aborts under Nixpkgs'
+  # libc++ hardening with "vector[] index out of bounds", breaking Deno and
+  # nvf builds.
+  # Upstream issue:
+  #   - Build failure: deno
+  #     https://github.com/NixOS/nixpkgs/issues/511900
+  # TODO: Remove once upstream fixes the slots test or updates rusty-v8/deno.
+  deno = super.deno.override {
+    librusty_v8 = super.deno.librusty_v8.overrideAttrs (old: {
+      checkFlags = old.checkFlags ++ [ "--skip=slots" ];
+    });
+  };
 })

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -27,4 +27,16 @@
   openldap = super.openldap.overrideAttrs (old: {
     doCheck = false;
   });
+
+  # Workaround: fwupd 2.1.1 tests call Inhibit on systemd-logind via D-Bus,
+  # which fails in the Nix sandbox with AccessDenied. Affects CauldronLake.
+  # Keep an eye on upstream for a proper fix:
+  #   - fwupd: 2.1.1 -> 2.1.2 (may or may not resolve test failures)
+  #     https://github.com/NixOS/nixpkgs/pull/513368
+  #   - Also watch for new issues/PRs specifically about fwupd logind/D-Bus
+  #     test failures in sandboxed builds.
+  # TODO: Remove once upstream fixes the sandboxed test failures.
+  fwupd = super.fwupd.overrideAttrs (old: {
+    doCheck = false;
+  });
 })

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -39,4 +39,16 @@
   fwupd = super.fwupd.overrideAttrs (old: {
     doCheck = false;
   });
+
+  # Workaround: xdg-desktop-portal 1.20.4 integration tests
+  # (integration/dynamiclauncher and integration/notification) fail in the
+  # Nix sandbox / CI environment. Affects CauldronLake.
+  # No exact upstream tracker yet for these two tests. Loosely related
+  # (same package, sandbox test flakiness — different root cause):
+  #   - xdg-desktop-portal: test failed (integration/location, geoclue disabled)
+  #     https://github.com/NixOS/nixpkgs/issues/511228
+  # TODO: Remove once upstream fixes the sandboxed test failures.
+  xdg-desktop-portal = super.xdg-desktop-portal.overrideAttrs (old: {
+    doCheck = false;
+  });
 })


### PR DESCRIPTION
## Nixpkgs Updated

The nixpkgs input has been updated to the latest version.

### Changes:
```diff
         "type": "github"
       },
       "original": {
@@ -534,11 +534,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
```
