### PR TITLE
attic: system-level cache config on Nexus and WorkLaptop

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,4 @@
 {
-  nixConfig = {
-    extra-substituters = [
-      "https://cache.matteopacini.me/main"
-    ];
-    extra-trusted-public-keys = [
-      "main:qAfi80bao6jxVrLVIuX07sthJscb2CcFBboYsEBxdG4="
-    ];
-  };
-
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     # Bleeding-edge nixpkgs master, used only to source a handful of

--- a/hosts/Nexus/services/attic.nix
+++ b/hosts/Nexus/services/attic.nix
@@ -20,8 +20,11 @@
   # router's split DNS.
   networking.hosts."127.0.0.1" = [ "cache.matteopacini.me" ];
 
-  # Auth for pulling from the private cache during rebuilds
-  nix.settings.netrc-file = config.age.secrets."nexus/attic-netrc".path;
+  # Substituter + auth for pulling from the private cache
+  custom.nix-core.atticCache = {
+    enable = true;
+    netrcFile = config.age.secrets."nexus/attic-netrc".path;
+  };
 
   # Token generation:
   #   sudo atticd-atticadm make-token --sub matteo --validity 2y \

--- a/hosts/WorkLaptop/default.nix
+++ b/hosts/WorkLaptop/default.nix
@@ -15,10 +15,12 @@
     trustedUsers = [
       "@admin"
     ];
+    # Substituter + auth for pulling from the private attic cache
+    atticCache = {
+      enable = true;
+      netrcFile = config.age.secrets."worklaptop/attic-netrc".path;
+    };
   };
-
-  # Auth for pulling from the private attic cache
-  nix.settings.netrc-file = config.age.secrets."worklaptop/attic-netrc".path;
 
   custom.fonts.enable = true;
   custom.nix-index.enable = true;

--- a/modules/darwin/nix-core.nix
+++ b/modules/darwin/nix-core.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   inputs,
   ...
 }:
@@ -15,26 +16,53 @@ in
       default = [ "root" ];
       description = "List of trusted Nix users";
     };
-  };
-
-  config = lib.mkIf cfg.enable {
-    nix = {
-      nixPath = [ "nixpkgs=${inputs.nixpkgs}" ];
-      registry = {
-        nixpkgs.flake = inputs.nixpkgs;
-      };
-      extraOptions = ''
-        extra-platforms = x86_64-darwin aarch64-darwin
-      '';
-      settings = {
-        experimental-features = [
-          "nix-command"
-          "flakes"
-        ];
-        trusted-users = cfg.trustedUsers;
-        sandbox = "relaxed";
+    atticCache = {
+      enable = lib.mkEnableOption "the self-hosted attic cache as a system-level substituter";
+      netrcFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "netrc file with the attic token, for pulling from the private cache";
       };
     };
-    nixpkgs.config.allowUnfree = true;
   };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        nix = {
+          nixPath = [ "nixpkgs=${inputs.nixpkgs}" ];
+          registry = {
+            nixpkgs.flake = inputs.nixpkgs;
+          };
+          extraOptions = ''
+            extra-platforms = x86_64-darwin aarch64-darwin
+          '';
+          settings = {
+            experimental-features = [
+              "nix-command"
+              "flakes"
+            ];
+            trusted-users = cfg.trustedUsers;
+            sandbox = "relaxed";
+          };
+        };
+        nixpkgs.config.allowUnfree = true;
+
+        # Client for the self-hosted attic cache on Nexus
+        environment.systemPackages = [ pkgs.attic-client ];
+      }
+      # System-level so the substituter applies to every user (the
+      # nix-daemon performs all downloads), with no flake nixConfig
+      # trust prompts
+      (lib.mkIf cfg.atticCache.enable {
+        nix.settings = {
+          extra-substituters = [ "https://cache.matteopacini.me/main" ];
+          extra-trusted-public-keys = [ "main:qAfi80bao6jxVrLVIuX07sthJscb2CcFBboYsEBxdG4=" ];
+        }
+        // lib.optionalAttrs (cfg.atticCache.netrcFile != null) {
+          netrc-file = cfg.atticCache.netrcFile;
+        };
+      })
+    ]
+  );
 }

--- a/modules/nixos/nix-core.nix
+++ b/modules/nixos/nix-core.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   inputs,
   ...
 }:
@@ -25,6 +26,14 @@ in
       default = [ ];
       description = "List of insecure packages to permit";
     };
+    atticCache = {
+      enable = lib.mkEnableOption "the self-hosted attic cache as a system-level substituter";
+      netrcFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "netrc file with the attic token, for pulling from the private cache";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable (
@@ -44,12 +53,27 @@ in
           };
         };
         nixpkgs.config.allowUnfree = true;
+
+        # Client for the self-hosted attic cache on Nexus
+        environment.systemPackages = [ pkgs.attic-client ];
       }
       (lib.mkIf (cfg.extraPlatforms != [ ]) {
         nix.settings.extra-platforms = cfg.extraPlatforms;
       })
       (lib.mkIf (cfg.permittedInsecurePackages != [ ]) {
         nixpkgs.config.permittedInsecurePackages = cfg.permittedInsecurePackages;
+      })
+      # System-level so the substituter applies to every user (the
+      # nix-daemon performs all downloads), with no flake nixConfig
+      # trust prompts
+      (lib.mkIf cfg.atticCache.enable {
+        nix.settings = {
+          extra-substituters = [ "https://cache.matteopacini.me/main" ];
+          extra-trusted-public-keys = [ "main:qAfi80bao6jxVrLVIuX07sthJscb2CcFBboYsEBxdG4=" ];
+        }
+        // lib.optionalAttrs (cfg.atticCache.netrcFile != null) {
+          netrc-file = cfg.atticCache.netrcFile;
+        };
       })
     ]
   );


### PR DESCRIPTION
- New `custom.nix-core.atticCache` option (nixos + darwin modules): puts the substituter, signing key and `netrc-file` into the system `nix.conf` — applies to every user including root rebuilds, no flake-config trust prompts
- Drops the flake `nixConfig` block: redundant on wired hosts, only 401 noise on hosts without the token, ignored by CI anyway
- `attic-client` added to systemPackages on all hosts via nix-core
- BrightFalls/CauldronLake/NightSprings: cache not wired yet (need their host keys for the netrc secret)