### PR TITLE
feat(claude-code): add diagnose/iterate/no-narration rules to CLAUDE.md

### DIFF
--- a/modules/home-manager/claude-code/claude-md/02-working-on-code.md
+++ b/modules/home-manager/claude-code/claude-md/02-working-on-code.md
@@ -1,8 +1,15 @@
 ## Working on code
 - Read relevant existing code before proposing changes.
 - Run the failing test or reproduce the bug before suggesting a fix.
+- For non-trivial bugs, diagnose the cause before proposing a fix.
+  Default to a plan, not a patch, unless the ask is mechanical.
+- When a task has an objective signal (tests, type-checker, build,
+  screenshot), run it and iterate until it's green rather than
+  declaring done after one pass.
 - Prefer minimal diffs over rewrites unless asked.
 - Match the surrounding code's style; don't impose a different one.
+- Don't narrate the diff in comments. Comment only what isn't
+  obvious from the code itself.
 
 ## Output format
 - Default to diffs or focused snippets, not full file dumps.


### PR DESCRIPTION
## Summary

Three behavioral additions to `02-working-on-code.md`, distilled from the Anthropic Claude Code talks (Boris + Cal):

- **Diagnose before patching** non-trivial bugs — default to a plan, not a patch, unless the ask is mechanical.
- **Iterate against objective signals** (tests, type-checker, build, screenshot) until green rather than declaring done after one pass.
- **Don't narrate the diff in comments** — comment only what isn't obvious from the code itself.

These reinforce model tendencies that the talks called out as persistent (one-pass declarations, comment spam, jumping to fixes without diagnosis) and aren't already covered by the existing fragments.

## Test plan
- [x] `nix build` of `darwinConfigurations.NightSprings` succeeds
- [x] Generated `~/.claude/CLAUDE.md` renders the new lines in the right cascade position (between existing "Working on code" bullets)
- [x] `RTK.md` reference still injected between fragments 01 and 02