### PR TITLE
feat(opencode): vendor derivation from nixpkgs master

### DIFF
--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -65,6 +65,15 @@
   # Refresh with `./packages/rtk/update.sh`.
   rtk = super.callPackage ../packages/rtk/package.nix { };
 
+  # opencode: vendored from nixpkgs master into ../packages/opencode/ so we
+  # can track upstream faster than the flake's nixos-unstable pin. Upstream
+  # ships frequent releases that fix provider/transform bugs and adjust
+  # agent behavior we depend on (see modules/home-manager/opencode.nix for
+  # the live list of issues we're chasing); waiting for nixos-unstable to
+  # pick them up noticeably lags day-to-day usage.
+  # Refresh with `./packages/opencode/update.sh`.
+  opencode = super.callPackage ../packages/opencode/package.nix { };
+
   # Token usage tracker for AI coding agents
   tokscale = super.callPackage ../packages/tokscale.nix { };
 

--- a/packages/claude-code/manifest.json
+++ b/packages/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.128",
-  "commit": "d6caed183d5f5b985cab02ef8c812d2abee9ecd9",
-  "buildDate": "2026-05-04T17:39:35Z",
+  "version": "2.1.131",
+  "commit": "c122cd1bd5247f2a4bde8bcaec712fb1dff247e8",
+  "buildDate": "2026-05-06T06:18:01Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "1a56ae4cd171ba7839fc2b03d558022ffaebb5693be532d8f3c344731063e979",
-      "size": 216953600
+      "checksum": "cc6066b0db7bb423c75316366542f771a41923999a76a5771afad87dd65dceae",
+      "size": 217349888
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "eb7f5441fcc169a01ec6a655d7663dffbcfe9cb03491dc0c7a157e9e67da3737",
-      "size": 218517840
+      "checksum": "a1bd2c782c3f961987d7d6456f75b3fa538cc425f1573908850afedcb038ca5f",
+      "size": 218914128
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "e2a31879b7433f658d915e6716249f10b913b467873950e8e7e066ba7c4d96e9",
-      "size": 248973888
+      "checksum": "0919cdf512ca673b38230882b458801b78e9248eb472383631cfc12d8d0d55cf",
+      "size": 249367104
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "770c81373ad42970ef576676da78d6be60413f4ade23abadbf1343ca0809bb3e",
-      "size": 248789632
+      "checksum": "9af15b9302ffde3fa83e3ea4a41cdd00158301cd8badc755567a8e9149f1c36c",
+      "size": 249178752
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "7d0e38623925ee076ede98392b2169bd88a2c529f080d7807ae03c350b6b2337",
-      "size": 241699200
+      "checksum": "78ffce2cad108ef1ca3301fc34307277b8a98e4095344b091b84be1678bd6ebc",
+      "size": 242092416
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "b6480ddd313432e37b35a356c38067b1a76b900a936e30e975111ad11f70dcf4",
-      "size": 243054976
+      "checksum": "f712c043f6df7552b95d30d256ebc4feb9c3a642f04b0e823719b524e3128939",
+      "size": 243444096
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "1d920cb73f612083ae4133ea4b63e1e8c7a4624a8ba827dfc928c12e86ad803e",
-      "size": 254711968
+      "checksum": "49204d250c5fe1797f74bc68f305016e72b356b06fe7ff1f8a651f7ad6a0df8b",
+      "size": 255085216
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "3b957bec823951455840accbdb6cfa970505691ce39b1fefa9de5c32a2ee2ff6",
-      "size": 250775712
+      "checksum": "d1b1336200468b5e29a0e4cc8c1dfc5c79d01f11118d8594756243bb6102dc40",
+      "size": 251148960
     }
   }
 }

--- a/packages/opencode/package.nix
+++ b/packages/opencode/package.nix
@@ -1,0 +1,199 @@
+{
+  lib,
+  stdenvNoCC,
+  bun,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  models-dev,
+  nodejs,
+  nix-update-script,
+  ripgrep,
+  sysctl,
+  installShellFiles,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "opencode";
+  version = "1.14.35";
+
+  src = fetchFromGitHub {
+    owner = "anomalyco";
+    repo = "opencode";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-i2Ct4QC0Tf+UWNWAQoW/IPtRKrVyZSC1/FTzQNpou2g=";
+  };
+
+  node_modules = stdenvNoCC.mkDerivation {
+    pname = "${finalAttrs.pname}-node_modules";
+    inherit (finalAttrs) version src;
+
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
+
+    nativeBuildInputs = [
+      bun
+      writableTmpDirAsHomeHook
+    ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+      bun install \
+        --cpu="*" \
+        --frozen-lockfile \
+        --filter ./ \
+        --filter ./packages/app \
+        --filter ./packages/desktop \
+        --filter ./packages/opencode \
+        --filter ./packages/shared \
+        --ignore-scripts \
+        --no-progress \
+        --os="*"
+
+      bun --bun ./nix/scripts/canonicalize-node-modules.ts
+      bun --bun ./nix/scripts/normalize-bun-binaries.ts
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      find . -type d -name node_modules -exec cp -R --parents {} $out \;
+
+      runHook postInstall
+    '';
+
+    # NOTE: Required else we get errors that our fixed-output derivation references store paths
+    dontFixup = true;
+
+    outputHash = "sha256-JwkXBlXS4AG0rquzdOSE5Atzm0Hm9UVEBmDMAnTlbyg=";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+
+  nativeBuildInputs = [
+    bun
+    nodejs
+    installShellFiles
+    makeBinaryWrapper
+    writableTmpDirAsHomeHook
+  ];
+
+  postPatch = ''
+    # NOTE: Relax Bun version check to be a warning instead of an error
+    substituteInPlace packages/script/src/index.ts \
+      --replace-fail 'throw new Error(`This script requires bun@''${expectedBunVersionRange}' \
+                     'console.warn(`Warning: This script requires bun@''${expectedBunVersionRange}'
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${finalAttrs.node_modules}/. .
+    patchShebangs node_modules
+    patchShebangs packages/*/node_modules
+
+    runHook postConfigure
+  '';
+
+  env.MODELS_DEV_API_JSON = "${models-dev}/dist/_api.json";
+  env.OPENCODE_DISABLE_MODELS_FETCH = true;
+  env.OPENCODE_VERSION = finalAttrs.version;
+  env.OPENCODE_CHANNEL = "stable";
+
+  buildPhase = ''
+    runHook preBuild
+
+    cd ./packages/opencode
+    bun --bun ./script/build.ts --single --skip-install
+    bun --bun ./script/schema.ts config.json tui.json
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 dist/opencode-*/bin/opencode $out/bin/opencode
+    wrapProgram $out/bin/opencode \
+     --prefix PATH : ${
+       lib.makeBinPath (
+         [
+           ripgrep
+         ]
+         ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [
+           sysctl
+         ]
+       )
+     }
+
+    install -Dm644 config.json $out/share/opencode/config.json
+    install -Dm644 tui.json $out/share/opencode/tui.json
+
+    runHook postInstall
+  '';
+
+  postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+    installShellCompletion --cmd opencode \
+      --bash <($out/bin/opencode completion) \
+      --zsh <(SHELL=/bin/zsh $out/bin/opencode completion)
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  doInstallCheck = true;
+  versionCheckKeepEnvironment = [
+    "HOME"
+    "OPENCODE_DISABLE_MODELS_FETCH"
+  ];
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    jsonschema = {
+      config = "${placeholder "out"}/share/opencode/config.json";
+      tui = "${placeholder "out"}/share/opencode/tui.json";
+    };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "node_modules"
+      ];
+    };
+  };
+
+  meta = {
+    description = "AI coding agent built for the terminal";
+    homepage = "https://github.com/anomalyco/opencode";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      delafthi
+      DuskyElf
+      graham33
+      superherointj
+    ];
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+    mainProgram = "opencode";
+    badPlatforms = [
+      # Broken as 2026-04-23, errors as:
+      # CPU lacks AVX support, strange crashes may occur. Reinstall Bun
+      "x86_64-darwin"
+    ];
+  };
+})

--- a/packages/opencode/update.sh
+++ b/packages/opencode/update.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Refresh the vendored opencode derivation from nixpkgs master.
+# Overwrites package.nix — any local edits are lost.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+BASE_URL="https://raw.githubusercontent.com/NixOS/nixpkgs/master/pkgs/by-name/op/opencode"
+
+curl -fsSL "$BASE_URL/package.nix" --output package.nix


### PR DESCRIPTION
## Summary

- Vendor `opencode` from nixpkgs master into `packages/opencode/`, hooked into `overlays/shared.nix` next to `claude-code` and `rtk`. Same rationale: track upstream faster than the flake's nixos-unstable pin.
- Refresh `packages/claude-code/manifest.json` via `./packages/claude-code/update.sh` while we're here.

## Versions

| Package     | Old      | New      |
|-------------|----------|----------|
| claude-code | 2.1.128  | 2.1.131  |
| opencode    | 1.14.31  | 1.14.35  |

## Changelogs

### claude-code 2.1.128 → 2.1.131

#### 2.1.131
- Fixed VS Code extension failing to activate on Windows due to a hardcoded build path in the bundled SDK (`createRequire` polyfill bug)
- Fixed Mantle endpoint authentication failing with missing `x-api-key` header

#### 2.1.129
- Added `--plugin-url <url>` flag to fetch a plugin `.zip` archive from a URL for the current session
- Added `CLAUDE_CODE_FORCE_SYNC_OUTPUT=1` env var to force-enable synchronized output on terminals that auto-detection misses (e.g. Emacs `eat`)
- Added `CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE`: when set on Homebrew or WinGet installations, Claude Code runs the upgrade command in the background and prompts to restart
- Plugin manifests: `themes` and `monitors` should now be declared under `"experimental": { ... }`. Top-level declarations still work but `claude plugin validate` will warn
- Gateway `/v1/models` discovery for the `/model` picker is now opt-in via `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` (was automatic in 2.1.126–2.1.128)
- Ctrl+R history picker now defaults to searching all prompts across all projects, matching pre-2.1.124 behavior. Press Ctrl+S to narrow to the current project or session
- Third-party deployments (Bedrock, Vertex, Foundry, or `ANTHROPIC_BASE_URL` gateway) no longer see spinner tips pointing at first-party Anthropic surfaces
- `skillOverrides` setting now works: `off` hides from model and `/`, `user-invocable-only` hides from model only, `name-only` collapses description
- The `claude_code.pull_request.count` OTel metric now counts PRs/MRs created via MCP tools, not just shell commands
- Policy refusal error messages now include the API Request ID for easier support debugging
- Fixed API errors with unrecognized 400 status codes showing raw JSON instead of the underlying error message
- Fixed `/clear` not resetting the terminal tab title after a conversation
- Fixed session title chip from `/rename` disappearing while a permission or other dialog is active
- Fixed agent panel below the prompt being hidden when subagents are running (regression in 2.1.122)
- Fixed external-editor handoff (Ctrl+G) blanking the conversation history above the prompt
- Fixed `/context` dumping its rendered ASCII visualization grid into the conversation, wasting ~1.6k tokens per call
- Fixed `/agents` Library list arrow-key navigation: the highlighted agent now stays visible when the list exceeds the viewport
- Fixed `/branch` success message not including the new branch's session id for `/resume`
- Fixed bold headers with keycap/ZWJ/skin-tone emoji losing trailing characters in fullscreen mode
- Fixed server-managed settings policy not applying for enterprise/team users whose stored OAuth credentials lacked the `user:inference` scope
- Fixed OAuth refresh race after wake-from-sleep that could log out all running sessions
- Fixed 1-hour prompt cache TTL being silently downgraded to 5 minutes
- Fixed cache-miss warning appearing spuriously after `/clear` or compaction when changing `/effort` or `/model`
- Fixed `Bash(mkdir *)`, `Bash(touch *)` and similar allow rules not being honored for in-project paths
- Fixed `deniedMcpServers` patterns with a `*://` scheme wildcard not matching mixed-case hostnames
- Fixed harmless WebSocket warning being logged as an error in `--debug` during voice mode
- [VSCode] Fixed `/clear` not clearing the conversation context and displayed transcript

(Note: 2.1.130 was not released.)

### opencode 1.14.31 → 1.14.35

Upstream releases don't ship release notes; user-facing changes from the [compare view](https://github.com/anomalyco/opencode/compare/v1.14.31...v1.14.35), filtered to drop pure refactors/chores:

- fix(tui): gate logo subpixel rendering on truecolor support (#25265)
- fix(session): use finite archived timestamp schema (#25275)
- fix: bedrock reasoning issue (#25303)
- core: allow agents to access global tmp directory without permission prompts
- core: fix npm package detection to properly handle cached directories without installed packages (#25354)
- fix(read): prevent unsupported image formats from being sent to provider (#21114)
- fix(httpapi): preserve OpenAPI parameter parity (#25291)
- fix(httpapi): re-land workspace create payload accepts missing extra (#25412)
- fix(httpapi): install Instance ALS for adapter Promise bridge (#25417)
- fix(tui): keep shell-mode prompt editable (#25419)
- fix(nix): remove stale packages/shared filter (#24930)
- feat(cli): add effectCmd wrapper + convert models command (#25429)
- tweak: allow read tool to accept offset of 0 (#25431)
- feat(models): effectify ModelsDev as Service (#25434)
- fix(telemetry): emit Tool.execute span for MCP and plugin tools (#25452)