### PR TITLE
attic: generalize push script to attic-push-closure

### DIFF
--- a/modules/darwin/nix-core.nix
+++ b/modules/darwin/nix-core.nix
@@ -8,26 +8,9 @@
 let
   cfg = config.custom.nix-core;
 
-  # One-shot push of the running system to the cache, using the agenix
-  # token; leaves no attic client config behind
-  atticPushCurrentSystem = pkgs.writeShellApplication {
-    name = "attic-push-current-system";
-    runtimeInputs = [
-      pkgs.attic-client
-      pkgs.gawk
-    ];
-    text = ''
-      if [ "$(id -u)" -ne 0 ]; then
-        echo "must run as root: the attic token is root-readable only" >&2
-        exit 1
-      fi
-      token=$(awk '/^password/ { print $2 }' "${toString cfg.atticCache.netrcFile}")
-      XDG_CONFIG_HOME=$(mktemp -d)
-      export XDG_CONFIG_HOME
-      trap 'rm -rf "$XDG_CONFIG_HOME"' EXIT
-      attic login nexus https://cache.matteopacini.me "$token"
-      attic push main /run/current-system
-    '';
+  atticPushClosure = import ../shared/attic-push-closure.nix {
+    inherit pkgs;
+    netrcFile = cfg.atticCache.netrcFile;
   };
 in
 {
@@ -83,7 +66,7 @@ in
         };
 
         environment.systemPackages = lib.optionals (cfg.atticCache.netrcFile != null) [
-          atticPushCurrentSystem
+          atticPushClosure
         ];
       })
     ]

--- a/modules/nixos/nix-core.nix
+++ b/modules/nixos/nix-core.nix
@@ -8,26 +8,9 @@
 let
   cfg = config.custom.nix-core;
 
-  # One-shot push of the running system to the cache, using the agenix
-  # token; leaves no attic client config behind
-  atticPushCurrentSystem = pkgs.writeShellApplication {
-    name = "attic-push-current-system";
-    runtimeInputs = [
-      pkgs.attic-client
-      pkgs.gawk
-    ];
-    text = ''
-      if [ "$(id -u)" -ne 0 ]; then
-        echo "must run as root: the attic token is root-readable only" >&2
-        exit 1
-      fi
-      token=$(awk '/^password/ { print $2 }' "${toString cfg.atticCache.netrcFile}")
-      XDG_CONFIG_HOME=$(mktemp -d)
-      export XDG_CONFIG_HOME
-      trap 'rm -rf "$XDG_CONFIG_HOME"' EXIT
-      attic login nexus https://cache.matteopacini.me "$token"
-      attic push main /run/current-system
-    '';
+  atticPushClosure = import ../shared/attic-push-closure.nix {
+    inherit pkgs;
+    netrcFile = cfg.atticCache.netrcFile;
   };
 in
 {
@@ -95,7 +78,7 @@ in
         };
 
         environment.systemPackages = lib.optionals (cfg.atticCache.netrcFile != null) [
-          atticPushCurrentSystem
+          atticPushClosure
         ];
       })
     ]

--- a/modules/shared/attic-push-closure.nix
+++ b/modules/shared/attic-push-closure.nix
@@ -1,0 +1,31 @@
+# Push one or more store-path closures to the self-hosted attic cache,
+# authenticating with the agenix netrc token. Login state goes into a
+# throwaway XDG_CONFIG_HOME so no attic client config is left behind.
+#
+# Shared by the NixOS and Darwin nix-core modules; exposed on hosts
+# with custom.nix-core.atticCache wired up.
+{ pkgs, netrcFile }:
+pkgs.writeShellApplication {
+  name = "attic-push-closure";
+  runtimeInputs = [
+    pkgs.attic-client
+    pkgs.gawk
+  ];
+  text = ''
+    if [ "$#" -lt 1 ]; then
+      echo "usage: attic-push-closure <store-path>..." >&2
+      echo "e.g.:  attic-push-closure /run/current-system" >&2
+      exit 64
+    fi
+    if [ "$(id -u)" -ne 0 ]; then
+      echo "must run as root: the attic token is root-readable only" >&2
+      exit 1
+    fi
+    token=$(awk '/^password/ { print $2 }' "${toString netrcFile}")
+    XDG_CONFIG_HOME=$(mktemp -d)
+    export XDG_CONFIG_HOME
+    trap 'rm -rf "$XDG_CONFIG_HOME"' EXIT
+    attic login nexus https://cache.matteopacini.me "$token"
+    attic push main "$@"
+  '';
+}


### PR DESCRIPTION
- `attic-push-current-system` → `attic-push-closure <store-path>...`: pushes any closure(s), `/run/current-system` is now just the common argument
- Script defined once in `modules/shared/attic-push-closure.nix`, imported by both the NixOS and Darwin nix-core modules (was duplicated inline in both)
- Still gated to `atticCache` adopters with a netrc (Nexus, BrightFalls, WorkLaptop) and root-only at runtime