### PR TITLE
fix(nexus): journal-recap first-run cursor handling

### DIFF
--- a/hosts/Nexus/services/journal-recap.nix
+++ b/hosts/Nexus/services/journal-recap.nix
@@ -10,6 +10,8 @@ let
   runtimeDeps = [
     pkgs.bash
     pkgs.coreutils
+    pkgs.gnused
+    pkgs.gnugrep
     pkgs.systemd
     pkgs.claude-code
     pkgs.telegram-notify

--- a/hosts/Nexus/services/journal-recap.sh
+++ b/hosts/Nexus/services/journal-recap.sh
@@ -16,10 +16,22 @@ set +a
 
 CURSOR_FILE="$STATE_DIRECTORY/cursor"
 
-# Cursor file = no gaps/overlaps between runs; --since only applies on the
-# first run, when the cursor file does not exist yet.
-ERRORS=$(journalctl -p err -q --no-pager -o short-iso \
-  --cursor-file="$CURSOR_FILE" --since "-6h" || true)
+# Cursor file = no gaps/overlaps between runs. journalctl (systemd 260)
+# refuses --cursor-file combined with --since, and a missing cursor file
+# means "from the beginning of the journal" - so the first run bounds the
+# window manually and saves the cursor itself.
+if [[ -f "$CURSOR_FILE" ]]; then
+  ERRORS=$(journalctl -p err -q --no-pager -o short-iso \
+    --cursor-file="$CURSOR_FILE")
+else
+  OUT=$(journalctl -p err -q --no-pager -o short-iso \
+    --since "-6h" --show-cursor)
+  CURSOR=$(printf '%s\n' "$OUT" | sed -n 's/^-- cursor: //p')
+  if [[ -n "$CURSOR" ]]; then
+    printf '%s\n' "$CURSOR" > "$CURSOR_FILE"
+  fi
+  ERRORS=$(printf '%s\n' "$OUT" | grep -v '^-- cursor:' || true)
+fi
 
 if [[ -z "$ERRORS" ]]; then
   exit 0


### PR DESCRIPTION
systemd 260 journalctl rejects `--cursor-file` combined with `--since` ("Please specify only one of..."), and a bare `--cursor-file` with a missing file reads from the beginning of the journal.

- First run: `--since -6h --show-cursor`, extract the `-- cursor:` trailer, write the cursor file manually.
- Subsequent runs: `--cursor-file` alone.
- Dropped the `|| true` that swallowed the journalctl failure, so the unit fails visibly instead of silently sending nothing.
- Added gnused/gnugrep to the unit PATH for the new extraction.

Verified on Nexus (read-only): `--show-cursor` trailer format parses, bare `--cursor-file` confirmed to start at journal head.