### PR TITLE
feat: add Claude Fable 5 + pinned Opus 4.7/4.6 model aliases

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -506,11 +506,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1780864402,
-        "narHash": "sha256-u+L8xSWKxPlpXLpwiUqlWwoCu5Api1KzOIEOfc4MvpE=",
+        "lastModified": 1781034373,
+        "narHash": "sha256-7P/e4EoMT83YsmvBw5PV1Z6QyDFRpeaSw9/rlTGnORE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e99531d2b408a588854d80b163084e916dfee5c",
+        "rev": "19c1fe4ff9335a9db73772c633e13ac4c7e1897a",
         "type": "github"
       },
       "original": {

--- a/modules/home-manager/claude-code.nix
+++ b/modules/home-manager/claude-code.nix
@@ -14,6 +14,13 @@ let
   # a full model ID (e.g. "claude-opus-4-8") when you need a specific version.
   # Empty list = model does not support --effort.
   modelEfforts = {
+    fable = [
+      "low"
+      "medium"
+      "high"
+      "xhigh"
+      "max"
+    ];
     opus = [
       "low"
       "medium"
@@ -28,15 +35,32 @@ let
       "max"
     ];
     haiku = [ ];
+    # Pinned legacy versions (still available; not evergreen aliases).
+    "claude-opus-4-7" = [
+      "low"
+      "medium"
+      "high"
+      "xhigh"
+      "max"
+    ];
+    "claude-opus-4-6" = [
+      "low"
+      "medium"
+      "high"
+      "max"
+    ];
   };
 
   # Maps each modelEfforts key to the slug used in the shell alias name
   # (`claude-<slug>` and `claude-<slug>-<effort>`). Pinned IDs get a compact
   # slug to avoid dash ambiguity with the effort suffix.
   modelAliasSlug = {
+    fable = "fable";
     opus = "opus";
     sonnet = "sonnet";
     haiku = "haiku";
+    "claude-opus-4-7" = "opus47";
+    "claude-opus-4-6" = "opus46";
   };
 
   # Whether each model supports the 1M-token context window. Source:
@@ -44,9 +68,12 @@ let
   # When true, an additional set of `claude-<slug>-1m[-<effort>]` aliases is
   # generated, invoking the model with the `[1m]` suffix.
   model1mContext = {
+    fable = true;
     opus = true;
     sonnet = true;
     haiku = false;
+    "claude-opus-4-7" = true;
+    "claude-opus-4-6" = true;
   };
 
   # Generate `claude-<slug>[-<effort>]` for the default context window, plus


### PR DESCRIPTION
Bumps `nixpkgs` to pull in claude-code 2.1.170, which adds **Claude Fable 5**.

## Changes
- New evergreen `fable` alias set — effort levels `low/medium/high/xhigh/max`, plus `[1m]` context variants (Fable 5 runs 1M by default).
- Pinned aliases for the still-available legacy Opus versions:
  - `opus47` → `claude-opus-4-7` (effort low..max incl. xhigh, 1M)
  - `opus46` → `claude-opus-4-6` (effort low/med/high/max — no xhigh, 1M)

The generator is data-driven; these are three attrset entries each. Verified via `nix eval` of the real host config (57 `claude-*` aliases total, all command strings correct and `[1m]` properly single-quoted).