### PR TITLE
fix(firefox): drop configPath pin breaking Darwin profiles

### DIFF
--- a/modules/home-manager/firefox.nix
+++ b/modules/home-manager/firefox.nix
@@ -64,8 +64,6 @@ in
       programs.firefox = {
         enable = true;
         package = pkgs.firefox;
-        # Pinned: gnome-theme injection below hardcodes .mozilla/firefox.
-        configPath = ".mozilla/firefox";
         profiles = {
           default = {
             id = 0;


### PR DESCRIPTION
## Summary

- The `configPath = \".mozilla/firefox\"` pin added in #245 broke Firefox on Darwin: HM started managing `~/.mozilla/firefox/` while real Firefox on macOS reads from `~/Library/Application Support/Firefox/`, so HM-managed symlinks (e.g. `profiles.ini`) at the macOS path got swept up on switch and Firefox launched with a fresh profile.
- The gnome-theme block that motivated the pin is already gated by `isLinux`, so the pin was unnecessary even on Linux. Dropping it restores the per-platform Home Manager defaults (`.mozilla/firefox` on Linux, `Library/Application Support/Firefox` on Darwin).

## Test plan

- [x] Switched on NightSprings (aarch64-darwin); existing profile picked up correctly after Firefox restart.
- [ ] CI builds all hosts on master.