### PR TITLE
feat(claude-code,opencode): manage RTK hooks from shared modules

### DIFF
--- a/modules/home-manager/claude-code.nix
+++ b/modules/home-manager/claude-code.nix
@@ -7,6 +7,19 @@
 let
   cfg = config.custom.claude-code;
   baseSettings = {
+    hooks = {
+      PreToolUse = [
+        {
+          matcher = "Bash";
+          hooks = [
+            {
+              type = "command";
+              command = "~/.claude/hooks/rtk-rewrite.sh";
+            }
+          ];
+        }
+      ];
+    };
     statusLine = {
       type = "command";
       # Relies on nodejs being on claude's PATH (set in overlays/shared.nix).
@@ -25,7 +38,7 @@ in
       default = { };
       description = ''
         Extra keys merged into ~/.claude/settings.json on top of the base
-        settings (which only sets statusLine). Use this for per-host overrides
+        settings (hooks + statusLine). Use this for per-host overrides
         like permissions.allow, enabledPlugins, effortLevel, etc.
       '';
     };
@@ -52,5 +65,10 @@ in
       (builtins.readFile ./claude-code/claude-md/04-non-negotiables.md)
     ];
     home.file.".claude/RTK.md".source = ./claude-code/RTK.md;
+
+    home.file.".claude/hooks/rtk-rewrite.sh" = {
+      source = ./claude-code/rtk-rewrite.sh;
+      executable = true;
+    };
   };
 }

--- a/modules/home-manager/claude-code/RTK.md
+++ b/modules/home-manager/claude-code/RTK.md
@@ -25,3 +25,5 @@ which rtk             # Verify correct binary
 
 All other commands are automatically rewritten by the Claude Code hook.
 Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
+
+Refer to CLAUDE.md for full command reference.

--- a/modules/home-manager/claude-code/rtk-rewrite.sh
+++ b/modules/home-manager/claude-code/rtk-rewrite.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# rtk-hook-version: 3
+# RTK Claude Code hook — rewrites commands to use rtk for token savings.
+# Requires: rtk >= 0.23.0, jq
+#
+# This is a thin delegating hook: all rewrite logic lives in `rtk rewrite`,
+# which is the single source of truth (src/discover/registry.rs).
+# To add or change rewrite rules, edit the Rust registry — not this file.
+#
+# Exit code protocol for `rtk rewrite`:
+#   0 + stdout  Rewrite found, no deny/ask rule matched → auto-allow
+#   1           No RTK equivalent → pass through unchanged
+#   2           Deny rule matched → pass through (Claude Code native deny handles it)
+#   3 + stdout  Ask rule matched → rewrite but let Claude Code prompt the user
+
+if ! command -v jq &>/dev/null; then
+  echo "[rtk] WARNING: jq is not installed. Hook cannot rewrite commands. Install jq: https://jqlang.github.io/jq/download/" >&2
+  exit 0
+fi
+
+if ! command -v rtk &>/dev/null; then
+  echo "[rtk] WARNING: rtk is not installed or not in PATH. Hook cannot rewrite commands. Install: https://github.com/rtk-ai/rtk#installation" >&2
+  exit 0
+fi
+
+# Version guard: rtk rewrite was added in 0.23.0.
+# Older binaries: warn once and exit cleanly (no silent failure).
+# Cache the version check to avoid spawning multiple processes on every hook call.
+CACHE_DIR=${XDG_CACHE_HOME:-$HOME/.cache}
+CACHE_FILE="$CACHE_DIR/rtk-hook-version-ok"
+if [ ! -f "$CACHE_FILE" ]; then
+  RTK_VERSION_RAW=$(rtk --version 2>/dev/null)
+  RTK_VERSION=${RTK_VERSION_RAW#rtk }
+  RTK_VERSION=${RTK_VERSION%% *}
+  if [ -n "$RTK_VERSION" ]; then
+    IFS=. read -r MAJOR MINOR PATCH <<<"$RTK_VERSION"
+    # Require >= 0.23.0
+    if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 23 ]; then
+      echo "[rtk] WARNING: rtk $RTK_VERSION is too old (need >= 0.23.0). Upgrade: cargo install rtk" >&2
+      exit 0
+    fi
+  fi
+  mkdir -p "$CACHE_DIR" 2>/dev/null
+  touch "$CACHE_FILE" 2>/dev/null
+fi
+
+INPUT=$(cat)
+CMD=$(jq -r '.tool_input.command // empty' <<<"$INPUT")
+
+if [ -z "$CMD" ]; then
+  exit 0
+fi
+
+# Delegate all rewrite + permission logic to the Rust binary.
+REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
+EXIT_CODE=$?
+
+case $EXIT_CODE in
+  0)
+    # Rewrite found, no permission rules matched — safe to auto-allow.
+    # If the output is identical, the command was already using RTK.
+    [ "$CMD" = "$REWRITTEN" ] && exit 0
+    ;;
+  1)
+    # No RTK equivalent — pass through unchanged.
+    exit 0
+    ;;
+  2)
+    # Deny rule matched — let Claude Code's native deny rule handle it.
+    exit 0
+    ;;
+  3)
+    # Ask rule matched — rewrite the command but do NOT auto-allow so that
+    # Claude Code prompts the user for confirmation.
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+if [ "$EXIT_CODE" -eq 3 ]; then
+  # Ask: rewrite the command, omit permissionDecision so Claude Code prompts.
+  jq -c --arg cmd "$REWRITTEN" \
+    '.tool_input.command = $cmd | {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "updatedInput": .tool_input
+      }
+    }' <<<"$INPUT"
+else
+  # Allow: rewrite the command and auto-allow.
+  jq -c --arg cmd "$REWRITTEN" \
+    '.tool_input.command = $cmd | {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+        "permissionDecisionReason": "RTK auto-rewrite",
+        "updatedInput": .tool_input
+      }
+    }' <<<"$INPUT"
+fi

--- a/modules/home-manager/claude-code/update-rtk.sh
+++ b/modules/home-manager/claude-code/update-rtk.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Refresh vendored RTK hook and awareness doc from upstream.
+# Overwrites RTK.md and rtk-rewrite.sh — any local edits are lost.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+BASE_URL="https://raw.githubusercontent.com/rtk-ai/rtk/master/hooks/claude"
+
+curl -fsSL "$BASE_URL/rtk-awareness.md" --output RTK.md
+curl -fsSL "$BASE_URL/rtk-rewrite.sh"   --output rtk-rewrite.sh

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -559,6 +559,10 @@ in
       theme = "dracula";
     };
 
+    # RTK plugin — auto-loaded from the plugins directory by OpenCode at
+    # startup (no opencode.json entry needed for file-based plugins).
+    home.file.".config/opencode/plugins/rtk.ts".source = ./opencode/rtk.ts;
+
     # recursiveUpdate (NOT //) — the base config now defines a `provider`
     # block (for the openrouter Kimi variants), and localLlamaProvider also
     # defines `provider`. Shallow `//` would let localLlama clobber the

--- a/modules/home-manager/opencode/rtk.ts
+++ b/modules/home-manager/opencode/rtk.ts
@@ -1,0 +1,39 @@
+import type { Plugin } from "@opencode-ai/plugin"
+
+// RTK OpenCode plugin — rewrites commands to use rtk for token savings.
+// Requires: rtk >= 0.23.0 in PATH.
+//
+// This is a thin delegating plugin: all rewrite logic lives in `rtk rewrite`,
+// which is the single source of truth (src/discover/registry.rs).
+// To add or change rewrite rules, edit the Rust registry — not this file.
+
+export const RtkOpenCodePlugin: Plugin = async ({ $ }) => {
+  try {
+    await $`which rtk`.quiet()
+  } catch {
+    console.warn("[rtk] rtk binary not found in PATH — plugin disabled")
+    return {}
+  }
+
+  return {
+    "tool.execute.before": async (input, output) => {
+      const tool = String(input?.tool ?? "").toLowerCase()
+      if (tool !== "bash" && tool !== "shell") return
+      const args = output?.args
+      if (!args || typeof args !== "object") return
+
+      const command = (args as Record<string, unknown>).command
+      if (typeof command !== "string" || !command) return
+
+      try {
+        const result = await $`rtk rewrite ${command}`.quiet().nothrow()
+        const rewritten = String(result.stdout).trim()
+        if (rewritten && rewritten !== command) {
+          ;(args as Record<string, unknown>).command = rewritten
+        }
+      } catch {
+        // rtk rewrite failed — pass through unchanged
+      }
+    },
+  }
+}

--- a/modules/home-manager/opencode/update-rtk.sh
+++ b/modules/home-manager/opencode/update-rtk.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Refresh vendored RTK OpenCode plugin from upstream.
+# Overwrites rtk.ts — any local edits are lost.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+BASE_URL="https://raw.githubusercontent.com/rtk-ai/rtk/master/hooks/opencode"
+
+curl -fsSL "$BASE_URL/rtk.ts" --output rtk.ts

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -13,8 +13,8 @@
   # with `./packages/claude-code/update.sh`.
   #
   # Wrapper additions on top of upstream (last reviewed against v2.1.123):
-  #   - PATH: nodejs and rtk are bundled onto claude's wrapped PATH instead of
-  #     being installed user-wide.
+  #   - PATH: nodejs, rtk, and jq are bundled onto claude's wrapped PATH
+  #     instead of being installed user-wide.
   #       * nodejs: so RTK's claude-code hook (and any other node-based hook
   #         under ~/.claude/hooks) can find `node`. Also satisfies the
   #         statusLine command (`npx -y ccstatusline@latest`).
@@ -22,6 +22,8 @@
   #         commands inside Claude sessions. Subprocesses spawned by claude
   #         inherit this PATH, so `rtk <cmd>` invocations from inside a session
   #         resolve. NOT on the user's interactive shell PATH by design.
+  #       * jq: needed by the rtk-rewrite hook to parse/emit JSON. macOS has
+  #         /usr/bin/jq but NixOS hosts don't install it by default.
   #     This is unrelated to upstream bugs — pure local-tooling concern.
   #   - CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000: works around the autocompact
   #     400k cap on Opus 4.7 [1m] variants
@@ -48,7 +50,7 @@
   claude-code = (super.callPackage ../packages/claude-code/package.nix { }).overrideAttrs (old: {
     postInstall = (old.postInstall or "") + ''
       wrapProgram $out/bin/claude \
-        --prefix PATH : ${super.nodejs}/bin:${super.rtk}/bin \
+        --prefix PATH : ${super.nodejs}/bin:${super.rtk}/bin:${super.jq}/bin \
         --set CLAUDE_CODE_AUTO_COMPACT_WINDOW 1000000 \
         --set ENABLE_PROMPT_CACHING_1H 1
     '';


### PR DESCRIPTION
## Summary

- **Claude Code**: Vendor `rtk-rewrite.sh` hook script, deploy via `home.file` (executable), and add `hooks.PreToolUse` to `settings.json` so the hook is actually invoked
- **Claude Code**: Bundle `jq` onto claude's wrapped PATH (needed by the hook on NixOS hosts)
- **OpenCode**: Deploy `rtk.ts` plugin to `~/.config/opencode/plugins/` for automatic command rewriting
- Add `update-rtk.sh` scripts for both modules to refresh vendored files from upstream

## Test plan

- [ ] `nix run nix-darwin -- switch --flake .#NightSprings`
- [ ] Verify `~/.claude/settings.json` contains `hooks.PreToolUse` entry
- [ ] Verify `~/.claude/hooks/rtk-rewrite.sh` is deployed and executable
- [ ] Verify `~/.config/opencode/plugins/rtk.ts` is deployed
- [ ] Start a Claude Code session, run a command, confirm `rtk gain` shows rewrite activity
- [ ] Start an OpenCode session, run a bash command, confirm RTK rewrites apply