### PR TITLE
chore: weekly flake update - 2026-06-05T15:58:32Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -309,11 +309,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780593650,
-        "narHash": "sha256-CHo7k65YTL3HY+WQVedDTupji+LMgNlKCdrtRHZFAK4=",
+        "lastModified": 1780679734,
+        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "447fd9ff62501dae7206dfe180ee89f8de27b7d5",
+        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
         "type": "github"
       },
       "original": {
@@ -325,11 +325,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1780618935,
-        "narHash": "sha256-Kk+CFgJHybDxYjRKfmM690M+UpTJEd+YU7wxGQwIyns=",
+        "lastModified": 1780851911,
+        "narHash": "sha256-O8fodM975X8B/shCfvn41jcQj/iaiRv0iMWn0k1J+HM=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "66a35e5ec84a28ef581b9f2d3bc7e20be30ba588",
+        "rev": "5b381cac6a4a43565e30ef1246d289ffa45b8ff5",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1780618907,
-        "narHash": "sha256-8GMTaPngUO4QoHZEK83EoqC0rtFchmWoVLPTN1vgFyQ=",
+        "lastModified": 1780864308,
+        "narHash": "sha256-S0Pq8B4YVZlrBqaxQmvPmgWJAJqYms/bV3vTUXImGik=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "7b08fbcd309dd8ecbd236581f02c25cfe1229405",
+        "rev": "3564e1d32019bf4158dab2ceb31cea0b49c040b5",
         "type": "github"
       },
       "original": {
@@ -421,11 +421,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1780795403,
+        "narHash": "sha256-AkWx4Zt9pQbD/f82Z8N57+d0HGLN/rV3gdMKJTpBPKs=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "6a771120d607dcccb279a27d227650e324815c35",
         "type": "github"
       },
       "original": {
@@ -460,11 +460,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780210899,
-        "narHash": "sha256-4axz3OBPTKa6LIkXV8n0lc63MQU+et2CB5DGobEAi6k=",
+        "lastModified": 1780816331,
+        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "97df9dc0b7c924344b793a15c1e8e4522ebb854e",
+        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
         "type": "github"
       },
       "original": {
@@ -506,11 +506,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1780673590,
-        "narHash": "sha256-/U9nyJD6uqlBcM4MomNrcioKs/8KnijsiZhMd2wA6Co=",
+        "lastModified": 1780864402,
+        "narHash": "sha256-u+L8xSWKxPlpXLpwiUqlWwoCu5Api1KzOIEOfc4MvpE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c60fcf543eb42d0b40b676fcce1d57935d012f5",
+        "rev": "6e99531d2b408a588854d80b163084e916dfee5c",
         "type": "github"
       },
       "original": {
@@ -592,11 +592,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780619538,
-        "narHash": "sha256-UuqI1R5zdQvfR2yKwlKTbYFcTE+jl6PsOdY8eC4IXmU=",
+        "lastModified": 1780862493,
+        "narHash": "sha256-epAgK6j2TEK8qeqJ7Y+svtUmgnM2LSAqjFCUs2GDmEY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "02c9239532568877a6de7c692f313e9205ef10bd",
+        "rev": "7aff5bbf3b63e55d9c0b3295a3ebaa8a3a51a4af",
         "type": "github"
       },
       "original": {
@@ -617,11 +617,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1780511420,
-        "narHash": "sha256-Ib44d47GTijSfCtcxFDliP3C9uUiLDYaAE/nVH8TQoY=",
+        "lastModified": 1780650009,
+        "narHash": "sha256-zUN3BFopCC9J7g8cQO69s93EKCKApSwRlLWMC2bI+GY=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "29f7eb8491d9833ee55006ab11169130a60c2652",
+        "rev": "0b92b1783de48499303fc6e61478da34ee124482",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:firelzrd/bore-scheduler/09075221d81b27cc6ba4dc0d1be14a62555fde85' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/115e5211780054d8a890b41f0b7734cafad54dfe' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/942159e73e40bf785816f7f1f5feed9ef3d7c8f9' into the Git cache...
unpacking 'github:nix-community/home-manager/b2b7db486e06e098711dc291bb25db82850e1d16' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/5b381cac6a4a43565e30ef1246d289ffa45b8ff5' into the Git cache...
unpacking 'github:homebrew/homebrew-core/3564e1d32019bf4158dab2ceb31cea0b49c040b5' into the Git cache...
unpacking 'github:hraban/mac-app-util/4747968574ea58512c5385466400b2364c85d2d0' into the Git cache...
unpacking 'github:lnl7/nix-darwin/6a771120d607dcccb279a27d227650e324815c35' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/562332f97de9f5ba51aa647d70462e88222b2988' into the Git cache...
unpacking 'github:nix-community/nix-index-database/1a2ea89c917781e88508d9fd2b507f2d2a0e173c' into the Git cache...
unpacking 'github:NixOS/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c' into the Git cache...
unpacking 'github:NixOS/nixpkgs/6e99531d2b408a588854d80b163084e916dfee5c' into the Git cache...
unpacking 'github:nix-community/NUR/7aff5bbf3b63e55d9c0b3295a3ebaa8a3a51a4af' into the Git cache...
unpacking 'github:NotAShelf/nvf/0b92b1783de48499303fc6e61478da34ee124482' into the Git cache...
unpacking 'github:dracula/opencode/e7b8ba5bff2eca780c974a241d233230e58c4e0c' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/447fd9ff62501dae7206dfe180ee89f8de27b7d5?narHash=sha256-CHo7k65YTL3HY%2BWQVedDTupji%2BLMgNlKCdrtRHZFAK4%3D' (2026-06-04)
  → 'github:nix-community/home-manager/b2b7db486e06e098711dc291bb25db82850e1d16?narHash=sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8%3D' (2026-06-05)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/66a35e5ec84a28ef581b9f2d3bc7e20be30ba588?narHash=sha256-Kk%2BCFgJHybDxYjRKfmM690M%2BUpTJEd%2BYU7wxGQwIyns%3D' (2026-06-05)
  → 'github:homebrew/homebrew-cask/5b381cac6a4a43565e30ef1246d289ffa45b8ff5?narHash=sha256-O8fodM975X8B/shCfvn41jcQj/iaiRv0iMWn0k1J%2BHM%3D' (2026-06-07)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/7b08fbcd309dd8ecbd236581f02c25cfe1229405?narHash=sha256-8GMTaPngUO4QoHZEK83EoqC0rtFchmWoVLPTN1vgFyQ%3D' (2026-06-05)
  → 'github:homebrew/homebrew-core/3564e1d32019bf4158dab2ceb31cea0b49c040b5?narHash=sha256-S0Pq8B4YVZlrBqaxQmvPmgWJAJqYms/bV3vTUXImGik%3D' (2026-06-07)
• Updated input 'nix-darwin':
    'github:lnl7/nix-darwin/56c666e108467d87d13508936aade6d567f2a501?narHash=sha256-zXcwYQGCT6pzinK%2B1dBB2ekTVtfxGZAapb3Evdcu4fY%3D' (2026-05-17)
  → 'github:lnl7/nix-darwin/6a771120d607dcccb279a27d227650e324815c35?narHash=sha256-AkWx4Zt9pQbD/f82Z8N57%2Bd0HGLN/rV3gdMKJTpBPKs%3D' (2026-06-07)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/97df9dc0b7c924344b793a15c1e8e4522ebb854e?narHash=sha256-4axz3OBPTKa6LIkXV8n0lc63MQU%2Bet2CB5DGobEAi6k%3D' (2026-05-31)
  → 'github:nix-community/nix-index-database/1a2ea89c917781e88508d9fd2b507f2d2a0e173c?narHash=sha256-0BYqs8yKWkOz2Q7%2BSP18N5E5gmDKSo6LSxIVIa0wWes%3D' (2026-06-07)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/1c60fcf543eb42d0b40b676fcce1d57935d012f5?narHash=sha256-/U9nyJD6uqlBcM4MomNrcioKs/8KnijsiZhMd2wA6Co%3D' (2026-06-05)
  → 'github:NixOS/nixpkgs/6e99531d2b408a588854d80b163084e916dfee5c?narHash=sha256-u%2BL8xSWKxPlpXLpwiUqlWwoCu5Api1KzOIEOfc4MvpE%3D' (2026-06-07)
• Updated input 'nur':
    'github:nix-community/NUR/02c9239532568877a6de7c692f313e9205ef10bd?narHash=sha256-UuqI1R5zdQvfR2yKwlKTbYFcTE%2Bjl6PsOdY8eC4IXmU%3D' (2026-06-05)
  → 'github:nix-community/NUR/7aff5bbf3b63e55d9c0b3295a3ebaa8a3a51a4af?narHash=sha256-epAgK6j2TEK8qeqJ7Y%2BsvtUmgnM2LSAqjFCUs2GDmEY%3D' (2026-06-07)
• Updated input 'nvf':
    'github:NotAShelf/nvf/29f7eb8491d9833ee55006ab11169130a60c2652?narHash=sha256-Ib44d47GTijSfCtcxFDliP3C9uUiLDYaAE/nVH8TQoY%3D' (2026-06-03)
  → 'github:NotAShelf/nvf/0b92b1783de48499303fc6e61478da34ee124482?narHash=sha256-zUN3BFopCC9J7g8cQO69s93EKCKApSwRlLWMC2bI%2BGY%3D' (2026-06-05)
```
