### PR TITLE
feat(brightfalls): add retroarch with beetle-psx-hw core

### DIFF
--- a/hosts/Brightfalls/users/matteo/gaming.nix
+++ b/hosts/Brightfalls/users/matteo/gaming.nix
@@ -15,6 +15,10 @@
 
   home.file.".config/MangoHud/MangoHud.conf".source = ./MangoHud.conf;
 
+  home.packages = [
+    (pkgs.retroarch.withCores (cores: with cores; [ beetle-psx-hw ]))
+  ];
+
   programs.obs-studio = {
     enable = true;
     package = pkgs.obs-studio;


### PR DESCRIPTION
## Summary
- Installs RetroArch on BrightFalls (user-level Home Manager) wrapped with the `beetle-psx-hw` libretro core for PS1 emulation via Vulkan.

## Test plan
- [x] `nix build .#nixosConfigurations.BrightFalls.config.system.build.toplevel` succeeds
- [x] Smoke-tested via `nix run --impure --expr '(builtins.getFlake (toString ./.)).inputs.nixpkgs.legacyPackages.x86_64-linux.retroarch.withCores (cores: with cores; [ beetle-psx-hw ])'`
- [ ] `sudo nixos-rebuild switch --flake .#BrightFalls` on host