### PR TITLE
feat(claude-code): split vendored CLAUDE.md into ordered fragments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,40 @@
 @AGENTS.md
+
+## Vendored Claude Code CLAUDE.md
+
+`~/.claude/CLAUDE.md` is a managed symlink — never edit it directly. The
+deployed file is assembled in `modules/home-manager/claude-code.nix` by
+concatenating fragments from
+`modules/home-manager/claude-code/claude-md/` in numeric order, with
+`@RTK.md` injected between fragments 01 and 02. To change a section,
+edit the matching fragment:
+
+- `01-role-tone.md` — role, tone, confidence
+- `02-working-on-code.md` — workflow, output format
+- `03-git.md` — git/PR rules
+- `04-non-negotiables.md` — short list of never-dos
+
+### Recommended order (don't break this)
+
+The fragments cascade from general framing to specific reinforcement.
+Each layer narrows the one below it, so reordering changes how the model
+weights conflicts:
+
+```
+1. ROLE / TONE / COMMUNICATION   ← frames everything below
+        ↓
+2. RTK.md INCLUSION              ← stable global token-efficiency rules
+        ↓
+3. WORKING ON CODE / OUTPUT      ← specific workflow guidance
+        ↓
+4. GIT GUIDANCE                  ← workflow specialization for VCS
+        ↓
+5. NON-NEGOTIABLES (short)       ← final reinforcement, 2–4 lines
+```
+
+When adding a new section, slot it where it fits this hierarchy rather
+than appending blindly. Reuse an existing fragment if the topic
+overlaps; create a new numbered fragment only for a genuinely new
+layer, and add a `builtins.readFile` line in the `concatStringsSep`
+list in `modules/home-manager/claude-code.nix`. `RTK.md` lives
+alongside the fragments and is deployed separately to `~/.claude/RTK.md`.

--- a/modules/home-manager/claude-code.nix
+++ b/modules/home-manager/claude-code.nix
@@ -41,7 +41,16 @@ in
 
     home.file.".claude/settings.json".text = builtins.toJSON (baseSettings // cfg.extraSettings);
 
-    home.file.".claude/CLAUDE.md".source = ./claude-code/CLAUDE.md;
+    # CLAUDE.md is assembled from numbered fragments so each section can be
+    # edited in isolation. Order matches the structure documented in the repo's
+    # root CLAUDE.md: role/tone → RTK reference → workflow → git → non-negotiables.
+    home.file.".claude/CLAUDE.md".text = lib.concatStringsSep "\n" [
+      (builtins.readFile ./claude-code/claude-md/01-role-tone.md)
+      "@RTK.md\n"
+      (builtins.readFile ./claude-code/claude-md/02-working-on-code.md)
+      (builtins.readFile ./claude-code/claude-md/03-git.md)
+      (builtins.readFile ./claude-code/claude-md/04-non-negotiables.md)
+    ];
     home.file.".claude/RTK.md".source = ./claude-code/RTK.md;
   };
 }

--- a/modules/home-manager/claude-code/claude-md/01-role-tone.md
+++ b/modules/home-manager/claude-code/claude-md/01-role-tone.md
@@ -1,0 +1,11 @@
+## Role and tone
+Be direct. Skip preamble like "Great question!" and postamble like
+"Let me know if you need anything else." Match response length to the
+question — one-line questions get one-line answers.
+
+## Confidence and uncertainty
+- Don't guess at API signatures, library behavior, or syntax. If
+  unsure, say so or check.
+- Don't invent file paths, function names, or config keys.
+- When evidence is weak, state the assumption explicitly rather than
+  proceeding silently.

--- a/modules/home-manager/claude-code/claude-md/02-working-on-code.md
+++ b/modules/home-manager/claude-code/claude-md/02-working-on-code.md
@@ -1,0 +1,11 @@
+## Working on code
+- Read relevant existing code before proposing changes.
+- Run the failing test or reproduce the bug before suggesting a fix.
+- Prefer minimal diffs over rewrites unless asked.
+- Match the surrounding code's style; don't impose a different one.
+
+## Output format
+- Default to diffs or focused snippets, not full file dumps.
+- For multi-step work, give the plan first, then execute.
+- Use prose for explanations, code blocks for code. Avoid bulleted
+  lists of two-word items.

--- a/modules/home-manager/claude-code/claude-md/03-git.md
+++ b/modules/home-manager/claude-code/claude-md/03-git.md
@@ -1,5 +1,3 @@
-@RTK.md
-
 ## Git
 
 - **Commits**: always commit as the default git author. Never add `Co-Authored-By: Claude` (or any Claude attribution) lines or trailers.

--- a/modules/home-manager/claude-code/claude-md/04-non-negotiables.md
+++ b/modules/home-manager/claude-code/claude-md/04-non-negotiables.md
@@ -1,0 +1,4 @@
+## Non-negotiables
+- No "you're absolutely right" reversals — push back if I'm wrong.
+- No emoji unless I use them first.
+- No summaries of what you just did unless I ask.


### PR DESCRIPTION
## Summary

- Split the vendored `~/.claude/CLAUDE.md` into four numbered fragments under `modules/home-manager/claude-code/claude-md/` so individual sections can be edited without touching the rest of the file.
- Assemble the deployed `CLAUDE.md` in `claude-code.nix` via `concatStringsSep`, with `@RTK.md` injected between fragments 01 and 02 to preserve the original layout.
- Document the cascading order (role/tone → RTK → workflow → git → non-negotiables) in the repo root `CLAUDE.md` along with editing rules pointing future changes at the fragments instead of the symlinked deploy target.

## Test plan

- [x] `nix eval --raw .#darwinConfigurations.NightSprings.config.home-manager.users.matteo.home.file.\".claude/CLAUDE.md\".text` produces the expected concatenated output with correct blank-line spacing around `@RTK.md`.
- [ ] CI build passes for all hosts.