### PR TITLE
ci: pin dix to v1.4.2 in PR diff job

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -117,5 +117,7 @@ jobs:
 
           echo "## Diff" >> "$GITHUB_STEP_SUMMARY"
           echo '```diff' >> "$GITHUB_STEP_SUMMARY"
-          nix run github:faukah/dix -- ./old-result ./result >> "$GITHUB_STEP_SUMMARY" || true
+          # Pinned to v1.4.2: dix HEAD fails to build because libsqlite3-sys
+          # 0.38.0 (pulled in 2026-05-27) uses the unstable cfg_select! macro.
+          nix run github:faukah/dix/v1.4.2 -- ./old-result ./result >> "$GITHUB_STEP_SUMMARY" || true
           echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

The `Compare configurations` step in `pr-build.yml` renders an empty Diff block in the PR summary. Root cause: `nix run github:faukah/dix` builds dix from source, and dix HEAD's `Cargo.lock` pulls in `libsqlite3-sys 0.38.0` (since 2026-05-27), whose `build.rs` uses the unstable `cfg_select!` macro. The pinned rustc rejects it (`error[E0658]`), the build fails, and the step's trailing `|| true` swallows the failure — so the job stays green but produces no diff.

This affects every runner (confirmed on both x86_64-linux and aarch64-darwin). No upstream issue/PR addresses it, and HEAD still carries the broken pin.

## Fix

Pin to `github:faukah/dix/v1.4.2` — the latest dix release, which ships `libsqlite3-sys 0.36.0` (pre-`cfg_select!`). Fully reproducible via the flake.lock + Cargo.lock carried at that tag.

## Notes

- The trailing `|| true` is intentionally left in place; failures still won't fail the check. Can be revisited separately if loud failures are preferred.