### PR TITLE
feat(nvf): python via ruff, enable Rust

### DIFF
--- a/modules/nvf/default.nix
+++ b/modules/nvf/default.nix
@@ -219,13 +219,42 @@
       markdown.enable = true;
       typescript.enable = true;
       go.enable = true;
-      python.enable = true;
+      python = {
+        enable = true;
+        lsp.servers = [
+          "basedpyright"
+          "ruff"
+        ];
+        format = {
+          enable = true;
+          type = [
+            "ruff"
+            "ruff-check"
+          ];
+        };
+        extraDiagnostics.enable = false;
+      };
       json.enable = true;
       xml.enable = true;
       ruby.enable = true;
       clang.enable = true;
       css.enable = true;
       html.enable = true;
+      rust = {
+        enable = true;
+        lsp.opts = ''
+          ['rust-analyzer'] = {
+            cargo = { allFeatures = true },
+            checkOnSave = true,
+            check = {
+              command = "clippy",
+              extraArgs = { "--no-deps" },
+            },
+            procMacro = { enable = true },
+          },
+        '';
+        extensions.crates-nvim.enable = true;
+      };
     };
     lsp.presets.tailwindcss-language-server.enable = true;
   };


### PR DESCRIPTION
## Summary

- **Python**: switch to `basedpyright` + `ruff` LSP; `ruff` / `ruff-check` as formatter; disable mypy (its diagnostics were the only `extraDiagnostics` provider upstream and ruff covers linting now). Previously formatting was effectively off — `enableFormat` is gated by `!lsp.enable`, so the default `black` never ran; only mypy was active.
- **Rust**: enable with rust-analyzer (`allFeatures`, `checkOnSave` running clippy with `--no-deps`, `procMacro`) and `crates-nvim` for Cargo.toml dependency management. DAP intentionally left off — upstream codelldb path hardcodes `liblldb.so` (Linux-only) which would break the macOS hosts.