### PR TITLE
fix(nexus): correct scrub-timer and paperless media-path in docs

### DIFF
--- a/docs/nexus/diskpool-handbook.md
+++ b/docs/nexus/diskpool-handbook.md
@@ -110,7 +110,7 @@ SnapRAID provides snapshot-based parity protection:
 
 With dual parity, SnapRAID can recover from up to **2 simultaneous data-disk failures**.
 
-**Note**: The NixOS snapraid-sync and snapraid-scrub timers are disabled; sync is triggered during the backup job.
+**Note**: The NixOS snapraid-sync timer is disabled (sync is triggered during the backup job); the snapraid-scrub timer remains enabled and runs weekly (Sun 06:00).
 
 **Configuration**: `hosts/Nexus/snapraid.nix`
 

--- a/docs/nexus/paperless-ngx-recovery.md
+++ b/docs/nexus/paperless-ngx-recovery.md
@@ -107,6 +107,6 @@ sudo rm -rf /tmp/restore
 
 - Backups run **daily** via `services.restic.backups.config`
 - PostgreSQL dumps are created by `services.postgresqlBackup`
-- Media files are at `/diskpool/configuration/paperless/documents/` (usually intact)
+- Live media files are at `/diskpool/paperless` (`services.paperless.mediaDir`, usually intact); `/diskpool/configuration/paperless` is the nightly rsync backup copy, not the live tree
 - Restic credentials are managed by **agenix**
 


### PR DESCRIPTION
Two stale facts surfaced while reviewing the Nexus docs, both verified against the live host (`nix eval` + `systemctl` on Nexus).

## Fixes

**`diskpool-handbook.md`** — the note claimed both `snapraid-sync` *and* `snapraid-scrub` timers are disabled. Only sync is disabled (`snapraid.nix` forces empty `wantedBy/startAt`). The scrub timer stays armed: `snapraid-scrub.timer` is `enabled`/`active`, next run Sun 06:00.

**`paperless-ngx-recovery.md`** — the Notes pointed media at `/diskpool/configuration/paperless/documents/`. Live `services.paperless.mediaDir` is `/diskpool/paperless` (`paperless.nix:40`); `/diskpool/configuration/paperless` is the nightly rsync backup copy (`backup.nix:8,207`), not the live tree. Now distinguishes the two to avoid restoring into the wrong directory.

Doc-only changes; no rebuild required.