### PR TITLE
feat(nvf): set EDITOR session variable to nvim

### DIFF
--- a/modules/home-manager/nvf.nix
+++ b/modules/home-manager/nvf.nix
@@ -15,6 +15,8 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    home.sessionVariables.EDITOR = "nvim";
+
     programs.nvf = {
       enable = true;
       settings = {


### PR DESCRIPTION
## Summary
- Sets `home.sessionVariables.EDITOR = "nvim"` in the nvf home-manager module so the editor is wired up alongside the Neovim config it enables.

## Test plan
- [x] `nix eval .#darwinConfigurations.NightSprings.config.system.build.toplevel` succeeds
- [ ] Rebuild on a host with `custom.nvf.enable = true` and confirm `$EDITOR` resolves to `nvim`