### PR TITLE
fix(nexus): allow atuin sync from WorkLaptop VLAN IP

### DIFF
--- a/hosts/Nexus/services/atuin.nix
+++ b/hosts/Nexus/services/atuin.nix
@@ -10,9 +10,10 @@
   };
 
   # WorkLaptop has no Tailscale (corp policy) and syncs over the LAN, so
-  # allow 8888 from the LAN subnet only instead of openFirewall's
-  # all-interfaces rule. Tailnet clients come in via trustedInterfaces.
+  # allow 8888 from the LAN subnet plus WorkLaptop's fixed IP on its VLAN
+  # instead of openFirewall's all-interfaces rule. Tailnet clients come
+  # in via trustedInterfaces.
   networking.firewall.extraInputRules = ''
-    ip saddr 192.168.10.0/24 tcp dport 8888 accept
+    ip saddr { 192.168.10.0/24, 192.168.20.143 } tcp dport 8888 accept
   '';
 }


### PR DESCRIPTION
Follow-up to #292 — WorkLaptop sits on a separate VLAN with fixed IP `192.168.20.143`, which the LAN-subnet-only rule blocked. Adds that single IP to the nftables accept set for 8888.

Verified: toplevel build green.