### PR TITLE
feat(nvf): auto-reload buffers/neo-tree + hide bufferline numbers

### DIFF
--- a/modules/nvf/default.nix
+++ b/modules/nvf/default.nix
@@ -17,7 +17,26 @@
       mouse = "";
       foldlevel = 99;
       foldlevelstart = 99;
+      autoread = true;
     };
+    augroups = [
+      {
+        name = "AutoReload";
+        clear = true;
+      }
+    ];
+    autocmds = [
+      {
+        event = [
+          "FocusGained"
+          "BufEnter"
+        ];
+        pattern = [ "*" ];
+        group = "AutoReload";
+        command = "checktime";
+        desc = "Reload buffers changed outside Neovim";
+      }
+    ];
     startPlugins = [
       pkgs.vimPlugins.vim-sleuth
       pkgs.vimPlugins.smear-cursor-nvim
@@ -42,6 +61,7 @@
           git_status_async = true;
           use_libuv_file_watcher = true;
           close_if_last_window = true;
+          filesystem.follow_current_file.enabled = true;
           event_handlers = [
             {
               event = "neo_tree_buffer_enter";

--- a/modules/nvf/default.nix
+++ b/modules/nvf/default.nix
@@ -215,7 +215,10 @@
       vim.api.nvim_set_hl(0, "NeogitDiffAddHighlight", { bg = "#3d5a42", fg = "#f8f8f2" })
       vim.api.nvim_set_hl(0, "NeogitDiffAddCursor", { bg = "#4d6a52", fg = "#f8f8f2" })
     '';
-    tabline.nvimBufferline.enable = true;
+    tabline.nvimBufferline = {
+      enable = true;
+      setupOpts.options.numbers = "none";
+    };
     visuals = {
       nvim-cursorline.enable = true;
       cinnamon-nvim.enable = true;


### PR DESCRIPTION
## Summary
- Enable `autoread` and add `FocusGained`/`BufEnter` autocommands to reload buffers changed outside Neovim
- Enable `filesystem.follow_current_file` so neo-tree tracks the active buffer
- Set bufferline `numbers = "none"` to remove the tiny ordinal/ID numbers from buffer tabs