### PR TITLE
feat(firefox): disable sponsored content, telemetry, studies, CFR

### DIFF
--- a/modules/home-manager/firefox.nix
+++ b/modules/home-manager/firefox.nix
@@ -78,6 +78,48 @@ in
             settings = {
               "places.history.enabled" = cfg.history.enable;
               "browser.chrome.site_icons" = true;
+
+              # Sponsored content & new-tab "Popular today / Health / Entertainment"
+              "browser.newtabpage.activity-stream.showSponsoredTopSites" = false;
+              "browser.newtabpage.activity-stream.showSponsored" = false;
+              "browser.newtabpage.activity-stream.feeds.section.topstories" = false;
+              "browser.newtabpage.activity-stream.showSponsoredCheckboxes" = false;
+              "browser.newtabpage.activity-stream.default.sites" = "";
+
+              # Telemetry
+              "datareporting.policy.dataSubmissionEnabled" = false;
+              "datareporting.healthreport.uploadEnabled" = false;
+              "datareporting.usage.uploadEnabled" = false;
+              "toolkit.telemetry.unified" = false;
+              "toolkit.telemetry.enabled" = false;
+              "toolkit.telemetry.server" = "data:,";
+              "toolkit.telemetry.archive.enabled" = false;
+              "toolkit.telemetry.newProfilePing.enabled" = false;
+              "toolkit.telemetry.shutdownPingSender.enabled" = false;
+              "toolkit.telemetry.updatePing.enabled" = false;
+              "toolkit.telemetry.bhrPing.enabled" = false;
+              "toolkit.telemetry.firstShutdownPing.enabled" = false;
+              "toolkit.telemetry.coverage.opt-out" = true;
+              "toolkit.coverage.opt-out" = true;
+              "toolkit.coverage.endpoint.base" = "";
+              "browser.newtabpage.activity-stream.feeds.telemetry" = false;
+              "browser.newtabpage.activity-stream.telemetry" = false;
+
+              # Studies / experiments (Normandy, Shield)
+              "app.shield.optoutstudies.enabled" = false;
+              "app.normandy.enabled" = false;
+              "app.normandy.api_url" = "";
+
+              # Crash reports
+              "breakpad.reportURL" = "";
+              "browser.tabs.crashReporting.sendReport" = false;
+
+              # CFR & personalized add-on recommendations
+              "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons" = false;
+              "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features" = false;
+              "browser.discovery.enabled" = false;
+              "extensions.htmlaboutaddons.recommendations.enabled" = false;
+              "extensions.getAddons.showPane" = false;
             };
           };
         };


### PR DESCRIPTION
## Summary

Bundles privacy/anti-cruft prefs into the base of `programs.firefox.customization` so every Firefox-using host (BrightFalls, BrightFalls VMs, CauldronLake, NightSprings, WorkLaptop) inherits them automatically. No new options.

- **Sponsored content / new tab cleanup** — `showSponsoredTopSites`, `showSponsored`, `feeds.section.topstories`, `showSponsoredCheckboxes` (FF140+ "Support Firefox" UI), `default.sites = ""`. Kills the "Popular today / Health / Entertainment" stories feed and Mozilla's pre-populated tiles (Amazon etc.).
- **Telemetry** — master `dataSubmissionEnabled` kill switch plus `healthreport`, `usage`, `unified`, `archive`, `newProfilePing`, `shutdownPingSender`, `updatePing`, `bhrPing`, `firstShutdownPing`, `coverage`, neutered `telemetry.server`, and the activity-stream telemetry pair.
- **Studies / experiments** — `app.shield.optoutstudies`, `app.normandy` + cleared `api_url`.
- **Crash reports** — cleared `breakpad.reportURL`, disabled tab crash send.
- **CFR & add-on recommendations** — `asrouter.userprefs.cfr.{addons,features}`, `browser.discovery.enabled`, `htmlaboutaddons.recommendations.enabled`, `extensions.getAddons.showPane`.

## Verification

Native builds: `darwinConfigurations.NightSprings`, `darwinConfigurations.WorkLaptop`. Foreign-platform evals from Darwin: `nixosConfigurations.BrightFalls`, `nixosConfigurations.CauldronLake`, `nixosConfigurations.BrightFallsVM-aarch64-linux`. All exit 0.