### PR TITLE
chore: bump stateVersion to 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -325,11 +325,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1778049089,
-        "narHash": "sha256-3iO52PYjtWQiBGvJtKxWq1x6yK1dRaK9lqLsSwCYfq8=",
+        "lastModified": 1778072663,
+        "narHash": "sha256-uMIsgTBizmLH+ceIrO3NC3THIWZF4FurrdYZdeYDGGs=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "3bc001b4439e37c8aee6b2877560f9cca889bc54",
+        "rev": "8f1e622f32d320e999a5ae3ccadca17ef4866989",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1778042439,
-        "narHash": "sha256-IxGVXPMLjhoLCFv04o2o0un5iBy/TpUFqjlBilVOY8Q=",
+        "lastModified": 1778071476,
+        "narHash": "sha256-J1Ej1f8iw/BrrNhE+opiMYXArbnq7UT/KjWIVSrNP98=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "7a759d09180a4d57224e3a78dcab5bfd4b3bdfb1",
+        "rev": "24104f3155dfed405a203bcf8bfb0e6e1f9ab4f1",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778050255,
-        "narHash": "sha256-ChC0gEg0izE3a4ykxs/L2QFzvb5OGBxzEvYhCDXBDDA=",
+        "lastModified": 1778071403,
+        "narHash": "sha256-lcF20w8OZGJWYAtopdXEyiXpy6SGdP2h+dKH2qd+U18=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fddfc4e23ef77afef482c8294daed57e0d3ca702",
+        "rev": "e7eb5efb2cde844dbb2c4c27bb4db5701bf35507",
         "type": "github"
       },
       "original": {

--- a/hosts/Brightfalls/default.nix
+++ b/hosts/Brightfalls/default.nix
@@ -53,5 +53,5 @@
   custom.bluetooth.enable = true;
   custom.fonts.enable = true;
 
-  system.stateVersion = "25.11";
+  system.stateVersion = "26.05";
 }

--- a/hosts/Brightfalls/users/matteo/default.nix
+++ b/hosts/Brightfalls/users/matteo/default.nix
@@ -79,7 +79,7 @@
   dracula.fzf.enable = true;
   dracula.bat.enable = true;
 
-  home.stateVersion = "25.11";
+  home.stateVersion = "26.05";
 
   programs.home-manager.enable = true;
 }

--- a/hosts/CauldronLake/default.nix
+++ b/hosts/CauldronLake/default.nix
@@ -35,5 +35,5 @@
     consoleKeyMap = "uk";
   };
 
-  system.stateVersion = "25.11";
+  system.stateVersion = "26.05";
 }

--- a/hosts/CauldronLake/users/debora/default.nix
+++ b/hosts/CauldronLake/users/debora/default.nix
@@ -38,7 +38,7 @@
     # package = pkgs.gitAndTools.gitFull;
   };
 
-  home.stateVersion = "25.11";
+  home.stateVersion = "26.05";
 
   programs.home-manager.enable = true;
 }

--- a/hosts/Nexus/default.nix
+++ b/hosts/Nexus/default.nix
@@ -49,5 +49,5 @@
     consoleFont = "ter-v24n";
   };
 
-  system.stateVersion = "25.11";
+  system.stateVersion = "26.05";
 }

--- a/hosts/Nexus/users/matteo/default.nix
+++ b/hosts/Nexus/users/matteo/default.nix
@@ -20,7 +20,7 @@
   home.packages = with pkgs; [
   ];
 
-  home.stateVersion = "25.11";
+  home.stateVersion = "26.05";
 
   programs.home-manager.enable = true;
 }

--- a/hosts/NightSprings/users/matteo/default.nix
+++ b/hosts/NightSprings/users/matteo/default.nix
@@ -37,7 +37,7 @@
   custom.claude-code.enable = true;
   custom.opencode.enable = true;
 
-  home.stateVersion = "25.11";
+  home.stateVersion = "26.05";
 
   programs.home-manager.enable = true;
 

--- a/hosts/WorkLaptop/users/matteo.pacini/default.nix
+++ b/hosts/WorkLaptop/users/matteo.pacini/default.nix
@@ -36,7 +36,7 @@
   custom.claude-code.enable = true;
   custom.opencode.enable = true;
 
-  home.stateVersion = "25.11";
+  home.stateVersion = "26.05";
 
   programs.home-manager.enable = true;
 

--- a/modules/home-manager/firefox.nix
+++ b/modules/home-manager/firefox.nix
@@ -64,6 +64,8 @@ in
       programs.firefox = {
         enable = true;
         package = pkgs.firefox;
+        # Pinned: gnome-theme injection below hardcodes .mozilla/firefox.
+        configPath = ".mozilla/firefox";
         profiles = {
           default = {
             id = 0;


### PR DESCRIPTION
## Summary

- Bump `system.stateVersion` `"25.11"` → `"26.05"` on all NixOS hosts (BrightFalls + 2 VMs, Nexus, CauldronLake), matching nixpkgs `lib.trivial.release`.
- Bump `home.stateVersion` `"25.11"` → `"26.05"` on all 5 user profiles.
- Pin `programs.firefox.configPath = ".mozilla/firefox";` in the shared module — `home.file.".mozilla/firefox/default/chrome/firefox-gnome-theme"` (firefox.nix:87) hardcodes the legacy path, so adopting the new XDG default would silently break the gnome theme.
- Refresh homebrew-core, homebrew-cask, and nur in `flake.lock` (~6–12h drift each).

Darwin `system.stateVersion` stays at `6` — that's the current `maxStateVersion` in nix-darwin master.

## Verification

`nix eval --no-eval-cache` on all 7 host configurations: zero warnings.

| Host | Pre-bump warnings | Post-bump |
|------|-------------------|-----------|
| BrightFalls | `programs.firefox.configPath` (matteo) | clean |
| BrightFallsVM-x86_64-linux | same | clean |
| BrightFallsVM-aarch64-linux | same | clean |
| Nexus | none | clean |
| CauldronLake | `programs.firefox.configPath` + `gtk.gtk4.theme` (debora) | clean |
| NightSprings | none | clean |
| WorkLaptop | none | clean |

`gtk.gtk4.theme` was not pinned: bumped default is `null`, but the existing `xdg.configFile."gtk-4.0/..."` block in `hosts/CauldronLake/users/debora/gnome.nix` already manages gtk-4.0 themes manually, so visible behavior is unchanged.

## Test plan

- [ ] CI eval passes on all 7 host configurations
- [ ] BrightFalls: `nixos-rebuild switch` is a no-op (toplevel hash byte-identical pre/post)
- [ ] CauldronLake: switch + verify GTK-4 apps still pick up the Adwaita-dark theme
- [ ] CauldronLake: switch + verify Firefox profile still loads the gnome theme
- [ ] Nexus: switch — services with stateVersion-conditional defaults (none currently identified) behave correctly
- [ ] NightSprings + WorkLaptop: `darwin-rebuild switch` succeeds (only `home.stateVersion` changed)