### PR TITLE
feat: replace command-not-found with nix-index-database

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,6 +453,26 @@
         "type": "github"
       }
     },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778393439,
+        "narHash": "sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc=",
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "rev": "01466c414c7357ae2ce32be4a272a7c69e94ab5f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1766736597,
@@ -624,6 +644,7 @@
         "mac-app-util": "mac-app-util",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
+        "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs_5",
         "nur": "nur",
         "nvf": "nvf",

--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,11 @@
     #######
     nvf.url = "github:NotAShelf/nvf";
     nvf.inputs.nixpkgs.follows = "nixpkgs";
+    #####################
+    # nix-index-database #
+    #####################
+    nix-index-database.url = "github:nix-community/nix-index-database";
+    nix-index-database.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
@@ -124,6 +129,7 @@
           ./modules/nixos/fonts.nix
           ./modules/nixos/kernel.nix
           ./modules/nixos/apcupsd-multi.nix
+          ./modules/nixos/nix-index.nix
         ];
       };
 
@@ -132,6 +138,7 @@
           ./modules/darwin/nix-core.nix
           ./modules/darwin/system-defaults.nix
           ./modules/darwin/fonts.nix
+          ./modules/darwin/nix-index.nix
         ];
       };
 

--- a/hosts/Brightfalls/default.nix
+++ b/hosts/Brightfalls/default.nix
@@ -52,6 +52,7 @@
   custom.locale.enable = true;
   custom.bluetooth.enable = true;
   custom.fonts.enable = true;
+  custom.nix-index.enable = true;
 
   system.stateVersion = "26.05";
 }

--- a/hosts/CauldronLake/default.nix
+++ b/hosts/CauldronLake/default.nix
@@ -19,6 +19,7 @@
   custom.kernel.enable = true;
   custom.bluetooth.enable = true;
   custom.fonts.enable = true;
+  custom.nix-index.enable = true;
 
   environment.systemPackages = with pkgs; [ sshfs ];
 

--- a/hosts/Nexus/default.nix
+++ b/hosts/Nexus/default.nix
@@ -13,6 +13,7 @@
   ];
 
   custom.kernel.enable = true;
+  custom.nix-index.enable = true;
 
   custom.nix-core = {
     enable = true;

--- a/hosts/NightSprings/default.nix
+++ b/hosts/NightSprings/default.nix
@@ -18,6 +18,7 @@
   };
 
   custom.fonts.enable = true;
+  custom.nix-index.enable = true;
 
   ids.gids.nixbld = 30000;
 

--- a/hosts/WorkLaptop/default.nix
+++ b/hosts/WorkLaptop/default.nix
@@ -17,6 +17,7 @@
   };
 
   custom.fonts.enable = true;
+  custom.nix-index.enable = true;
 
   environment.systemPackages = [ pkgs.nix-output-monitor ];
 

--- a/modules/darwin/nix-index.nix
+++ b/modules/darwin/nix-index.nix
@@ -1,0 +1,25 @@
+{
+  config,
+  lib,
+  inputs,
+  ...
+}:
+let
+  cfg = config.custom.nix-index;
+in
+{
+  imports = [ inputs.nix-index-database.darwinModules.nix-index ];
+
+  options.custom.nix-index = {
+    enable = lib.mkEnableOption "nix-index with prebuilt database (command-not-found replacement for nix-darwin)";
+    comma = lib.mkEnableOption "comma (`,` run-without-installing) wrapper backed by the prebuilt index";
+  };
+
+  # nix-darwin has no `programs.command-not-found` option; the upstream Darwin module
+  # turns on `programs.nix-index` via `mkDefault true` unconditionally on import,
+  # so bind our toggle directly to that option to allow opting out.
+  config = {
+    programs.nix-index.enable = cfg.enable;
+    programs.nix-index-database.comma.enable = cfg.enable && cfg.comma;
+  };
+}

--- a/modules/nixos/nix-index.nix
+++ b/modules/nixos/nix-index.nix
@@ -1,0 +1,28 @@
+{
+  config,
+  lib,
+  inputs,
+  ...
+}:
+let
+  cfg = config.custom.nix-index;
+in
+{
+  imports = [ inputs.nix-index-database.nixosModules.nix-index ];
+
+  options.custom.nix-index = {
+    enable = lib.mkEnableOption "nix-index with prebuilt database (flake-friendly command-not-found replacement)";
+    comma = lib.mkEnableOption "comma (`,` run-without-installing) wrapper backed by the prebuilt index";
+  };
+
+  # Bind upstream toggle directly: the upstream module's `programs.nix-index-database.enable`
+  # defaults to true, so a plain `mkIf cfg.enable` wrapper here would leak it on when off.
+  # `programs.command-not-found.enable` is force-disabled because nixpkgs auto-enables it via
+  # `pathExists dbPath`, and on flake systems that path doesn't exist at eval time, causing
+  # both an assertion conflict with nix-index's shell integration and a path-coercion error.
+  config = {
+    programs.nix-index-database.enable = cfg.enable;
+    programs.nix-index-database.comma.enable = cfg.enable && cfg.comma;
+    programs.command-not-found.enable = lib.mkIf cfg.enable (lib.mkForce false);
+  };
+}


### PR DESCRIPTION
## Summary

- The nixpkgs `programs.command-not-found` module ships a SQLite database only via the channel tarball, so on a flakes-based system it falls back to "Missing package database". Replaces it with `nix-community/nix-index-database`, which provides a weekly-prebuilt index and wires up a working `command_not_found_handler` for bash/zsh/fish.
- New `custom.nix-index.{enable,comma}` modules for both NixOS and nix-darwin, wrapping the upstream modules with the project's `mkEnableOption` convention.
- Enabled on all 5 hosts (BrightFalls, Nexus, CauldronLake, NightSprings, WorkLaptop). Comma wrapper is plumbed but off by default.
- NixOS module force-disables `programs.command-not-found.enable` because nixpkgs auto-enables it via `pathExists dbPath`; on flake systems that triggers both an assertion conflict with `nix-index.enableBashIntegration` and a path-coercion error during eval.

## Test plan

- [x] `nix eval .#nixosConfigurations.BrightFalls.config.system.build.toplevel`
- [x] `nix eval .#nixosConfigurations.Nexus.config.system.build.toplevel`
- [x] `nix eval .#nixosConfigurations.CauldronLake.config.system.build.toplevel`
- [x] `nix eval .#darwinConfigurations.NightSprings.config.system.build.toplevel`
- [x] `nix eval .#darwinConfigurations.WorkLaptop.config.system.build.toplevel`
- [ ] Rebuild a host and confirm unknown commands trigger nix-index suggestions instead of the "Missing package database" error