### PR TITLE
fix(brightfalls): pin user monitors.xml via Home Manager for mutter 50

### DIFF
--- a/hosts/Brightfalls/monitors.xml
+++ b/hosts/Brightfalls/monitors.xml
@@ -44,6 +44,54 @@
     </logicalmonitor>
   </configuration>
   <configuration>
+    <layoutmode>logical</layoutmode>
+    <logicalmonitor>
+      <x>0</x>
+      <y>0</y>
+      <scale>1</scale>
+      <primary>yes</primary>
+      <monitor>
+        <monitorspec>
+          <connector>DP-1</connector>
+          <vendor>AUS</vendor>
+          <product>ROG PG278QR</product>
+          <serial>#ASO0f7HLJ+Pd</serial>
+        </monitorspec>
+        <mode>
+          <width>2560</width>
+          <height>1440</height>
+          <rate>143.998</rate>
+        </mode>
+      </monitor>
+    </logicalmonitor>
+    <logicalmonitor>
+      <x>2560</x>
+      <y>0</y>
+      <scale>1</scale>
+      <monitor>
+        <monitorspec>
+          <connector>DP-2</connector>
+          <vendor>DEL</vendor>
+          <product>DELL U2719D</product>
+          <serial>7CGY223</serial>
+        </monitorspec>
+        <mode>
+          <width>2560</width>
+          <height>1440</height>
+          <rate>59.951</rate>
+        </mode>
+      </monitor>
+    </logicalmonitor>
+    <disabled>
+      <monitorspec>
+        <connector>HDMI-1</connector>
+        <vendor>FUN</vendor>
+        <product>Evanlak8K V2</product>
+        <serial>0x00006410</serial>
+      </monitorspec>
+    </disabled>
+  </configuration>
+  <configuration>
     <layoutmode>physical</layoutmode>
     <logicalmonitor>
       <x>0</x>

--- a/hosts/Brightfalls/users/matteo/gnome.nix
+++ b/hosts/Brightfalls/users/matteo/gnome.nix
@@ -5,6 +5,8 @@
 }:
 with lib.hm.gvariant;
 {
+  xdg.configFile."monitors.xml".source = ../../monitors.xml;
+
   dconf.settings = {
     "org/gnome/desktop/interface" = {
       color-scheme = "prefer-dark";


### PR DESCRIPTION
## Summary

- Mutter 50 (nixpkgs >= `64c08a7`) stopped honoring the existing DP-1+DP-2 configurations in `monitors.xml` and picked the Evanlak8K V2 capture device (HDMI-1) as primary on autologin, rendering the GNOME shell to the capture target and leaving DP-1/DP-2 wallpaper-only.
- Add a new `layoutmode=logical` configuration with HDMI-1 explicitly `<disabled>` (generated via `gdctl set --persistent`).
- Link `~/.config/monitors.xml` from the repo via Home Manager `xdg.configFile`, so the user session and GDM share one source.