### PR TITLE
attic: scoped push tooling, user-config cleanup script

### DIFF
--- a/modules/darwin/nix-core.nix
+++ b/modules/darwin/nix-core.nix
@@ -7,6 +7,28 @@
 }:
 let
   cfg = config.custom.nix-core;
+
+  # One-shot push of the running system to the cache, using the agenix
+  # token; leaves no attic client config behind
+  atticPushCurrentSystem = pkgs.writeShellApplication {
+    name = "attic-push-current-system";
+    runtimeInputs = [
+      pkgs.attic-client
+      pkgs.gawk
+    ];
+    text = ''
+      if [ "$(id -u)" -ne 0 ]; then
+        echo "must run as root: the attic token is root-readable only" >&2
+        exit 1
+      fi
+      token=$(awk '/^password/ { print $2 }' "${toString cfg.atticCache.netrcFile}")
+      XDG_CONFIG_HOME=$(mktemp -d)
+      export XDG_CONFIG_HOME
+      trap 'rm -rf "$XDG_CONFIG_HOME"' EXIT
+      attic login nexus https://cache.matteopacini.me "$token"
+      attic push main /run/current-system
+    '';
+  };
 in
 {
   options.custom.nix-core = {
@@ -47,9 +69,6 @@ in
           };
         };
         nixpkgs.config.allowUnfree = true;
-
-        # Client for the self-hosted attic cache on Nexus
-        environment.systemPackages = [ pkgs.attic-client ];
       }
       # System-level so the substituter applies to every user (the
       # nix-daemon performs all downloads), with no flake nixConfig
@@ -62,6 +81,10 @@ in
         // lib.optionalAttrs (cfg.atticCache.netrcFile != null) {
           netrc-file = cfg.atticCache.netrcFile;
         };
+
+        environment.systemPackages = lib.optionals (cfg.atticCache.netrcFile != null) [
+          atticPushCurrentSystem
+        ];
       })
     ]
   );

--- a/modules/nixos/nix-core.nix
+++ b/modules/nixos/nix-core.nix
@@ -7,6 +7,28 @@
 }:
 let
   cfg = config.custom.nix-core;
+
+  # One-shot push of the running system to the cache, using the agenix
+  # token; leaves no attic client config behind
+  atticPushCurrentSystem = pkgs.writeShellApplication {
+    name = "attic-push-current-system";
+    runtimeInputs = [
+      pkgs.attic-client
+      pkgs.gawk
+    ];
+    text = ''
+      if [ "$(id -u)" -ne 0 ]; then
+        echo "must run as root: the attic token is root-readable only" >&2
+        exit 1
+      fi
+      token=$(awk '/^password/ { print $2 }' "${toString cfg.atticCache.netrcFile}")
+      XDG_CONFIG_HOME=$(mktemp -d)
+      export XDG_CONFIG_HOME
+      trap 'rm -rf "$XDG_CONFIG_HOME"' EXIT
+      attic login nexus https://cache.matteopacini.me "$token"
+      attic push main /run/current-system
+    '';
+  };
 in
 {
   options.custom.nix-core = {
@@ -53,9 +75,6 @@ in
           };
         };
         nixpkgs.config.allowUnfree = true;
-
-        # Client for the self-hosted attic cache on Nexus
-        environment.systemPackages = [ pkgs.attic-client ];
       }
       (lib.mkIf (cfg.extraPlatforms != [ ]) {
         nix.settings.extra-platforms = cfg.extraPlatforms;
@@ -74,6 +93,10 @@ in
         // lib.optionalAttrs (cfg.atticCache.netrcFile != null) {
           netrc-file = cfg.atticCache.netrcFile;
         };
+
+        environment.systemPackages = lib.optionals (cfg.atticCache.netrcFile != null) [
+          atticPushCurrentSystem
+        ];
       })
     ]
   );

--- a/scripts/wipe-user-nix-config.sh
+++ b/scripts/wipe-user-nix-config.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Wipe stale per-user nix/attic config that shadows the system
+# (flake-managed) nix configuration — leftovers from `attic use` in the
+# fly.dev era. A plain `substituters =` / `netrc-file =` in
+# ~/.config/nix/nix.conf silently overrides the flake-provided cache
+# settings for that user (and for root, all sudo rebuilds).
+#
+# Run once per host as your login user:
+#   ./scripts/wipe-user-nix-config.sh
+# Or remotely:
+#   ssh -t <host> 'sh -s' < scripts/wipe-user-nix-config.sh
+set -eu
+
+case "$(uname -s)" in
+  Darwin) ROOT_HOME=/var/root ;;
+  *) ROOT_HOME=/root ;;
+esac
+
+echo "== user: $HOME =="
+rm -rfv "$HOME/.config/nix/nix.conf" "$HOME/.config/nix/netrc" "$HOME/.config/attic"
+
+echo "== root: $ROOT_HOME =="
+# explicit root home: $HOME under sudo is unreliable on macOS
+sudo rm -rfv "$ROOT_HOME/.config/nix/nix.conf" "$ROOT_HOME/.config/nix/netrc" "$ROOT_HOME/.config/attic"
+
+echo "verify: nix config show | grep -E '^substituters|^netrc'"


### PR DESCRIPTION
- Drops `attic-client` from systemPackages everywhere: pulling needs no client (daemon + system nix.conf), ad-hoc pushes can `nix run nixpkgs#attic-client`
- `attic-push-current-system` (only on `atticCache` adopters, i.e. Nexus + WorkLaptop): root-only one-shot push of `/run/current-system` to `main`, token read from the agenix netrc, attic client config written to a throwaway `XDG_CONFIG_HOME` and removed by trap — smoke-tested on WorkLaptop
- `scripts/wipe-user-nix-config.sh`: removes stale `~/.config/nix/{nix.conf,netrc}` and `~/.config/attic` (user + root) left behind by `attic use` from the fly.dev era — those shadow the flake-managed system nix.conf and caused 401s on WorkLaptop for both user and root