### PR TITLE
feat(nexus): harden journal-recap systemd service

### DIFF
--- a/hosts/Nexus/services/journal-recap.nix
+++ b/hosts/Nexus/services/journal-recap.nix
@@ -47,14 +47,65 @@ in
     serviceConfig = {
       Type = "oneshot";
       StateDirectory = "journal-recap";
-      # Keep claude's config/cache out of /root
+      TimeoutStartSec = "15min"; # oneshot runtime cap (claude hang guard)
+
+      # Unprivileged: secrets are loaded by systemd (as root) and exposed
+      # read-only via the credentials directory (%d); journal access comes
+      # from the systemd-journal group instead of running as root.
+      DynamicUser = true;
+      SupplementaryGroups = [ "systemd-journal" ];
+      LoadCredential = [
+        "janitor.env:${envFile}"
+        "claude.env:${claudeEnvFile}"
+      ];
+
+      # %S = /var/lib, %d = credentials directory
       Environment = [
-        "HOME=%S/journal-recap"
-        "TELEGRAM_ENV_FILE=${envFile}"
-        "CLAUDE_ENV_FILE=${claudeEnvFile}"
+        "HOME=%S/journal-recap" # keep claude's config/cache in the state dir
+        "TELEGRAM_ENV_FILE=%d/janitor.env"
+        "CLAUDE_ENV_FILE=%d/claude.env"
         "ALERT_MENTION=${alertMention}"
       ];
       ExecStart = "${pkgs.bash}/bin/bash ${./journal-recap.sh}";
+
+      # Hardening. Notes:
+      # - io_uring_* must be allowed explicitly: claude is a Bun binary and
+      #   Bun uses io_uring on Linux; @system-service does not include it.
+      # - No PrivateUsers/ProcSubset: PrivateUsers breaks the
+      #   systemd-journal group mapping; ProcSubset=pid hides /proc/meminfo
+      #   from the JS runtime.
+      # - No MemoryDenyWriteExecute: Bun JIT needs W^X.
+      CapabilityBoundingSet = "";
+      LockPersonality = true;
+      MemoryMax = "2G";
+      NoNewPrivileges = true;
+      PrivateDevices = true;
+      PrivateTmp = true;
+      ProtectClock = true;
+      ProtectControlGroups = true;
+      ProtectHome = true;
+      ProtectHostname = true;
+      ProtectKernelLogs = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      ProtectProc = "invisible";
+      ProtectSystem = "strict";
+      RestrictAddressFamilies = [
+        "AF_UNIX"
+        "AF_INET"
+        "AF_INET6"
+      ];
+      RestrictNamespaces = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      SystemCallArchitectures = "native";
+      SystemCallFilter = [
+        "@system-service"
+        "io_uring_setup"
+        "io_uring_enter"
+        "io_uring_register"
+      ];
+      UMask = "0077";
     };
   };
 


### PR DESCRIPTION
Baseline `systemd-analyze security`: **9.6 UNSAFE** (root, no confinement).

- `DynamicUser=true` + `LoadCredential=` — systemd loads the agenix secrets as root, exposes them read-only via the credentials directory (`%d`); service runs as a throwaway unprivileged user.
- `SupplementaryGroups=systemd-journal` — journal read without root.
- Standard confinement: `ProtectSystem=strict`, `ProtectHome`, `PrivateTmp`/`PrivateDevices`, `ProtectKernel*`, `ProtectProc=invisible`, `CapabilityBoundingSet=""`, `NoNewPrivileges`, `RestrictAddressFamilies`, `RestrictNamespaces`, `RestrictSUIDSGID`, `RestrictRealtime`, `LockPersonality`, `SystemCallArchitectures=native`, `UMask=0077`, `MemoryMax=2G`, `TimeoutStartSec=15min` (oneshot hang guard).
- `SystemCallFilter=@system-service` + explicit `io_uring_{setup,enter,register}` — claude is a Bun binary; verified on Nexus that `@system-service` contains no io_uring syscalls.
- Deliberately omitted: `MemoryDenyWriteExecute` (Bun JIT), `PrivateUsers` (breaks systemd-journal group mapping), `ProcSubset=pid` (hides /proc/meminfo from the runtime).
- `journal-recap-test` unaffected — runs outside the unit with direct secret paths.

Post-deploy verification: `sudo systemctl start journal-recap.service`, check logs for EPERM, re-run `systemd-analyze security`.