### PR TITLE
fix(brightfalls): correct Sunshine audio_sink to actual iec958-stereo node

### DIFF
--- a/hosts/Brightfalls/gaming.nix
+++ b/hosts/Brightfalls/gaming.nix
@@ -78,7 +78,7 @@
           undo = "${pkgs.mutter}/bin/gdctl set --logical-monitor --primary --monitor DP-1 --mode 2560x1440@143.998 --logical-monitor --monitor DP-2 --right-of DP-1 --mode 2560x1440@59.951";
         }
       ];
-      audio_sink = "alsa_output.usb-Schiit_Audio_USB_Modi_Device-00.analog-stereo";
+      audio_sink = "alsa_output.usb-Schiit_Audio_USB_Modi_Device-00.iec958-stereo";
       fec_percentage = 10;
       qp = 10;
     };


### PR DESCRIPTION
## Summary

The Modi 2 is a USB DAC that only exposes the `iec958-stereo` PipeWire profile (confirmed via `pw-cli`). The previous `analog-stereo` node name referenced a sink that does not exist on this hardware, so Sunshine was either failing to capture or silently falling back to the default sink.