### PR TITLE
fix(firefox): re-pin Linux configPath to ~/.mozilla/firefox

### DIFF
--- a/modules/home-manager/firefox.nix
+++ b/modules/home-manager/firefox.nix
@@ -64,6 +64,10 @@ in
       programs.firefox = {
         enable = true;
         package = pkgs.firefox;
+        # Pin: HM 26.05's Linux default flipped to ~/.config/mozilla/firefox,
+        # but stock pkgs.firefox still reads ~/.mozilla/firefox. Darwin keeps
+        # HM's default (Library/Application Support/Firefox).
+        configPath = mkIf isLinux ".mozilla/firefox";
         profiles = {
           default = {
             id = 0;


### PR DESCRIPTION
## Summary

- Restore the `configPath = ".mozilla/firefox"` pin on Linux. HM 26.05 flipped the default to `${xdg.configHome}/mozilla/firefox`, but stock `pkgs.firefox` on Linux still reads `~/.mozilla/firefox` — so after the stateVersion 26.05 bump and #247 (which dropped the explicit pin), HM was writing the profile, chrome, and extensions to the XDG path while Firefox happily started a fresh profile at the legacy path. Symptom on BrightFalls: Firefox opens with no theme and no extensions.
- Gate on `isLinux` so Darwin keeps HM's native default (`Library/Application Support/Firefox`) — which #247 correctly fixed and this PR preserves.

The reasoning in #247 ("the gnome-theme block is gated by isLinux, so the pin was unnecessary even on Linux") missed that the pin was independently load-bearing on Linux: HM's default disagrees with where stock `pkgs.firefox` actually looks once stateVersion is ≥ 26.05.

Verified with `nix eval` across all five hosts:

| Host | Platform | configPath |
|---|---|---|
| NightSprings | aarch64-darwin | `Library/Application Support/Firefox` (unchanged) |
| WorkLaptop | aarch64-darwin | `Library/Application Support/Firefox` (unchanged) |
| BrightFalls | x86_64-linux | `.mozilla/firefox` (fixed) |
| CauldronLake | x86_64-linux | `.mozilla/firefox` (fixed) |
| Nexus | x86_64-linux | n/a (does not enable `customization`) |

## Test plan

- [ ] `sudo nixos-rebuild switch --flake .#BrightFalls` → reopen Firefox → GNOME theme + uBlock + 1Password + Violentmonkey present
- [ ] `nix run nix-darwin -- switch --flake .#NightSprings` → Firefox profile unchanged (regression check on #247)