### PR TITLE
feat(nexus): mention admin on actionable journal digests

### DIFF
--- a/hosts/Nexus/services/journal-recap.nix
+++ b/hosts/Nexus/services/journal-recap.nix
@@ -16,13 +16,19 @@ let
     pkgs.claude-code
     pkgs.telegram-notify
   ];
+  alertMention = "@matteopacini";
   # End-to-end test run: same script, throwaway state dir (fresh cursor picks
   # up the last 6h; the real timer's cursor is untouched). Sends to the real
-  # channel. Needs sudo to read the agenix secrets.
+  # channel. Needs sudo to read the agenix secrets. Pass "alert" to force the
+  # mention path (tests ping-through-mute).
   journalRecapTest = pkgs.writeShellScriptBin "journal-recap-test" ''
     set -euo pipefail
+    if [[ "''${1:-}" == "alert" ]]; then
+      export FORCE_ALERT=1
+    fi
     export TELEGRAM_ENV_FILE=${envFile}
     export CLAUDE_ENV_FILE=${claudeEnvFile}
+    export ALERT_MENTION=${alertMention}
     STATE_DIRECTORY=$(${pkgs.coreutils}/bin/mktemp -d)
     export STATE_DIRECTORY
     export HOME=$STATE_DIRECTORY
@@ -46,6 +52,7 @@ in
         "HOME=%S/journal-recap"
         "TELEGRAM_ENV_FILE=${envFile}"
         "CLAUDE_ENV_FILE=${claudeEnvFile}"
+        "ALERT_MENTION=${alertMention}"
       ];
       ExecStart = "${pkgs.bash}/bin/bash ${./journal-recap.sh}";
     };

--- a/hosts/Nexus/services/journal-recap.sh
+++ b/hosts/Nexus/services/journal-recap.sh
@@ -45,7 +45,9 @@ Produce a Telegram-friendly digest, max 3000 characters, plain text only - no Ma
 2. Grouped findings: per unit, count and one representative message, deduplicated.
 3. "Worth a look": only things that need action, each with the next diagnostic command to run. You may run the allowed read-only commands (systemctl status, journalctl) to add context before deciding.
 
-If everything is routine noise (e.g. misclassified info logs from containers), say so in one line and keep the digest short.'
+If everything is routine noise (e.g. misclassified info logs from containers), say so in one line and keep the digest short.
+
+The very first line of your reply must be exactly ALERT if the "Worth a look" section contains anything actionable, otherwise exactly OK. The digest starts on the second line.'
 
 DIGEST=$(printf '%s\n' "$ERRORS" | claude -p "$PROMPT" \
   --model sonnet \
@@ -56,14 +58,32 @@ DIGEST=$(printf '%s\n' "$ERRORS" | claude -p "$PROMPT" \
   ) || DIGEST=""
 
 if [[ -z "$DIGEST" ]]; then
+  STATUS="ALERT" # pipeline failure is always worth a ping
   DIGEST="claude digest failed, raw errors:
 $ERRORS"
+else
+  STATUS=$(printf '%s' "$DIGEST" | head -n 1 | tr -d '[:space:]')
+  case "$STATUS" in
+    ALERT | OK) DIGEST=$(printf '%s' "$DIGEST" | tail -n +2) ;;
+    *) STATUS="ALERT" ;; # claude ignored the marker - assume actionable
+  esac
+fi
+
+if [[ -n "${FORCE_ALERT:-}" ]]; then
+  STATUS="ALERT"
+fi
+
+# Group mute can't be bypassed by the Bot API, but Telegram clients notify on
+# @mentions even in muted groups - so actionable digests mention the admin.
+MENTION=""
+if [[ "$STATUS" == "ALERT" && -n "${ALERT_MENTION:-}" ]]; then
+  MENTION=" $ALERT_MENTION"
 fi
 
 # telegram-notify sends with parse_mode=Markdown; strip characters that can
 # break Telegram's parser, and respect the 4096-char message cap.
 DIGEST=$(printf '%s' "$DIGEST" | tr -d '*_`[]')
 
-telegram-notify "⚠️ Nexus journal recap
+telegram-notify "⚠️ Nexus journal recap$MENTION
 
 ${DIGEST:0:3800}"


### PR DESCRIPTION
Group mute can't be bypassed via the Bot API, but Telegram clients notify on @mentions even in muted groups. So:

- Claude now prefixes its digest with a first line of exactly `ALERT` or `OK`.
- `ALERT` (or a pipeline failure, or an ignored marker) puts `@matteopacini` in the message header; `OK` digests stay mention-free so the muted group stays quiet.
- `journal-recap-test alert` forces the mention path end-to-end to verify ping-through-mute; plain `journal-recap-test` is unchanged.
- Handle configured in journal-recap.nix (`alertMention`), passed to the script via the unit environment.