### PR TITLE
fix(nexus): scope arr/paperless/z2m web UIs to trusted devices

### DIFF
--- a/hosts/Nexus/networking.nix
+++ b/hosts/Nexus/networking.nix
@@ -33,13 +33,29 @@
         443 # HTTPS (Caddy reverse proxy for all services)
       ]
       ++ config.services.openssh.ports
-      ++ [
-        config.services.paperless.port
-        config.services.zigbee2mqtt.settings.frontend.port
-      ]
       ++ lib.optionals config.services.nzbhydra2.enable [ 5076 ]
       ++ lib.optionals config.services.nzbget.enable [ 6789 ]
       ++ lib.unique (map (l: l.port) config.services.mosquitto.listeners);
+
+      # Admin web UIs (paperless, zigbee2mqtt, radarr, sonarr): trusted-device
+      # VLAN + WorkLaptop only. Guest and IoT VLANs and WAN are blocked.
+      # Tailnet bypasses via trustedInterfaces.
+      extraInputRules =
+        let
+          uiPorts = lib.concatMapStringsSep ", " toString [
+            config.services.paperless.port
+            config.services.zigbee2mqtt.settings.frontend.port
+            config.services.radarr.settings.server.port
+            config.services.sonarr.settings.server.port
+          ];
+        in
+        ''
+          ip saddr { 192.168.10.0/24, 192.168.20.143 } tcp dport { ${uiPorts} } accept
+        '';
+
+      # n8n's paperless agent tools call 28981 from inside the container;
+      # that traffic arrives via the podman bridge, not a trusted saddr.
+      interfaces."podman*".allowedTCPPorts = [ config.services.paperless.port ];
 
       # Allow HTTP/3 (QUIC) for Caddy
       allowedUDPPorts = [

--- a/hosts/Nexus/services/radarr.nix
+++ b/hosts/Nexus/services/radarr.nix
@@ -10,7 +10,7 @@
   services.radarr = {
     enable = true;
     group = "media";
-    openFirewall = true; # Direct port access (7878)
+    openFirewall = false; # tailnet + trusted-device rule in ../networking.nix
   };
 
   # Radarr requires PostgreSQL to be running

--- a/hosts/Nexus/services/sonarr.nix
+++ b/hosts/Nexus/services/sonarr.nix
@@ -10,7 +10,7 @@
   services.sonarr = {
     enable = true;
     group = "media";
-    openFirewall = true; # Direct port access (8989)
+    openFirewall = false; # tailnet + trusted-device rule in ../networking.nix
   };
 
   # Sonarr requires PostgreSQL to be running


### PR DESCRIPTION
Phase 4+6 of Nexus hardening — admin web UI exposure.

- radarr/sonarr `openFirewall = false`; paperless + zigbee2mqtt frontend ports removed from global `allowedTCPPorts`
- New nftables rule allows all four UI ports (28981, 8099, 7878, 8989 — resolved from service config options) from the trusted-device VLAN `192.168.10.0/24` + WorkLaptop's fixed IP `192.168.20.143` only; guest/IoT VLANs and WAN are blocked
- `podman*` interface exception for paperless — n8n's paperless agent tools call 28981 from inside the container via the podman bridge
- Tailnet access unchanged via `trustedInterfaces`
- radarr/sonarr capability overrides left untouched (import-chown history)

Verified: toplevel build green; merged `extraInputRules` eval correct.