### PR TITLE
feat(claude-code): per-model shell aliases + package/flake bumps

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778146321,
-        "narHash": "sha256-HeBwuJmuBioZHyZqDOcf7W/xsMFupSD583v6I5Cl7a8=",
+        "lastModified": 1778427648,
+        "narHash": "sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "af835384ac574f76025adb38b292b04cecee1f1f",
+        "rev": "6f293daa9f9f5832e13b497976335e90509886d7",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.10",
+        "ref": "5.1.11",
         "repo": "brew",
         "type": "github"
       }
@@ -123,11 +123,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777713215,
-        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
+        "lastModified": 1778958912,
+        "narHash": "sha256-6pvS9rIF9mZRj1ENwu9fDLHeG1JFDTCpRyy6vJhXkTA=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
+        "rev": "6e8dc7aa0e65fce67c76e18227a13a7d529f2cdf",
         "type": "github"
       },
       "original": {
@@ -309,11 +309,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778681890,
-        "narHash": "sha256-RK4sTgei29wBzLu+e4ljeixKutWhbMygFsdxdFKpZOU=",
+        "lastModified": 1779027260,
+        "narHash": "sha256-ZbgWWFQmSyM3HQ31nAZk2hJ7OSeNr9uRFHL8jCifY9M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7654d90b94bab7eba3a52fd6f73b3f5a4c544fa2",
+        "rev": "bcb774cfc3268120cd61808629f9aa7dad3750a2",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1778693573,
-        "narHash": "sha256-C+LWZuUbwy8AXagUJmdKYA7K8gZZ+StjqiuPRLhJw5g=",
+        "lastModified": 1779047371,
+        "narHash": "sha256-yWtgOOE5fMdiGqbU8M5h5j/T1D5TvpEp64mHjVHJDa8=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "5cf35a689437df0a59e1f338ada2342aed56be57",
+        "rev": "64fe3cd79757058ce58b336aefd453d513bb02f8",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1778694665,
-        "narHash": "sha256-G6QtfV6K7HdhI/psaHztT67oMbbkig4R/d3+Dbq+lYY=",
+        "lastModified": 1779045784,
+        "narHash": "sha256-4HyeW8xJb1ZyceG3YF/9UdNXjc6T3NOCgenxlWH25xE=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "165e6face8397001b8f60d4ff7ea829f8a8615a9",
+        "rev": "fb87eace39dda10ee4424fa797b74f830cf63fde",
         "type": "github"
       },
       "original": {
@@ -421,11 +421,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777780666,
-        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
@@ -440,11 +440,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1778332591,
-        "narHash": "sha256-ctJ3ADtugrnbMfMBobA645gCqXVIyHnsCNMkVaIuSiM=",
+        "lastModified": 1778851564,
+        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "7d0038b5bb60568ec41f5f4ef5067cd221ca7c0d",
+        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
         "type": "github"
       },
       "original": {
@@ -460,11 +460,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778393439,
-        "narHash": "sha256-mOtQxUjtKaPHLeoLOY/YEDctmud1X9KwJr4kE1MJ3Wc=",
+        "lastModified": 1778999127,
+        "narHash": "sha256-V5GquqJvAqwFTcpN6hxKSQAtwuJFRUEHmyNKbeaTQDg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "01466c414c7357ae2ce32be4a272a7c69e94ab5f",
+        "rev": "f680e0d3c1dbefe298c423691662e238496890f2",
         "type": "github"
       },
       "original": {
@@ -554,11 +554,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -576,11 +576,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778693695,
-        "narHash": "sha256-cKCeSfIYf9t5cNsfKQp7Olv4ecfq+eJI0oQXf2Wgp2Q=",
+        "lastModified": 1779047312,
+        "narHash": "sha256-Q4CSXZehRX3CKnXXaHc2nCMjK9lgZR2Leu5DTwe1Vnw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ef11828818f99ed3ae2ed33b55739dd973ea346f",
+        "rev": "8070eab81003118a0d3cde9c316aca3b2c21533e",
         "type": "github"
       },
       "original": {
@@ -601,11 +601,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1778618635,
-        "narHash": "sha256-eiZkwksjBS4yr5uPt9rzoEQrnuwTgmFVFb6glGrNGF4=",
+        "lastModified": 1779018518,
+        "narHash": "sha256-RUmjcuxbaa8UKsd5rUO5bqDe9YxGBDLXd4tFFBi351E=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "0f7a1ff6ecff4a1f4fa2bbdd0f42151706a26831",
+        "rev": "cd45295f9c65ca81f323155660ba83d427bd0154",
         "type": "github"
       },
       "original": {

--- a/modules/home-manager/claude-code.nix
+++ b/modules/home-manager/claude-code.nix
@@ -6,6 +6,79 @@
 }:
 let
   cfg = config.custom.claude-code;
+
+  # Effort levels supported by each model. Source of truth:
+  # https://code.claude.com/docs/en/model-config#adjust-effort-level
+  # Keys are values passed to `claude --model` — aliases auto-track the latest
+  # version (https://code.claude.com/docs/en/model-config#model-aliases); pin
+  # a full model ID (e.g. "claude-opus-4-6") when you need a specific version.
+  # Empty list = model does not support --effort.
+  modelEfforts = {
+    opus = [
+      "low"
+      "medium"
+      "high"
+      "xhigh"
+      "max"
+    ];
+    sonnet = [
+      "low"
+      "medium"
+      "high"
+      "max"
+    ];
+    haiku = [ ];
+    "claude-opus-4-6" = [
+      "low"
+      "medium"
+      "high"
+      "max"
+    ];
+  };
+
+  # Maps each modelEfforts key to the slug used in the shell alias name
+  # (`claude-<slug>` and `claude-<slug>-<effort>`). Pinned IDs get a compact
+  # slug to avoid dash ambiguity with the effort suffix.
+  modelAliasSlug = {
+    opus = "opus";
+    sonnet = "sonnet";
+    haiku = "haiku";
+    "claude-opus-4-6" = "opus46";
+  };
+
+  # Whether each model supports the 1M-token context window. Source:
+  # https://code.claude.com/docs/en/model-config#extended-context
+  # When true, an additional set of `claude-<slug>-1m[-<effort>]` aliases is
+  # generated, invoking the model with the `[1m]` suffix.
+  model1mContext = {
+    opus = true;
+    sonnet = true;
+    haiku = false;
+    "claude-opus-4-6" = true;
+  };
+
+  # Generate `claude-<slug>[-<effort>]` for the default context window, plus
+  # `claude-<slug>-1m[-<effort>]` when the model supports 1M context. The
+  # model arg is single-quoted so zsh doesn't glob the `[1m]` brackets.
+  claudeAliases = lib.listToAttrs (
+    lib.concatMap (
+      model:
+      let
+        slug = modelAliasSlug.${model};
+        mkVariants =
+          modelArg: slugSuffix:
+          let
+            baseCmd = "claude --model '${modelArg}'";
+          in
+          [ (lib.nameValuePair "claude-${slug}${slugSuffix}" baseCmd) ]
+          ++ map (
+            effort: lib.nameValuePair "claude-${slug}${slugSuffix}-${effort}" "${baseCmd} --effort ${effort}"
+          ) modelEfforts.${model};
+      in
+      mkVariants model "" ++ lib.optionals model1mContext.${model} (mkVariants "${model}[1m]" "-1m")
+    ) (lib.attrNames modelEfforts)
+  );
+
   baseSettings = {
     hooks = {
       PreToolUse = [
@@ -49,6 +122,10 @@ in
     # via overlays/shared.nix so it's only visible inside Claude sessions
     # (where ~/.claude/hooks/rtk-rewrite.sh consumes it). Same story for nodejs.
     home.packages = [ pkgs.claude-code ];
+
+    # Aliases are set on zsh directly (every host enables it). Has no effect
+    # on a host where programs.zsh.enable is false.
+    programs.zsh.shellAliases = claudeAliases;
 
     home.file.".config/ccstatusline/settings.json".source = ./claude-code/ccstatusline.json;
 

--- a/packages/claude-code/manifest.json
+++ b/packages/claude-code/manifest.json
@@ -1,47 +1,47 @@
 {
-  "version": "2.1.140",
-  "commit": "89b4b3854fac52fdb8f9970133c4afe00174b6b9",
-  "buildDate": "2026-05-12T18:36:21Z",
+  "version": "2.1.141",
+  "commit": "4f4623ddd339e1c1b87d659b7c9eb3b66397e7a3",
+  "buildDate": "2026-05-13T21:34:55Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "087ce732fb79658cd3e828cc377291dc56835fc5318cd519123b0880a09149c0",
-      "size": 206069664
+      "checksum": "31ac95bb19a33b1d0cddd3f3ff594bf8bfd2be5051cd2af7867109641cab705e",
+      "size": 207076896
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "2616b1e775ec0520228cd99135d07ef99e4b93b4532a03ef019e0a8e81cc7729",
-      "size": 208583824
+      "checksum": "fa9000fdf4a522fcaf30ea283555aca2ba5d0e76cdb8842154b7735b558c7c25",
+      "size": 209591056
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "0ec6fc062e99aa95a6edbb5308a563262d27a0772b107d01d4fa61110fb44472",
-      "size": 231454344
+      "checksum": "dc931e24f62afbadc8dc68115278b08493825a3ed1ea753d587077181a6cc63b",
+      "size": 232437384
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "807a5d6ca063f5e03e4b7283934036a3122723b28c28e1a6978e98cf2d43d0b5",
-      "size": 231577296
+      "checksum": "832be26e8f15b2ae99e520a22b034fc4bfad1cb5b84de6b706487072c56bb42e",
+      "size": 232572624
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "b840a07551c3e1baecff728eb6b9a849483be87bf1fdaed5da22d0b3427a88cf",
-      "size": 224309080
+      "checksum": "e6e6a481c0aab084198b3529c6d96774e14d18da999aba7d22e207952ed8faf0",
+      "size": 225292120
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "7db8946293de9ec11d2b02472f715f18ea9a346238d472605b5d9a4dc7bfd3f1",
-      "size": 225971248
+      "checksum": "8af1f6e19d3786cac74dcf369ff58f79df08be429813b29ae076247cc8d1ddae",
+      "size": 226966576
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "fcfe90297861b1bcfa581d7db645ec8a71984baed3b1c44d28032650baa2617c",
-      "size": 227456160
+      "checksum": "3ab326c39d195dbe394c173f31126d880a80270f98ade74ef555429e2dadb19f",
+      "size": 228410016
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "3f782467ec6e593a5e23522b678cf4268965e4ec6fe904e41729a12d64232c40",
-      "size": 223420576
+      "checksum": "f622af48157bce7a24905fa6121191f5a472800ed9f77fa41c59bd5ecd161285",
+      "size": 224374432
     }
   }
 }

--- a/packages/claude-code/package.nix
+++ b/packages/claude-code/package.nix
@@ -9,6 +9,7 @@
   installShellFiles,
   makeBinaryWrapper,
   autoPatchelfHook,
+  alsa-lib,
   procps,
   ripgrep,
   bubblewrap,
@@ -56,7 +57,9 @@ stdenv.mkDerivation (finalAttrs: {
       --set-default FORCE_AUTOUPDATE_PLUGINS 1 \
       --set DISABLE_INSTALLATION_CHECKS 1 \
       --set USE_BUILTIN_RIPGREP 0 \
-      --prefix PATH : ${
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ alsa-lib ]} \
+      ''}--prefix PATH : ${
         lib.makeBinPath (
           [
             # claude-code uses [node-tree-kill](https://github.com/pkrumins/node-tree-kill) which requires procps's pgrep(darwin) or ps(linux)

--- a/packages/opencode/package.nix
+++ b/packages/opencode/package.nix
@@ -16,13 +16,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "1.14.48";
+  version = "1.15.3";
 
   src = fetchFromGitHub {
     owner = "anomalyco";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gyybqabTco+5ZeWv4lCX8t/R9Jm3tYsA8wVvkrxkEYQ=";
+    hash = "sha256-OKQR76q7trKQTvlMxH8tG2jNnRtBe3YeFfvNw8c3+8I=";
   };
 
   node_modules = stdenvNoCC.mkDerivation {
@@ -75,7 +75,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # NOTE: Required else we get errors that our fixed-output derivation references store paths
     dontFixup = true;
 
-    outputHash = "sha256-94uXrhyGqW016U6LPE/xIfZGoDOzyUto5DyQrYYePds=";
+    outputHash = "sha256-O6czNd9n6b0TTIsPseZn9qOlxsPzRTrePu3L6gM13oM=";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };

--- a/packages/rtk/package.nix
+++ b/packages/rtk/package.nix
@@ -12,19 +12,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rtk";
-  version = "0.38.0";
+  version = "0.40.0";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "rtk-ai";
     repo = "rtk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eINYlatbjpsqe46LNZIXvIrZEBf+QC3+2EjY7Ei7VZI=";
+    hash = "sha256-xWHIOZRpSyyOPQe/db9dxoODcnheBlpXrnKET010vVg=";
   };
 
-  strictDeps = true;
-  __structuredAttrs = true;
-
-  cargoHash = "sha256-qTDj7xTBM8dOOE7XLTewtHVwHtxVDcvCLs0ebtT2uSI=";
+  cargoHash = "sha256-DJazpSx1FCt9pjFjqsoL3MLEQLdFvLwEj3UsP0aYHmc=";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
## Summary
- **Module:** generate per-model shell aliases (`claude-opus`, `claude-opus-max`, `claude-sonnet-1m`, `claude-opus46-high`, …) by iterating over three top-level attrsets (`modelEfforts`, `modelAliasSlug`, `model1mContext`) in `modules/home-manager/claude-code.nix`. 33 aliases across opus, sonnet, opus-4-6 (pinned), and haiku, including 1M-context variants where supported. Doc links in comments cite [code.claude.com/docs/en/model-config](https://code.claude.com/docs/en/model-config) as the source of truth.
- **claude-code:** 2.1.140 → 2.1.141; adds `alsa-lib` to `LD_LIBRARY_PATH` on Linux to fix voice-mode native module load (mirrors [nixpkgs dbacac5](https://github.com/NixOS/nixpkgs/commit/dbacac5)).
- **opencode:** 1.14.48 → 1.15.3.
- **rtk:** 0.38.0 → 0.40.0. Vendored `RTK.md` and `rtk-rewrite.sh` already match `v0.40.0` upstream byte-for-byte (verified via the integrity hash the binary embeds).
- **flake.lock:** refreshed.

## Test plan
- [ ] CI green (eval + diff against base)
- [ ] `nix build .#nixosConfigurations.BrightFalls.config.system.build.toplevel`
- [ ] `nix build .#nixosConfigurations.Nexus.config.system.build.toplevel`
- [ ] `nix eval .#darwinConfigurations.NightSprings.config.system.build.toplevel --raw` (Darwin eval from Linux)
- [ ] After switch, `alias | grep ^claude-` shows all 33 entries
- [ ] Spot-check: `claude-opus-1m-max` launches Claude Code with `opus[1m]` + `--effort max`
- [ ] Confirm rtk hook still passes integrity check on first Bash tool use