### PR TITLE
chore: weekly flake update - 2026-06-03T21:46:15Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778427648,
-        "narHash": "sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE=",
+        "lastModified": 1779646357,
+        "narHash": "sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6f293daa9f9f5832e13b497976335e90509886d7",
+        "rev": "10a163ac127624caa80cc5cc5a705e97f3615b0e",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.11",
+        "ref": "5.1.14",
         "repo": "brew",
         "type": "github"
       }
@@ -309,11 +309,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780408569,
-        "narHash": "sha256-s7Tv6FUQThRAvW8En8XVC6HMb0uiikzVccCcCo9u/Bg=",
+        "lastModified": 1780593650,
+        "narHash": "sha256-CHo7k65YTL3HY+WQVedDTupji+LMgNlKCdrtRHZFAK4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f384af1bec6423a0d4ba1855917ab948f64e5808",
+        "rev": "447fd9ff62501dae7206dfe180ee89f8de27b7d5",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1780434656,
-        "narHash": "sha256-1vjMDIQvGOpLnBIiqqaVnPkQMj0K0yAC6ILj6BjYXRI=",
+        "lastModified": 1780618935,
+        "narHash": "sha256-Kk+CFgJHybDxYjRKfmM690M+UpTJEd+YU7wxGQwIyns=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "1049608057a7b602cf71de26d554511ac248632d",
+        "rev": "66a35e5ec84a28ef581b9f2d3bc7e20be30ba588",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1780437925,
-        "narHash": "sha256-sWoUXj8f0bCEphPbju58E2jSWMAmIalHbaIA7OSmLdM=",
+        "lastModified": 1780618907,
+        "narHash": "sha256-8GMTaPngUO4QoHZEK83EoqC0rtFchmWoVLPTN1vgFyQ=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "e7a7be1f25f623cf1137d3505d7996be678d17ce",
+        "rev": "7b08fbcd309dd8ecbd236581f02c25cfe1229405",
         "type": "github"
       },
       "original": {
@@ -440,11 +440,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1778851564,
-        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
+        "lastModified": 1780492467,
+        "narHash": "sha256-zMEJwtQPmsPPgPczFkyjWHgd1z0HagOPS2Wt2WDYLJY=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
+        "rev": "562332f97de9f5ba51aa647d70462e88222b2988",
         "type": "github"
       },
       "original": {
@@ -506,11 +506,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1780438112,
-        "narHash": "sha256-92vB6kHcBkyNuY24jlL1Ot0RKduBBqWVDz7w1UT95Ic=",
+        "lastModified": 1780619685,
+        "narHash": "sha256-j65/WBYa22stISaoRdOquE3EDWkUvG6Ggs3t7BbeSM4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7a2bc003b546bc500af7a778e4c7e24ae2574a8e",
+        "rev": "f4d2fa6b5c9e2f1555ef1c7559993d00714d1bf3",
         "type": "github"
       },
       "original": {
@@ -592,11 +592,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780438327,
-        "narHash": "sha256-bAFXjxSV3GJLIrxdT1dgwf1QFl2iVVcdbiCq9uEPrhs=",
+        "lastModified": 1780619538,
+        "narHash": "sha256-UuqI1R5zdQvfR2yKwlKTbYFcTE+jl6PsOdY8eC4IXmU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fdd2b25e13ee6f21db830f7fa3f2feadce7d9c9c",
+        "rev": "02c9239532568877a6de7c692f313e9205ef10bd",
         "type": "github"
       },
       "original": {
@@ -617,11 +617,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1780421419,
-        "narHash": "sha256-EkZYvhK9B9M9j9vuLNSexG1Uf51UshGkPy5iVpYORe8=",
+        "lastModified": 1780511420,
+        "narHash": "sha256-Ib44d47GTijSfCtcxFDliP3C9uUiLDYaAE/nVH8TQoY=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "8265ea062b4c37dc1b9846ec83bb8c9615048ef1",
+        "rev": "29f7eb8491d9833ee55006ab11169130a60c2652",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:firelzrd/bore-scheduler/09075221d81b27cc6ba4dc0d1be14a62555fde85' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/115e5211780054d8a890b41f0b7734cafad54dfe' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/942159e73e40bf785816f7f1f5feed9ef3d7c8f9' into the Git cache...
unpacking 'github:nix-community/home-manager/447fd9ff62501dae7206dfe180ee89f8de27b7d5' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/66a35e5ec84a28ef581b9f2d3bc7e20be30ba588' into the Git cache...
unpacking 'github:homebrew/homebrew-core/7b08fbcd309dd8ecbd236581f02c25cfe1229405' into the Git cache...
unpacking 'github:hraban/mac-app-util/4747968574ea58512c5385466400b2364c85d2d0' into the Git cache...
unpacking 'github:lnl7/nix-darwin/56c666e108467d87d13508936aade6d567f2a501' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/562332f97de9f5ba51aa647d70462e88222b2988' into the Git cache...
unpacking 'github:nix-community/nix-index-database/97df9dc0b7c924344b793a15c1e8e4522ebb854e' into the Git cache...
unpacking 'github:NixOS/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c' into the Git cache...
unpacking 'github:NixOS/nixpkgs/f4d2fa6b5c9e2f1555ef1c7559993d00714d1bf3' into the Git cache...
unpacking 'github:nix-community/NUR/02c9239532568877a6de7c692f313e9205ef10bd' into the Git cache...
unpacking 'github:NotAShelf/nvf/29f7eb8491d9833ee55006ab11169130a60c2652' into the Git cache...
unpacking 'github:dracula/opencode/e7b8ba5bff2eca780c974a241d233230e58c4e0c' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/f384af1bec6423a0d4ba1855917ab948f64e5808?narHash=sha256-s7Tv6FUQThRAvW8En8XVC6HMb0uiikzVccCcCo9u/Bg%3D' (2026-06-02)
  → 'github:nix-community/home-manager/447fd9ff62501dae7206dfe180ee89f8de27b7d5?narHash=sha256-CHo7k65YTL3HY%2BWQVedDTupji%2BLMgNlKCdrtRHZFAK4%3D' (2026-06-04)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/1049608057a7b602cf71de26d554511ac248632d?narHash=sha256-1vjMDIQvGOpLnBIiqqaVnPkQMj0K0yAC6ILj6BjYXRI%3D' (2026-06-02)
  → 'github:homebrew/homebrew-cask/66a35e5ec84a28ef581b9f2d3bc7e20be30ba588?narHash=sha256-Kk%2BCFgJHybDxYjRKfmM690M%2BUpTJEd%2BYU7wxGQwIyns%3D' (2026-06-05)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/e7a7be1f25f623cf1137d3505d7996be678d17ce?narHash=sha256-sWoUXj8f0bCEphPbju58E2jSWMAmIalHbaIA7OSmLdM%3D' (2026-06-02)
  → 'github:homebrew/homebrew-core/7b08fbcd309dd8ecbd236581f02c25cfe1229405?narHash=sha256-8GMTaPngUO4QoHZEK83EoqC0rtFchmWoVLPTN1vgFyQ%3D' (2026-06-05)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/b3a87b4793205cc111f3c61e25e018ffac3b8039?narHash=sha256-p8wzcnpB2Iys%2BQzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE%3D' (2026-05-15)
  → 'github:zhaofengli/nix-homebrew/562332f97de9f5ba51aa647d70462e88222b2988?narHash=sha256-zMEJwtQPmsPPgPczFkyjWHgd1z0HagOPS2Wt2WDYLJY%3D' (2026-06-03)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/6f293daa9f9f5832e13b497976335e90509886d7?narHash=sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE%3D' (2026-05-10)
  → 'github:Homebrew/brew/10a163ac127624caa80cc5cc5a705e97f3615b0e?narHash=sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k%3D' (2026-05-24)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/7a2bc003b546bc500af7a778e4c7e24ae2574a8e?narHash=sha256-92vB6kHcBkyNuY24jlL1Ot0RKduBBqWVDz7w1UT95Ic%3D' (2026-06-02)
  → 'github:NixOS/nixpkgs/f4d2fa6b5c9e2f1555ef1c7559993d00714d1bf3?narHash=sha256-j65/WBYa22stISaoRdOquE3EDWkUvG6Ggs3t7BbeSM4%3D' (2026-06-05)
• Updated input 'nur':
    'github:nix-community/NUR/fdd2b25e13ee6f21db830f7fa3f2feadce7d9c9c?narHash=sha256-bAFXjxSV3GJLIrxdT1dgwf1QFl2iVVcdbiCq9uEPrhs%3D' (2026-06-02)
  → 'github:nix-community/NUR/02c9239532568877a6de7c692f313e9205ef10bd?narHash=sha256-UuqI1R5zdQvfR2yKwlKTbYFcTE%2Bjl6PsOdY8eC4IXmU%3D' (2026-06-05)
• Updated input 'nvf':
    'github:NotAShelf/nvf/8265ea062b4c37dc1b9846ec83bb8c9615048ef1?narHash=sha256-EkZYvhK9B9M9j9vuLNSexG1Uf51UshGkPy5iVpYORe8%3D' (2026-06-02)
  → 'github:NotAShelf/nvf/29f7eb8491d9833ee55006ab11169130a60c2652?narHash=sha256-Ib44d47GTijSfCtcxFDliP3C9uUiLDYaAE/nVH8TQoY%3D' (2026-06-03)
```
