### PR TITLE
docs(readme): sync with flake state and restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,203 +1,202 @@
-<div align="center"><img src="assets/nixos-logo.png" width="300px"></div>
-<h1 align="center">Matteo's NixOS/Nix Configurations</h1>
 <div align="center">
+  <img src="assets/nixos-logo.png" width="220px" alt="NixOS Logo">
+  <h1>Matteo's NixOS &amp; Nix-Darwin Configurations</h1>
 
 [![NixOS](https://img.shields.io/badge/NixOS-unstable-blue?logo=nixos&logoColor=white)](https://nixos.org)
+[![nix-darwin](https://img.shields.io/badge/nix--darwin-master-purple?logo=apple&logoColor=white)](https://github.com/LnL7/nix-darwin)
 [![Flakes](https://img.shields.io/badge/Flakes-enabled-green?logo=nix&logoColor=white)](https://nixos.wiki/wiki/Flakes)
 [![Build](https://github.com/matteo-pacini/nixos-configs/actions/workflows/build.yml/badge.svg)](https://github.com/matteo-pacini/nixos-configs/actions/workflows/build.yml)
 [![License](https://img.shields.io/badge/License-MIT-yellow)](LICENSE)
 
+<em>Personal NixOS &amp; nix-darwin flake. Hosts named after the <a href="https://en.wikipedia.org/wiki/Alan_Wake">Alan Wake</a> universe.</em>
+
 </div>
 
-Personal NixOS and nix-darwin configurations for my machines. Uses flakes, Home Manager, and agenix for secrets. Host names are from the [Alan Wake](https://en.wikipedia.org/wiki/Alan_Wake) universe.
+---
+
+## Overview
+
+Seven build configurations across five physical machines. Linux hosts run NixOS on `linuxPackages_7_0`; Darwin hosts use nix-darwin with Homebrew taps pinned through `nix-homebrew`. Home Manager is shared across both. Secrets are managed with [agenix](https://github.com/ryantm/agenix) (Nexus only, today).
+
+| Host | Platform | Role | User |
+|------|----------|------|------|
+| **BrightFalls** | `x86_64-linux` | Gaming desktop | `matteo` |
+| **BrightFallsVM-x86_64-linux** | `x86_64-linux` | VM variant | `matteo` |
+| **BrightFallsVM-aarch64-linux** | `aarch64-linux` | VM variant | `matteo` |
+| **Nexus** | `x86_64-linux` | Headless home server | `matteo` |
+| **CauldronLake** | `x86_64-linux` | Razer travel laptop | `debora` |
+| **NightSprings** | `aarch64-darwin` | MacBook Pro M1 Max | `matteo` |
+| **WorkLaptop** | `aarch64-darwin` | MacBook Pro M4 | `matteo.pacini` |
 
 ## Quick Start
 
 ```bash
 # Build a configuration (doesn't apply it)
-nix build ".#nixosConfigurations.BrightFalls.config.system.build.toplevel"
+nix build ".#nixosConfigurations.<Host>.config.system.build.toplevel"
 
 # Apply on NixOS
-sudo nixos-rebuild switch --flake .#BrightFalls
+sudo nixos-rebuild switch --flake .#<Host>
 
 # Apply on macOS
-nix run nix-darwin -- switch --flake .#NightSprings
+nix run nix-darwin -- switch --flake .#<Host>
+
+# Format the tree
+nix fmt
 ```
+
+> See [`AGENTS.md`](AGENTS.md) for the full development workflow, cross-platform evaluation tips, and module conventions.
+
+---
 
 ## Hosts
 
-### Gaming
+### BrightFalls — Gaming Desktop
 
-#### BrightFalls
-
-**Minisforum UM890 Pro** with RX 6800 XT eGPU — my main desktop.
+**Minisforum UM890 Pro** with an **RX 6800 XT** running through a DEG1 eGPU dock. Daily driver.
 
 <details>
-<summary>Hardware</summary>
+<summary><strong>Hardware</strong></summary>
 
 | Component | Model |
 |-----------|-------|
-| CPU | AMD Ryzen 7 8845HS (Zen4, 8C/16T, 45W) |
-| RAM | 32GB DDR5-5600 |
-| GPU | RX 6800 XT 16GB (DEG1 eGPU dock) |
-| Storage | Crucial P310 4TB NVMe |
-| Displays | ROG SWIFT PG278QR 1440p 165Hz + Dell U2719D 1440p 60Hz |
-| Audio | Schiit Modi 2/Magni 2, Sennheiser HD 650 |
+| CPU | AMD Ryzen 7 8845HS — Zen 4, 8C/16T, 45 W |
+| RAM | 32 GB DDR5-5600 |
+| GPU | RX 6800 XT 16 GB (DEG1 eGPU dock) |
+| Storage | Crucial P310 4 TB NVMe |
+| Displays | ASUS ROG SWIFT PG278QR 1440p @165 Hz · Dell U2719D 1440p @60 Hz |
+| Audio | Schiit Modi 2 / Magni 2 + Sennheiser HD 650 |
 | VR | Valve Index |
 
 </details>
 
 <details>
-<summary>Software</summary>
+<summary><strong>Software</strong></summary>
 
 - GNOME on Wayland
-- Linux 6.18 with BORE scheduler
-- Full disk encryption (LUKS2) with vault-based keyfile unlock
-- KVM/QEMU for VMs, Sunshine for streaming, LACT for GPU control
-- Suspend disabled (eGPU doesn't survive it)
+- Linux 7.0 with **BORE** scheduler patches
+- Per-host **znver4** overlay tuning the system for Zen 4
+- **Full-disk encryption** (LUKS2) using vault-based keyfile unlock
+- KVM/QEMU virtualization, **Sunshine** for game streaming, **LACT** for GPU control
+- Suspend disabled (the eGPU never recovers cleanly)
 
 </details>
 
 <details>
-<summary>Disk Layout</summary>
+<summary><strong>Disk Layout</strong></summary>
 
-Single 4TB NVMe partitioned with [disko](https://github.com/nix-community/disko):
+Single 4 TB NVMe partitioned with [disko](https://github.com/nix-community/disko):
 
-| Mount | Size | Filesystem | Encryption |
-|-------|------|------------|------------|
-| `/boot` | 1GB | FAT32 | None |
-| `/vault` | 64MB | ext2 | LUKS2 (password) |
-| `swap` | 36GB | swap | LUKS2 (keyfile) |
-| `/` | 200GB | ext4 | LUKS2 (keyfile) |
-| `/home` | 1TB | ext4 | LUKS2 (keyfile) |
-| `/games` | ~2.7TB | XFS | LUKS2 (keyfile) |
+| Mount | Size | FS | Encryption |
+|-------|------|----|------------|
+| `/boot` | 1 GB | FAT32 | none |
+| `/vault` | 64 MB | ext2 | LUKS2 (password) |
+| `swap` | 36 GB | swap | LUKS2 (keyfile) |
+| `/` | 200 GB | ext4 | LUKS2 (keyfile) |
+| `/home` | 1 TB | ext4 | LUKS2 (keyfile) |
+| `/games` | ~2.7 TB | XFS | LUKS2 (keyfile) |
 
-On boot, you enter the vault password once. Everything else unlocks automatically from the keyfile stored in `/vault`.
+You enter the vault password once at boot. Everything else unlocks automatically from the keyfile stored in `/vault`. Initrd SSH on port `2222` is available for remote unlock.
 
 **Fresh install:**
+
 ```bash
-# Create vault password and generate keyfile
+# 1. Stage vault password and a random keyfile
 echo -n "your-vault-password" > /tmp/vault.key
 dd if=/dev/urandom of=/tmp/luks.key bs=4096 count=1 iflag=fullblock
 
-# Partition and format
+# 2. Partition, format, and mount
 sudo nix run github:nix-community/disko/latest -- \
   --mode destroy,format,mount \
   --flake github:matteo-pacini/nixos-configs#BrightFalls
 
-# Install
+# 3. Install
 sudo nixos-install --flake github:matteo-pacini/nixos-configs#BrightFalls
 ```
 
 </details>
 
-#### CauldronLake
+### CauldronLake — Razer Blade
 
-**Razer Blade** — gaming laptop for travel.
+Travel gaming laptop running NixOS. Intel CPU + NVIDIA GPU (Optimus, PRIME render offload), GNOME on Linux 7.0, Steam with Proton.
 
-- Intel CPU + NVIDIA GPU (Optimus, Prime offload)
-- GNOME, Linux 6.18
-- Steam with Proton
+### Nexus — Home Server
 
----
-
-### Server
-
-#### Nexus
-
-**Dell PowerEdge R730xd** — home server for media, backups, and home automation.
+**Dell PowerEdge R730xd**. Headless. Handles media, automation, backups, and home-lab workloads. Secrets via agenix.
 
 <details>
-<summary>Hardware</summary>
+<summary><strong>Hardware</strong></summary>
 
 | Component | Model |
 |-----------|-------|
-| CPU | 2x Xeon E5-2697 v4 (36C/72T total) |
-| RAM | 132GB DDR4 ECC |
-| GPU | Quadro P2000 5GB (transcoding) |
-| Network | 8x 1GbE |
-| RAID | H730p (2GB cache) |
-| PSU | 1100W Platinum |
+| CPU | 2× Xeon E5-2697 v4 (36C / 72T total) |
+| RAM | 132 GB DDR4 ECC |
+| GPU | NVIDIA Quadro P2000 5 GB (Jellyfin transcoding) |
+| Network | 8× 1 GbE |
+| RAID | PERC H730p (2 GB cache) |
+| PSU | 1100 W 80+ Platinum |
 
 </details>
 
 <details>
-<summary>Storage</summary>
+<summary><strong>Storage</strong> — ~82 TB raw / ~73 TB usable</summary>
 
-~82TB raw, ~73TB usable after parity.
+| Pool | Disks | FS | Notes |
+|------|-------|----|-------|
+| OS | 2× MX500 2 TB | XFS | mdadm RAID1 |
+| Data | 10× 7–9 TB HDDs | ext4 | LUKS encrypted, merged via [mergerfs](https://github.com/trapexit/mergerfs) |
+| Parity | 2× 9 TB HDDs | ext4 | [SnapRAID](https://www.snapraid.it) dual parity |
 
-| Purpose | Disks | Filesystem | Notes |
-|---------|-------|------------|-------|
-| OS | 2x MX500 2TB | XFS | Software RAID1 |
-| Data | 10x 7-9TB HDDs | ext4 | LUKS encrypted, merged via [mergerfs](https://github.com/trapexit/mergerfs) |
-| Parity | 2x 9TB HDDs | ext4 | [SnapRAID](https://www.snapraid.it/) dual parity |
-
-See [Diskpool Handbook](docs/nexus/diskpool-handbook.md) for the full storage architecture.
+See the [Diskpool Handbook](docs/nexus/diskpool-handbook.md) for the full storage architecture.
 
 </details>
 
 <details>
-<summary>Services</summary>
+<summary><strong>Services</strong></summary>
 
-**Media:** Jellyfin, Sonarr, Radarr, qBittorrent, NZBGet, NZBHydra, Paperless-ngx
-
-**Home Automation:** Home Assistant, Zigbee2MQTT, Mosquitto, Wyoming (Piper TTS + Whisper STT)
-
-**Automation:** n8n
-
-**Infrastructure:** PostgreSQL, Caddy, Grafana, VictoriaMetrics, VictoriaLogs, Tailscale, Fail2ban, Route53 DDNS
+- **Media** — Jellyfin (NVENC), Sonarr, Radarr, NZBGet, NZBHydra, Paperless-ngx
+- **Cloud & sync** — Nextcloud, Atuin shell-history server
+- **Home automation** — Home Assistant, Zigbee2MQTT, Mosquitto, Wyoming (faster-whisper STT + Piper TTS)
+- **AI & automation** — n8n, LibreChat with Meilisearch (OpenRouter backend)
+- **Infrastructure** — PostgreSQL, Caddy, Tailscale, Mosh, Fail2ban, Route53 DDNS, MaxMind GeoIP
 
 </details>
 
 <details>
-<summary>Software</summary>
+<summary><strong>Software</strong></summary>
 
 - Headless (no desktop)
-- Linux 6.18, legacy BIOS boot
+- Linux 7.0, legacy BIOS boot
 - aarch64 binfmt emulation for cross-compilation
-- smartd monitoring, dual UPS with apcupsd
+- smartd monitoring + dual-UPS [`apcupsd-multi`](modules/nixos/apcupsd-multi.nix)
 - Secrets managed with [agenix](https://github.com/ryantm/agenix)
 
 </details>
 
----
+### NightSprings — MacBook Pro M1 Max
 
-### macOS
+Personal laptop. nix-darwin + nix-homebrew, declaratively managed Xcode versions (see [`xcodes`](#homemanagermodulesxcodes--declarative-xcode) below), Tailscale.
 
-#### NightSprings
+### WorkLaptop — MacBook Pro M4
 
-**MacBook Pro M1 Max** — personal laptop.
-
-nix-darwin + Homebrew, managed Xcode versions, Tailscale.
-
-#### WorkLaptop
-
-**MacBook Pro M1** — work machine.
-
-nix-darwin + Homebrew, Docker via Colima, Tailscale.
+Work machine. nix-darwin + nix-homebrew, Docker via Colima, Tailscale.
 
 ---
 
 ## Modules
 
-### Xcodes
+The flake exposes three module sets — `nixosModules.default`, `darwinModules.default`, and `homeManagerModules.default` — plus the standalone `homeManagerModules.xcodes`. Most modules are personal config; the ones below are written with options so they can be reused.
 
-Home Manager module for declaratively managing [Xcode](https://developer.apple.com/xcode/) versions via [xcodes](https://github.com/XcodesOrg/xcodes). macOS only.
+### `homeManagerModules.xcodes` — Declarative Xcode
 
-Handles installation, version switching, and cleanup of old versions automatically.
-
-**Usage:**
+Home Manager module for managing [Xcode](https://developer.apple.com/xcode/) versions through [xcodes](https://github.com/XcodesOrg/xcodes). Darwin only. Handles installation, version switching, and cleanup of old versions automatically.
 
 ```nix
-# flake.nix
 inputs.nixos-configs.url = "github:matteo-pacini/nixos-configs";
 
-# In your darwin configuration
 home-manager.sharedModules = [
   inputs.nixos-configs.homeManagerModules.xcodes
 ];
 
-# In your Home Manager config
 programs.xcodes = {
   enable = true;
   versions = [ "16.2" "16.3" ];
@@ -205,24 +204,41 @@ programs.xcodes = {
 };
 ```
 
-First activation requires Apple ID authentication. Subsequent runs are automatic.
-
-**Options:**
+First activation requires Apple ID authentication; subsequent runs are automatic.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enable` | bool | `false` | Enable the module |
 | `versions` | list | `[]` | Xcode versions to install |
-| `active` | string | `null` | Version to set as active |
+| `active` | string | `null` | Version to set active |
+
+### Other configurable modules
+
+Scoped to this flake but written with options should you want to crib them:
+
+- **`custom.nix-core`** *(NixOS, Darwin)* — Trusted users, experimental features, extra platforms.
+- **`custom.kernel`** *(NixOS)* — Linux 7.0 with optional BORE scheduler patches.
+- **`custom.locale`** *(NixOS)* — Locale, timezone, console keymap and font.
+- **`custom.bluetooth`**, **`custom.fonts`** *(NixOS / Darwin)* — Simple bundles.
+- **`custom.system-defaults`** *(Darwin)* — Dock, Finder, Touch ID for `sudo`, dark mode.
+- **`programs.git`**, **`programs.ssh`**, **`programs.atuin`**, **`programs.shell-tools`** *(Home Manager)* — Wrappers around their upstream counterparts with my preferences pre-applied.
+- **[`apcupsd-multi`](modules/nixos/apcupsd-multi.nix)** *(NixOS)* — apcupsd configured for multiple UPS units.
+
+## Packages
+
+`overlays/shared.nix` exposes a few custom packages:
+
+- **`tokscale`** — CLI for tracking token usage across agentic coding tools (Claude Code, OpenCode). Nix packaging of [junhoyeo/tokscale](https://github.com/junhoyeo/tokscale).
+- **`reshade-steam-proton`** — ReShade installer for Linux games running under Wine/Proton.
+- **`claude-code`** — Vendored from nixpkgs master with a wrapper that puts Node.js and `rtk` on PATH and toggles auto-compact + prompt caching.
 
 ---
 
 ## Documentation
 
-- [Diskpool Handbook](docs/nexus/diskpool-handbook.md) — Nexus storage architecture (LUKS, mergerfs, SnapRAID)
-- [Paperless-ngx Recovery](docs/nexus/paperless-ngx-recovery.md) — Disaster recovery procedures
-
----
+- [`AGENTS.md`](AGENTS.md) — Development workflow, conventions, and gotchas for working in this repo.
+- [Diskpool Handbook](docs/nexus/diskpool-handbook.md) — Nexus storage architecture (LUKS, mergerfs, SnapRAID).
+- [Paperless-ngx Recovery](docs/nexus/paperless-ngx-recovery.md) — Disaster recovery for the document archive.
 
 ## Acknowledgments
 
@@ -233,3 +249,5 @@ Built on top of excellent projects from the Nix community:
 - [agenix](https://github.com/ryantm/agenix)
 - [disko](https://github.com/nix-community/disko)
 - [nix-homebrew](https://github.com/zhaofengli/nix-homebrew)
+- [nvf](https://github.com/NotAShelf/nvf)
+- [BORE Scheduler](https://github.com/firelzrd/bore-scheduler)


### PR DESCRIPTION
## Summary

Audit the README against the live flake and fix factual drift, then restructure for readability.

### Factual corrections

- **Linux kernel**: `6.18` -> `7.0` (matches `linuxPackages_7_0` in `modules/nixos/kernel.nix`).
- **WorkLaptop hardware**: `MacBook Pro M1` -> `MacBook Pro M4`.
- **Nexus services list** rebuilt against `hosts/Nexus/services/`:
  - **Removed** (not configured anywhere): qBittorrent, Grafana, VictoriaMetrics, VictoriaLogs.
  - **Added** (configured but undocumented): Nextcloud, LibreChat + Meilisearch, Atuin shell-history server, Mosh, MaxMind GeoIP.

### Structural changes

- New **Overview** table mapping each host to its platform, role, and user.
- Nexus services regrouped by category (Media / Cloud / Home automation / AI / Infrastructure).
- **Modules** section expanded beyond `xcodes` to cover the other configurable modules: `custom.nix-core`, `custom.kernel`, `custom.locale`, `custom.bluetooth`, `custom.fonts`, `custom.system-defaults`, the Home Manager wrappers (`git`, `ssh`, `atuin`, `shell-tools`), and `apcupsd-multi`.
- New **Packages** section documenting `tokscale`, `reshade-steam-proton`, and the vendored `claude-code` wrapper.
- BrightFalls software section now mentions BORE patches (verified enabled) and the `znver4` overlay.
- Initrd-SSH-on-2222 detail surfaced in the BrightFalls disk section.
- Cross-link `AGENTS.md` as the workflow reference; add a `nix-darwin` badge.

## Test plan

- [ ] CI pr-build workflow passes (no `.nix` files touched, so eval/diff should be a no-op).
- [ ] Spot-check rendered README on the PR page — host table, badges, and `<details>` blocks render correctly.