### PR TITLE
chore: flake bump, drop CVE-2026-43284 patch, bump vendored packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1776478798,
-        "narHash": "sha256-ERStG27tf83VbCfYMxtDSs+sa8FUMJ/3jSu/QfX9rKE=",
+        "lastModified": 1778146321,
+        "narHash": "sha256-HeBwuJmuBioZHyZqDOcf7W/xsMFupSD583v6I5Cl7a8=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "3aae056b8d072624255bc8fd27febb7f327b2265",
+        "rev": "af835384ac574f76025adb38b292b04cecee1f1f",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.7",
+        "ref": "5.1.10",
         "repo": "brew",
         "type": "github"
       }
@@ -155,11 +155,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1776136500,
-        "narHash": "sha256-r0gN2brVWA351zwMV0Flmlcd6SGMvYqFbvC3DfKFM8Y=",
+        "lastModified": 1778269021,
+        "narHash": "sha256-ci4vHnWYfLEwImOmhHkLwuToebVi76O+7C0zCxUIzUw=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "0f8ba203d475587f477e7ae12661bd8459e225b7",
+        "rev": "7f81880cdb6278703221d26a25aefed9561c8904",
         "type": "github"
       },
       "original": {
@@ -309,11 +309,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778009629,
-        "narHash": "sha256-nUoQtf4Zq7DRYJrfv904hjrxjAlWVP6a1pNNFKx3FCg=",
+        "lastModified": 1778681890,
+        "narHash": "sha256-RK4sTgei29wBzLu+e4ljeixKutWhbMygFsdxdFKpZOU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "00ed86e58bb6979a7921859fd1615d19382eac5c",
+        "rev": "7654d90b94bab7eba3a52fd6f73b3f5a4c544fa2",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1778072663,
-        "narHash": "sha256-uMIsgTBizmLH+ceIrO3NC3THIWZF4FurrdYZdeYDGGs=",
+        "lastModified": 1778693573,
+        "narHash": "sha256-C+LWZuUbwy8AXagUJmdKYA7K8gZZ+StjqiuPRLhJw5g=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "8f1e622f32d320e999a5ae3ccadca17ef4866989",
+        "rev": "5cf35a689437df0a59e1f338ada2342aed56be57",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1778071476,
-        "narHash": "sha256-J1Ej1f8iw/BrrNhE+opiMYXArbnq7UT/KjWIVSrNP98=",
+        "lastModified": 1778694665,
+        "narHash": "sha256-G6QtfV6K7HdhI/psaHztT67oMbbkig4R/d3+Dbq+lYY=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "24104f3155dfed405a203bcf8bfb0e6e1f9ab4f1",
+        "rev": "165e6face8397001b8f60d4ff7ea829f8a8615a9",
         "type": "github"
       },
       "original": {
@@ -440,11 +440,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1777250621,
-        "narHash": "sha256-WynkkG0hdZ5niYPJUbVg7oMfu8MVwGGzKZ6lKmfa+O8=",
+        "lastModified": 1778332591,
+        "narHash": "sha256-ctJ3ADtugrnbMfMBobA645gCqXVIyHnsCNMkVaIuSiM=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "aeb2069920742d0d6570089e8b3b8620050bacf2",
+        "rev": "7d0038b5bb60568ec41f5f4ef5067cd221ca7c0d",
         "type": "github"
       },
       "original": {
@@ -534,11 +534,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778071403,
-        "narHash": "sha256-lcF20w8OZGJWYAtopdXEyiXpy6SGdP2h+dKH2qd+U18=",
+        "lastModified": 1778693695,
+        "narHash": "sha256-cKCeSfIYf9t5cNsfKQp7Olv4ecfq+eJI0oQXf2Wgp2Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e7eb5efb2cde844dbb2c4c27bb4db5701bf35507",
+        "rev": "ef11828818f99ed3ae2ed33b55739dd973ea346f",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1778049651,
-        "narHash": "sha256-EC5pBiLcP/EVmYWldJRNfkChCqF9rkeTnTs8t9Cs+ZY=",
+        "lastModified": 1778618635,
+        "narHash": "sha256-eiZkwksjBS4yr5uPt9rzoEQrnuwTgmFVFb6glGrNGF4=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "88dbbad1f44efe3d2c18903e2c7542452f7bdfd6",
+        "rev": "0f7a1ff6ecff4a1f4fa2bbdd0f42151706a26831",
         "type": "github"
       },
       "original": {

--- a/modules/nixos/kernel.nix
+++ b/modules/nixos/kernel.nix
@@ -37,20 +37,7 @@
             patch = "${patchesDir}/${name}";
           }) (builtins.readDir patchesDir)
         );
-
-        # CVE-2026-43284 (Dirty Frag, ESP half): xfrm decrypts in place over
-        # MSG_SPLICE_PAGES-backed frags an unprivileged process still owns.
-        # Drop once nixpkgs bumps linuxPackages_7_0 past 7.0.3.
-        # Copy Fail (CVE-2026-31431) is already applied in 7.0.3 source.
-        # Dirty Frag RxRPC half (CVE-2026-43500) has no upstream patch yet.
-        dirtyFragEspPatch = {
-          name = "CVE-2026-43284-xfrm-esp-no-inplace-shared-frags";
-          patch = pkgs.fetchpatch {
-            url = "https://github.com/torvalds/linux/commit/f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4.patch";
-            hash = "sha256-68d7/BoMYHWVBY8btrr8yuObhkGod1Hwj5Ny2CZt+qk=";
-          };
-        };
       in
-      [ dirtyFragEspPatch ] ++ borePatches;
+      borePatches;
   };
 }

--- a/packages/claude-code/manifest.json
+++ b/packages/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.131",
-  "commit": "c122cd1bd5247f2a4bde8bcaec712fb1dff247e8",
-  "buildDate": "2026-05-06T06:18:01Z",
+  "version": "2.1.140",
+  "commit": "89b4b3854fac52fdb8f9970133c4afe00174b6b9",
+  "buildDate": "2026-05-12T18:36:21Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "cc6066b0db7bb423c75316366542f771a41923999a76a5771afad87dd65dceae",
-      "size": 217349888
+      "checksum": "087ce732fb79658cd3e828cc377291dc56835fc5318cd519123b0880a09149c0",
+      "size": 206069664
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "a1bd2c782c3f961987d7d6456f75b3fa538cc425f1573908850afedcb038ca5f",
-      "size": 218914128
+      "checksum": "2616b1e775ec0520228cd99135d07ef99e4b93b4532a03ef019e0a8e81cc7729",
+      "size": 208583824
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "0919cdf512ca673b38230882b458801b78e9248eb472383631cfc12d8d0d55cf",
-      "size": 249367104
+      "checksum": "0ec6fc062e99aa95a6edbb5308a563262d27a0772b107d01d4fa61110fb44472",
+      "size": 231454344
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "9af15b9302ffde3fa83e3ea4a41cdd00158301cd8badc755567a8e9149f1c36c",
-      "size": 249178752
+      "checksum": "807a5d6ca063f5e03e4b7283934036a3122723b28c28e1a6978e98cf2d43d0b5",
+      "size": 231577296
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "78ffce2cad108ef1ca3301fc34307277b8a98e4095344b091b84be1678bd6ebc",
-      "size": 242092416
+      "checksum": "b840a07551c3e1baecff728eb6b9a849483be87bf1fdaed5da22d0b3427a88cf",
+      "size": 224309080
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "f712c043f6df7552b95d30d256ebc4feb9c3a642f04b0e823719b524e3128939",
-      "size": 243444096
+      "checksum": "7db8946293de9ec11d2b02472f715f18ea9a346238d472605b5d9a4dc7bfd3f1",
+      "size": 225971248
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "49204d250c5fe1797f74bc68f305016e72b356b06fe7ff1f8a651f7ad6a0df8b",
-      "size": 255085216
+      "checksum": "fcfe90297861b1bcfa581d7db645ec8a71984baed3b1c44d28032650baa2617c",
+      "size": 227456160
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "d1b1336200468b5e29a0e4cc8c1dfc5c79d01f11118d8594756243bb6102dc40",
-      "size": 251148960
+      "checksum": "3f782467ec6e593a5e23522b678cf4268965e4ec6fe904e41729a12d64232c40",
+      "size": 223420576
     }
   }
 }

--- a/packages/opencode/package.nix
+++ b/packages/opencode/package.nix
@@ -16,13 +16,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "1.14.35";
+  version = "1.14.48";
 
   src = fetchFromGitHub {
     owner = "anomalyco";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-i2Ct4QC0Tf+UWNWAQoW/IPtRKrVyZSC1/FTzQNpou2g=";
+    hash = "sha256-gyybqabTco+5ZeWv4lCX8t/R9Jm3tYsA8wVvkrxkEYQ=";
   };
 
   node_modules = stdenvNoCC.mkDerivation {
@@ -75,7 +75,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # NOTE: Required else we get errors that our fixed-output derivation references store paths
     dontFixup = true;
 
-    outputHash = "sha256-JwkXBlXS4AG0rquzdOSE5Atzm0Hm9UVEBmDMAnTlbyg=";
+    outputHash = "sha256-94uXrhyGqW016U6LPE/xIfZGoDOzyUto5DyQrYYePds=";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };


### PR DESCRIPTION
## Summary

- Bump `flake.lock` (nixpkgs, home-manager, homebrew taps, nix-homebrew, firefox-gnome-theme).
- Drop the `CVE-2026-43284` ESP backport in `modules/nixos/kernel.nix`. `linuxPackages_7_0` is now 7.0.5, which carries commit `f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4` (xfrm: esp: avoid in-place decrypt on shared skb frags) from stable.
- Bump vendored derivations: `claude-code` 2.1.131 -> 2.1.140, `opencode` 1.14.35 -> 1.14.48 (matches current nixpkgs master).

## Test plan

- [x] `nix eval .#nixosConfigurations.BrightFalls.config.system.build.toplevel` succeeds locally
- [ ] CI builds for all five hosts pass