### PR TITLE
feat(brightfalls): scrcpy phone mirroring with mDNS discovery

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,22 +57,6 @@
         "type": "github"
       }
     },
-    "caveman-skills": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1781272264,
-        "narHash": "sha256-FbmfhFaPs/SnSZdfNdErdIUHXt1FfBzErpPpLy8kdIc=",
-        "owner": "JuliusBrussee",
-        "repo": "caveman",
-        "rev": "25d22f864ad68cc447a4cb93aefde918aa4aec9f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "JuliusBrussee",
-        "repo": "caveman",
-        "type": "github"
-      }
-    },
     "cl-nix-lite": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -393,22 +377,6 @@
         "type": "github"
       }
     },
-    "matteo-skills": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1775924021,
-        "narHash": "sha256-Q0AuLLfwEvuJ+ZD9wgbD0rzl/yWhj6z+Pi5jJQto4AI=",
-        "owner": "matteo-pacini",
-        "repo": "skills",
-        "rev": "9d47600aefb5141c57a2bfcff743706f19943314",
-        "type": "github"
-      },
-      "original": {
-        "owner": "matteo-pacini",
-        "repo": "skills",
-        "type": "github"
-      }
-    },
     "mnw": {
       "locked": {
         "lastModified": 1778541201,
@@ -666,7 +634,6 @@
       "inputs": {
         "agenix": "agenix",
         "bore-scheduler-src": "bore-scheduler-src",
-        "caveman-skills": "caveman-skills",
         "colorls-dracula-theme": "colorls-dracula-theme",
         "disko": "disko",
         "dracula-wallpaper": "dracula-wallpaper",
@@ -675,7 +642,6 @@
         "homebrew-cask": "homebrew-cask",
         "homebrew-core": "homebrew-core",
         "mac-app-util": "mac-app-util",
-        "matteo-skills": "matteo-skills",
         "nix-darwin": "nix-darwin",
         "nix-homebrew": "nix-homebrew",
         "nix-index-database": "nix-index-database",

--- a/flake.nix
+++ b/flake.nix
@@ -141,6 +141,7 @@
           ./modules/home-manager/starship.nix
           ./modules/home-manager/wezterm.nix
           ./modules/home-manager/claude-code.nix
+          ./modules/home-manager/phone-scrcpy.nix
           ./modules/home-manager/mpv
         ];
       };

--- a/hosts/Brightfalls/services.nix
+++ b/hosts/Brightfalls/services.nix
@@ -80,6 +80,10 @@ in
 
   services.fwupd.enable = true;
 
+  # mDNS discovery for phone mirroring (custom.phone.scrcpy);
+  # GNOME already enables avahi, this just makes the dependency explicit
+  services.avahi.enable = true;
+
   # fwupd-refresh.service runs as the sessionless `fwupd-refresh` user,
   # and refresh-remote defaults to auth_admin outside an active session,
   # so polkit denies it ("Failed to obtain auth") without this rule

--- a/hosts/Brightfalls/users/matteo/default.nix
+++ b/hosts/Brightfalls/users/matteo/default.nix
@@ -67,6 +67,7 @@
   custom.zellij.enable = true;
   custom.starship.enable = true;
   custom.claude-code.enable = true;
+  custom.phone.scrcpy.enable = true;
   custom.mpv.enable = true;
   custom.mpv.jellyfinShim.enable = true;
 

--- a/modules/home-manager/phone-scrcpy.nix
+++ b/modules/home-manager/phone-scrcpy.nix
@@ -1,0 +1,61 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.custom.phone.scrcpy;
+
+  # Wireless debugging randomizes its port per session, so resolve the
+  # phone's address via mDNS on every launch instead of hardcoding it.
+  phone-mirror = pkgs.writeShellScriptBin "phone-mirror" ''
+    set -u
+    export PATH=${
+      lib.makeBinPath [
+        pkgs.avahi
+        pkgs.android-tools
+        pkgs.scrcpy
+        pkgs.libnotify
+        pkgs.gawk
+      ]
+    }:$PATH
+
+    ADDR=$(avahi-browse -rpt _adb-tls-connect._tcp 2>/dev/null \
+      | awk -F';' '/^=/ && $3=="IPv4" {print $8":"$9; exit}')
+
+    if [ -z "$ADDR" ]; then
+      notify-send "Phone mirror" "Phone not found — enable Wireless debugging"
+      exit 1
+    fi
+
+    adb connect "$ADDR" >/dev/null
+    exec scrcpy -s "$ADDR" \
+      --turn-screen-off \
+      --stay-awake \
+      --power-off-on-close \
+      --window-title "Phone"
+  '';
+in
+{
+  options.custom.phone.scrcpy = {
+    enable = lib.mkEnableOption "scrcpy phone mirroring with mDNS discovery";
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [
+      phone-mirror
+      pkgs.scrcpy
+      pkgs.android-tools
+    ];
+
+    xdg.desktopEntries.phone-mirror = {
+      name = "Phone Mirror";
+      comment = "Mirror the phone via scrcpy";
+      exec = "phone-mirror";
+      icon = "phone";
+      terminal = false;
+      categories = [ "Utility" ];
+    };
+  };
+}


### PR DESCRIPTION
Adds a `custom.phone.scrcpy.enable` home-manager module providing a `phone-mirror` script (plus a desktop entry) that discovers the phone's Wireless-debugging address via `avahi-browse` (the port is randomized per session), connects with adb, and mirrors it with `scrcpy --turn-screen-off --stay-awake --power-off-on-close`.

Enabled only for matteo on BrightFalls. Also enables `services.avahi` explicitly on BrightFalls — currently redundant (GNOME already pulls it in; store path is unchanged) but makes the module's dependency explicit.