### PR TITLE
chore: weekly flake update - 2026-05-04T13:11:53Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1774235677,
-        "narHash": "sha256-0ryNYmzDAeRlrzPTAgmzGH/Cgc8iv/LBN6jWGUANvIk=",
+        "lastModified": 1776478798,
+        "narHash": "sha256-ERStG27tf83VbCfYMxtDSs+sa8FUMJ/3jSu/QfX9rKE=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "894a3d23ac0c8aaf561b9874b528b9cb2e839201",
+        "rev": "3aae056b8d072624255bc8fd27febb7f327b2265",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.1",
+        "ref": "5.1.7",
         "repo": "brew",
         "type": "github"
       }
@@ -123,11 +123,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776613567,
-        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
+        "lastModified": 1777713215,
+        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
+        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
         "type": "github"
       },
       "original": {
@@ -309,11 +309,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776777932,
-        "narHash": "sha256-0R3Yow/NzSeVGUke5tL7CCkqmss4Vmi6BbV6idHzq/8=",
+        "lastModified": 1777913624,
+        "narHash": "sha256-4MwfrGuqjsnEORQbM3cmkmG/9cWhDV63dTDguDj4FXw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d5640599a0050b994330328b9fd45709c909720",
+        "rev": "a89686d115e970e200eb2caa7603f3673050e00c",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1776839947,
-        "narHash": "sha256-AXWzCRMLMrjHAm7PxGqiHbFbm0p54Y4YUkxbJxMaG9M=",
+        "lastModified": 1777956731,
+        "narHash": "sha256-djF1Y9RPTTXvbswcxEMI6k7UtihBhH3dmODsMFaaA3g=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "32f12c76fa73da5142708eb9fdabeaea75ab88e3",
+        "rev": "827139ab3e63292e8cec4783076ff51d0204d5b2",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776840796,
-        "narHash": "sha256-4NeqnM4JKnmw3ow0ec0TBTBYFbXbVdvtpqTj+C0sqEs=",
+        "lastModified": 1777960586,
+        "narHash": "sha256-XbeVNT/1FcefHUbVvnFQ/0XvZcxzMF+Vw9oo7pkhhAs=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "bcac962a0cb666729b9aac358307c607808883bb",
+        "rev": "096fa97c4503a1e702fc33e5394cce16db2f216d",
         "type": "github"
       },
       "original": {
@@ -379,11 +379,11 @@
     },
     "mnw": {
       "locked": {
-        "lastModified": 1770419553,
-        "narHash": "sha256-b1XqsH7AtVf2dXmq2iyRr2NC1yG7skY7Z6N2MpWHlK4=",
+        "lastModified": 1777828893,
+        "narHash": "sha256-gVWVnmyNr74BVKfhMMZDWkhx2699dhmZ2g0W8TTHtkk=",
         "owner": "Gerg-L",
         "repo": "mnw",
-        "rev": "2aaffa8030d0b262176146adbb6b0e6374ce2957",
+        "rev": "c1c0b544bfabe6669b5a6a0383ccb475fe60258b",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768214250,
-        "narHash": "sha256-hnBZDQWUxJV3KbtvyGW5BKLO/fAwydrxm5WHCWMQTbw=",
+        "lastModified": 1776882296,
+        "narHash": "sha256-DWZozXwMsgvUqfVlL1mQ8dOxW7GJ/8CdyaDN+1niZRg=",
         "owner": "feel-co",
         "repo": "ndg",
-        "rev": "a6bd3c1ce2668d096e4fdaaa03ad7f03ba1fbca8",
+        "rev": "ab7d78d4884b3a34968cf9fa3d16c0c1246d5c6e",
         "type": "github"
       },
       "original": {
@@ -421,11 +421,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775037210,
-        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
+        "lastModified": 1777780666,
+        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
+        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
         "type": "github"
       },
       "original": {
@@ -440,11 +440,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1774720267,
-        "narHash": "sha256-YYftFe8jyfpQI649yfr0E+dqEXE2jznZNcYvy/lKV1U=",
+        "lastModified": 1777250621,
+        "narHash": "sha256-WynkkG0hdZ5niYPJUbVg7oMfu8MVwGGzKZ6lKmfa+O8=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "a7760a3a83f7609f742861afb5732210fdc437ed",
+        "rev": "aeb2069920742d0d6570089e8b3b8620050bacf2",
         "type": "github"
       },
       "original": {
@@ -534,11 +534,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776839963,
-        "narHash": "sha256-gDDYO6hUyrIKSITgDP07UdQVAypRQg9vWKRfjN3PrFI=",
+        "lastModified": 1777962000,
+        "narHash": "sha256-Nrr5s5BZM6NSSdTjXY9x0qpFoOX19FFtlbNF+Mf9pRE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "403318582e512d3a8b24e54c36697688acf727bc",
+        "rev": "2fcf045936bc226a0f006b2e92cd697478e8df31",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1776807380,
-        "narHash": "sha256-0ER2alMmyCMbq9ke2QrqqEIF4p2lbau0q8nYnSl+pDo=",
+        "lastModified": 1777837065,
+        "narHash": "sha256-uRD6a4uNno3SsAw0E0E6xqbiK7pX63Ad1F37q5fyz9g=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "0af681507273a8e7d4f18d535744de58cc158991",
+        "rev": "7ec206a5d9a7d5d27900d81a6bb382823902276d",
         "type": "github"
       },
       "original": {

--- a/hosts/NightSprings/users/matteo/default.nix
+++ b/hosts/NightSprings/users/matteo/default.nix
@@ -26,7 +26,6 @@
     # Social
     element-desktop
     # Music
-    jellyfin-desktop
     jellyfin-tui
     # Window Management
     loopwm

--- a/hosts/WorkLaptop/users/matteo.pacini/default.nix
+++ b/hosts/WorkLaptop/users/matteo.pacini/default.nix
@@ -25,7 +25,6 @@
     # Window Management
     loopwm
     # Music
-    jellyfin-desktop
     jellyfin-tui
   ];
 

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -92,4 +92,29 @@
   fwupd = super.fwupd.overrideAttrs (_: {
     doCheck = false;
   });
+
+  # xdg-desktop-portal-1.20.4: two integration tests fail in the Nix build
+  # sandbox because the validator helpers (xdg-desktop-portal-validate-sound
+  # and -validate-icon) shell out to bwrap, which tries to create a nested
+  # user namespace and trips on:
+  #     bwrap: Can't mount proc on /newroot/proc: Operation not permitted
+  # The failures:
+  #   - integration/dynamiclauncher (exit status 1)
+  #   - integration/notification    (pytest test_sound_fd: "invalid sound:
+  #                                  The sound data is invalid (36)" because
+  #                                  the validator subprocess died)
+  # Same family as openldap/fwupd above — environment-driven, not a real
+  # package bug. Affects the gaming Linux hosts (CauldronLake / BrightFalls)
+  # that pull xdg-desktop-portal in via their desktop closure.
+  #
+  # Skipping the check phase until upstream nixpkgs ships a fix. The closest
+  # tracking issue is open with no comments and was filed for a different
+  # trigger (a custom enableGeoLocation override), but the failing test is
+  # the same one:
+  #   Issue: https://github.com/NixOS/nixpkgs/issues/511228 (OPEN)
+  # Drop this override once nixos-unstable ships an xdg-desktop-portal whose
+  # checkPhase passes inside the build sandbox.
+  xdg-desktop-portal = super.xdg-desktop-portal.overrideAttrs (_: {
+    doCheck = false;
+  });
 })

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -74,4 +74,22 @@
   openldap = super.openldap.overrideAttrs (_: {
     doCheck = false;
   });
+
+  # fwupd-2.1.1: two test cases fail in the Nix build sandbox because they
+  # expect a running desktop session:
+  #   - fu-engine-gtypes-test: FuPluginLogind aborts with
+  #     "GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: Permission
+  #     denied" when it tries to call logind.Inhibit (no logind in sandbox).
+  #   - fwupd-client-test:     killed by SIGABRT (related fallout).
+  # Affects the gaming hosts (CauldronLake / BrightFalls) that pull fwupd
+  # in transitively, killing the system build in CI.
+  #
+  # Skipping the check phase until upstream nixpkgs gets a fix. There's no
+  # tracking issue specific to this; the next-version bump PR doesn't
+  # address tests either, so don't expect it to land a fix on its own.
+  #   2.1.2 bump:    https://github.com/NixOS/nixpkgs/pull/513368 (OPEN, x86_64-linux only)
+  # Drop this once nixos-unstable ships a fwupd whose checkPhase passes.
+  fwupd = super.fwupd.overrideAttrs (_: {
+    doCheck = false;
+  });
 })

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -57,21 +57,21 @@
   # Token usage tracker for AI coding agents
   tokscale = super.callPackage ../packages/tokscale.nix { };
 
-  # openldap-2.6.13: test017-syncreplication-refresh is timing-sensitive and
-  # fails on slow/sandboxed builders ("provider and consumer databases
-  # differ"). The failure cascades into bottles / lutris / wine FHS envs
-  # pulled in by the gaming hosts (BrightFalls, CauldronLake), killing their
-  # full system builds in CI.
+  # openldap-2.6.13: the syncreplication tests are timing-sensitive and fail
+  # on slow / sandboxed builders ("provider and consumer databases differ").
+  # First test017 fell over, then surgically skipping it just exposed the
+  # next one (test019-syncreplication-cascade). The failure cascades into
+  # bottles / lutris / wine FHS envs pulled in by the gaming hosts
+  # (BrightFalls, CauldronLake), killing their full system builds in CI.
   #
-  # Mirrors the upstream nixpkgs fix (still OPEN) by extending preCheck to
-  # delete the offending test script, matching how other flaky openldap
-  # tests (test022, test063, test076) are already skipped.
+  # Disabling the check phase entirely until upstream lands a real fix —
+  # going test-by-test is whack-a-mole.
   #   Issue: https://github.com/NixOS/nixpkgs/issues/516392 (CLOSED, links to PR)
-  #   Fix:   https://github.com/NixOS/nixpkgs/pull/516445   (OPEN as of 2026-05-05)
-  # Drop this override once the fix PR lands in nixos-unstable.
-  openldap = super.openldap.overrideAttrs (old: {
-    preCheck = (old.preCheck or "") + ''
-      rm -f tests/scripts/test017-syncreplication-refresh
-    '';
+  #   Fix:   https://github.com/NixOS/nixpkgs/pull/516445   (OPEN as of 2026-05-05,
+  #          only patches test017 — won't fully unbreak us; revisit when
+  #          upstream addresses test019 too)
+  # Drop this override once nixos-unstable ships a build that passes checks.
+  openldap = super.openldap.overrideAttrs (_: {
+    doCheck = false;
   });
 })

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -56,4 +56,22 @@
 
   # Token usage tracker for AI coding agents
   tokscale = super.callPackage ../packages/tokscale.nix { };
+
+  # openldap-2.6.13: test017-syncreplication-refresh is timing-sensitive and
+  # fails on slow/sandboxed builders ("provider and consumer databases
+  # differ"). The failure cascades into bottles / lutris / wine FHS envs
+  # pulled in by the gaming hosts (BrightFalls, CauldronLake), killing their
+  # full system builds in CI.
+  #
+  # Mirrors the upstream nixpkgs fix (still OPEN) by extending preCheck to
+  # delete the offending test script, matching how other flaky openldap
+  # tests (test022, test063, test076) are already skipped.
+  #   Issue: https://github.com/NixOS/nixpkgs/issues/516392 (CLOSED, links to PR)
+  #   Fix:   https://github.com/NixOS/nixpkgs/pull/516445   (OPEN as of 2026-05-05)
+  # Drop this override once the fix PR lands in nixos-unstable.
+  openldap = super.openldap.overrideAttrs (old: {
+    preCheck = (old.preCheck or "") + ''
+      rm -f tests/scripts/test017-syncreplication-refresh
+    '';
+  });
 })


### PR DESCRIPTION
## Nixpkgs Updated

The nixpkgs input has been updated to the latest version.

### Changes:
```diff
         "type": "github"
       },
       "original": {
@@ -534,11 +534,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {
```
