### PR TITLE
feat(rtk): vendor derivation and pin hook fetches

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -309,11 +309,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777913624,
-        "narHash": "sha256-4MwfrGuqjsnEORQbM3cmkmG/9cWhDV63dTDguDj4FXw=",
+        "lastModified": 1778009629,
+        "narHash": "sha256-nUoQtf4Zq7DRYJrfv904hjrxjAlWVP6a1pNNFKx3FCg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a89686d115e970e200eb2caa7603f3673050e00c",
+        "rev": "00ed86e58bb6979a7921859fd1615d19382eac5c",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1777956731,
-        "narHash": "sha256-djF1Y9RPTTXvbswcxEMI6k7UtihBhH3dmODsMFaaA3g=",
+        "lastModified": 1778049089,
+        "narHash": "sha256-3iO52PYjtWQiBGvJtKxWq1x6yK1dRaK9lqLsSwCYfq8=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "827139ab3e63292e8cec4783076ff51d0204d5b2",
+        "rev": "3bc001b4439e37c8aee6b2877560f9cca889bc54",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1777960586,
-        "narHash": "sha256-XbeVNT/1FcefHUbVvnFQ/0XvZcxzMF+Vw9oo7pkhhAs=",
+        "lastModified": 1778042439,
+        "narHash": "sha256-IxGVXPMLjhoLCFv04o2o0un5iBy/TpUFqjlBilVOY8Q=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "096fa97c4503a1e702fc33e5394cce16db2f216d",
+        "rev": "7a759d09180a4d57224e3a78dcab5bfd4b3bdfb1",
         "type": "github"
       },
       "original": {
@@ -534,11 +534,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1777578337,
-        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777962000,
-        "narHash": "sha256-Nrr5s5BZM6NSSdTjXY9x0qpFoOX19FFtlbNF+Mf9pRE=",
+        "lastModified": 1778050255,
+        "narHash": "sha256-ChC0gEg0izE3a4ykxs/L2QFzvb5OGBxzEvYhCDXBDDA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2fcf045936bc226a0f006b2e92cd697478e8df31",
+        "rev": "fddfc4e23ef77afef482c8294daed57e0d3ca702",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1777837065,
-        "narHash": "sha256-uRD6a4uNno3SsAw0E0E6xqbiK7pX63Ad1F37q5fyz9g=",
+        "lastModified": 1778049651,
+        "narHash": "sha256-EC5pBiLcP/EVmYWldJRNfkChCqF9rkeTnTs8t9Cs+ZY=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "7ec206a5d9a7d5d27900d81a6bb382823902276d",
+        "rev": "88dbbad1f44efe3d2c18903e2c7542452f7bdfd6",
         "type": "github"
       },
       "original": {

--- a/modules/home-manager/claude-code/update-rtk.sh
+++ b/modules/home-manager/claude-code/update-rtk.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
-# Refresh vendored RTK hook and awareness doc from upstream.
+# Refresh vendored RTK hook and awareness doc, pinned to the rtk binary
+# version in ../../../packages/rtk/package.nix. The rtk binary embeds an
+# integrity hash for rtk-rewrite.sh; pulling the hook from master while the
+# binary lags behind upstream causes the runtime check to fail. Always
+# fetch from the tag the binary was built from.
 # Overwrites RTK.md and rtk-rewrite.sh — any local edits are lost.
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-BASE_URL="https://raw.githubusercontent.com/rtk-ai/rtk/master/hooks/claude"
+PACKAGE_NIX="../../../packages/rtk/package.nix"
+VERSION=$(grep -m1 -E '^\s*version = "' "$PACKAGE_NIX" | sed -E 's/.*"([^"]+)".*/\1/')
+if [ -z "$VERSION" ]; then
+  echo "error: could not parse rtk version from $PACKAGE_NIX" >&2
+  exit 1
+fi
+
+BASE_URL="https://raw.githubusercontent.com/rtk-ai/rtk/v${VERSION}/hooks/claude"
 
 curl -fsSL "$BASE_URL/rtk-awareness.md" --output RTK.md
 curl -fsSL "$BASE_URL/rtk-rewrite.sh"   --output rtk-rewrite.sh

--- a/modules/home-manager/opencode/update-rtk.sh
+++ b/modules/home-manager/opencode/update-rtk.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
-# Refresh vendored RTK OpenCode plugin from upstream.
+# Refresh vendored RTK OpenCode plugin, pinned to the rtk binary version in
+# ../../../packages/rtk/package.nix. Pinning keeps plugin behavior in sync
+# with the binary it talks to (same reasoning as the claude-code hook,
+# though OpenCode's plugin has no runtime integrity check).
 # Overwrites rtk.ts — any local edits are lost.
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-BASE_URL="https://raw.githubusercontent.com/rtk-ai/rtk/master/hooks/opencode"
+PACKAGE_NIX="../../../packages/rtk/package.nix"
+VERSION=$(grep -m1 -E '^\s*version = "' "$PACKAGE_NIX" | sed -E 's/.*"([^"]+)".*/\1/')
+if [ -z "$VERSION" ]; then
+  echo "error: could not parse rtk version from $PACKAGE_NIX" >&2
+  exit 1
+fi
+
+BASE_URL="https://raw.githubusercontent.com/rtk-ai/rtk/v${VERSION}/hooks/opencode"
 
 curl -fsSL "$BASE_URL/rtk.ts" --output rtk.ts

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -50,11 +50,20 @@
   claude-code = (super.callPackage ../packages/claude-code/package.nix { }).overrideAttrs (old: {
     postInstall = (old.postInstall or "") + ''
       wrapProgram $out/bin/claude \
-        --prefix PATH : ${super.nodejs}/bin:${super.rtk}/bin:${super.jq}/bin \
+        --prefix PATH : ${super.nodejs}/bin:${self.rtk}/bin:${super.jq}/bin \
         --set CLAUDE_CODE_AUTO_COMPACT_WINDOW 1000000 \
         --set ENABLE_PROMPT_CACHING_1H 1
     '';
   });
+
+  # rtk: vendored from nixpkgs master into ../packages/rtk/ so we can track
+  # upstream faster than the flake's nixos-unstable pin. The rtk binary embeds
+  # an expected hash for the bundled rtk-rewrite.sh hook; when upstream pushes
+  # a hook content change ahead of a binary release, anyone on a nixpkgs lag
+  # sees the integrity check fail. Vendoring lets us bump the rtk derivation
+  # as soon as upstream tags a release that bundles the new hook.
+  # Refresh with `./packages/rtk/update.sh`.
+  rtk = super.callPackage ../packages/rtk/package.nix { };
 
   # Token usage tracker for AI coding agents
   tokscale = super.callPackage ../packages/tokscale.nix { };

--- a/packages/claude-code/manifest.json
+++ b/packages/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.123",
-  "commit": "54903ade25087ef906df59ec6a608cc3a50a3f06",
-  "buildDate": "2026-04-29T00:41:50Z",
+  "version": "2.1.128",
+  "commit": "d6caed183d5f5b985cab02ef8c812d2abee9ecd9",
+  "buildDate": "2026-05-04T17:39:35Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "44597dff0f1c11e37c1954d4ac3965909be376e5961b558345723357253bcc90",
-      "size": 215880320
+      "checksum": "1a56ae4cd171ba7839fc2b03d558022ffaebb5693be532d8f3c344731063e979",
+      "size": 216953600
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "ddea227d4c2b2602d650d2c5d5c812f7680701a1504bcaff81e42c165c583ef9",
-      "size": 217444560
+      "checksum": "eb7f5441fcc169a01ec6a655d7663dffbcfe9cb03491dc0c7a157e9e67da3737",
+      "size": 218517840
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "825c526035d1d75ff0bc1eebf18c887f98d07ea49ea80bd312ff416fe61a39b3",
-      "size": 247925312
+      "checksum": "e2a31879b7433f658d915e6716249f10b913b467873950e8e7e066ba7c4d96e9",
+      "size": 248973888
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "5a78139b679a86a88a0ac5476c706a64c3105bf6a6d435ba10f3aa3fb635bdb2",
-      "size": 247732864
+      "checksum": "770c81373ad42970ef576676da78d6be60413f4ade23abadbf1343ca0809bb3e",
+      "size": 248789632
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "0cd6e1a18036bee71ace8cbf7ed25cc4a443e69924796fc985b6719321cb37d3",
-      "size": 240650624
+      "checksum": "7d0e38623925ee076ede98392b2169bd88a2c529f080d7807ae03c350b6b2337",
+      "size": 241699200
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "bddd41dde044863f04c0a5fce16514e7fa24e123d217e09526a88188af67dbc0",
-      "size": 241998208
+      "checksum": "b6480ddd313432e37b35a356c38067b1a76b900a936e30e975111ad11f70dcf4",
+      "size": 243054976
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "34345e5c3c2d3910772aa7ecce2c33c2fce6cf2e146ff6c031f9c01debba02c6",
-      "size": 253691552
+      "checksum": "1d920cb73f612083ae4133ea4b63e1e8c7a4624a8ba827dfc928c12e86ad803e",
+      "size": 254711968
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "bc4a102e5086f8faa1b7f2848a0fb482a01314f4004619a05da8352b905b3154",
-      "size": 249754272
+      "checksum": "3b957bec823951455840accbdb6cfa970505691ce39b1fefa9de5c32a2ee2ff6",
+      "size": 250775712
     }
   }
 }

--- a/packages/rtk/package.nix
+++ b/packages/rtk/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  pkg-config,
+  sqlite,
+  gitMinimal,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rtk";
+  version = "0.38.0";
+
+  src = fetchFromGitHub {
+    owner = "rtk-ai";
+    repo = "rtk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eINYlatbjpsqe46LNZIXvIrZEBf+QC3+2EjY7Ei7VZI=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-qTDj7xTBM8dOOE7XLTewtHVwHtxVDcvCLs0ebtT2uSI=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    sqlite
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/rtk \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          gitMinimal
+        ]
+      }
+  '';
+
+  nativeCheckInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "CLI proxy that reduces LLM token consumption by 60-90% on common dev commands";
+    homepage = "https://github.com/rtk-ai/rtk";
+    changelog = "https://github.com/rtk-ai/rtk/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "rtk";
+  };
+})

--- a/packages/rtk/update.sh
+++ b/packages/rtk/update.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Refresh the vendored rtk derivation from nixpkgs master.
+# Overwrites package.nix — any local edits are lost.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+BASE_URL="https://raw.githubusercontent.com/NixOS/nixpkgs/master/pkgs/by-name/rt/rtk"
+
+curl -fsSL "$BASE_URL/package.nix" --output package.nix


### PR DESCRIPTION
## Summary

- Vendor rtk's nixpkgs derivation into `packages/rtk/` (same pattern as `packages/claude-code/`) so we can track upstream faster than the `nixos-25.11` channel pin. Includes a mirror-from-nixpkgs-master `update.sh`.
- Bump rtk to **v0.38.0**. The previously-shipped v0.37.2 binary expected an older hook hash than the v0.37.2 git tag now serves (upstream pushed a hook content change after v0.37.2 was tagged), which broke the runtime integrity check. v0.38.0 was tagged after the hook update and bakes in the matching hash.
- Switch claude-code's wrapper to use `self.rtk` so it picks up the overlay version.
- Rework both `update-rtk.sh` scripts (claude-code + opencode) to read the version from `packages/rtk/package.nix` and fetch hooks from the matching `v${VERSION}` tag instead of `master`. The single source of truth is now the vendored derivation — bump it and re-run the update script.
- Routine input bumps (separate commit): `home-manager`, `homebrew-cask`, claude-code `2.1.123 → 2.1.128`.

## Why

When rtk's hook content drifted ahead of the binary release in upstream master, `update-rtk.sh` happily pulled the new content while the nixpkgs-built binary still expected the old hash. Result: every Bash invocation tripped `rtk: hook integrity check FAILED`, blocking work in Claude Code. Pinning the hook fetch to the binary's tag makes that class of drift structurally impossible.

## Test plan

- [x] `nix build .#nixosConfigurations.Nexus.pkgs.rtk` succeeds with v0.38.0
- [x] `darwin-rebuild switch` on NightSprings deploys rtk 0.38.0 + matching hook
- [x] `rtk verify` no longer reports an integrity mismatch
- [x] Bash commands inside Claude Code run cleanly (no integrity warning, compound commands work)
- [ ] CI builds all 7 host configs