### PR TITLE
fix(nexus): close atuin registration and scope firewall to LAN

### DIFF
--- a/hosts/Nexus/services/atuin.nix
+++ b/hosts/Nexus/services/atuin.nix
@@ -2,10 +2,17 @@
 {
   services.atuin = {
     enable = true;
-    openRegistration = true;
-    openFirewall = true;
+    openRegistration = false;
+    openFirewall = false;
     host = "0.0.0.0";
     port = 8888;
     database.createLocally = true;
   };
+
+  # WorkLaptop has no Tailscale (corp policy) and syncs over the LAN, so
+  # allow 8888 from the LAN subnet only instead of openFirewall's
+  # all-interfaces rule. Tailnet clients come in via trustedInterfaces.
+  networking.firewall.extraInputRules = ''
+    ip saddr 192.168.10.0/24 tcp dport 8888 accept
+  '';
 }


### PR DESCRIPTION
Phase 3 of Nexus hardening — atuin server lockdown.

- `openRegistration = false` — no more anonymous account creation on the shell-history server
- `openFirewall = false` — drops the all-interfaces 8888 rule
- nftables input rule allows 8888 from `192.168.10.0/24` only — WorkLaptop has no Tailscale (corp policy) and must keep syncing over the LAN; WAN sources are dropped even if the router forwards the port
- Tailnet clients still come in via `trustedInterfaces = [ "tailscale0" ]`
- No client changes needed on any host

Verified: toplevel build green.