### PR TITLE
feat(nexus): push PR builds to attic cache for merge cache hits

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -120,3 +120,15 @@ jobs:
           # 0.38.0 (pulled in 2026-05-27) uses the unstable cfg_select! macro.
           nix run github:faukah/dix/v1.4.2 -- ./old-result ./result >> "$GITHUB_STEP_SUMMARY" || true
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      # Cache the PR's candidate toplevel so the post-merge master build in
+      # build.yml is a cache hit. Chunks dedup globally with what build.yml
+      # already pushed, so this costs only the PR's delta; merged paths get
+      # re-pinned by build.yml, abandoned-PR paths age out under GC retention.
+      - uses: nick-fields/retry@v4
+        name: Push new configuration
+        with:
+          timeout_minutes: 60
+          max_attempts: 5
+          retry_on: error
+          command: nix run nixpkgs#attic-client -- push main result -j 3

--- a/docs/nexus/attic-cache-handbook.md
+++ b/docs/nexus/attic-cache-handbook.md
@@ -375,3 +375,4 @@ Other synced machines pick up the atuin tombstones on their next sync.
 | 2026-06-10 | `attic-client` removed from systemPackages; push script + `wipe-user-nix-config.sh` added (#285) |
 | 2026-06-10 | BrightFalls adopted the cache (#286) |
 | 2026-06-10 | Push script generalized to `attic-push-closure`, defined once in `modules/shared/` (#287) |
+| 2026-06-13 | `pr-build.yml` pushes the PR candidate toplevel to `main` so post-merge master builds are cache hits (#304) |

--- a/docs/nexus/attic-cache-handbook.md
+++ b/docs/nexus/attic-cache-handbook.md
@@ -207,6 +207,17 @@ log in with the `ATTIC_TOKEN` repository secret and push build results
 to `main`. The login alias is hardcoded; there is no
 `ATTIC_CACHE_NAME` secret.
 
+`pr-build.yml` pushes the PR's candidate toplevel (`result`) so the
+post-merge master build in `build.yml` is a cache hit rather than a
+full rebuild. Because attic dedups chunks globally, this adds only the
+PR's delta over what `build.yml` already pushed — not a second copy of
+the closure. Merged paths get re-pinned by `build.yml`; abandoned-PR
+paths carry no special retention and simply age out under the
+server-wide GC window. This is why a separate short-retention "PR
+cache" was not created: global dedup already makes the second push
+disk-cheap, and a second cache would only add a substituter lookup per
+build plus its own token and upkeep.
+
 ## Cache Administration (on Nexus)
 
 ### One-shot authenticated admin session


### PR DESCRIPTION
## What

`pr-build.yml` now pushes the PR's candidate toplevel (`result`) to the `main` attic cache after the diff step, mirroring the retry-wrapped push already used in `build.yml`.

## Why

Previously `pr-build.yml` only ran `attic use main` (pull) — it never pushed. So when a PR merged, `build.yml` rebuilt the toplevel from scratch on master. Pushing the candidate toplevel makes that post-merge build a **cache hit**.

Global chunk dedup means the PR push costs only the PR's delta over what `build.yml` already pushed — not a second copy of the closure. Merged paths get re-pinned by `build.yml`; abandoned-PR paths carry no special retention and age out under the existing GC window.

## Why not a separate low-retention PR cache

Considered and rejected: global dedup already makes the second push disk-cheap, so a dedicated cache would only add a substituter lookup per build plus its own token and upkeep, for the marginal benefit of expiring abandoned-PR objects on a shorter clock. Documented in the handbook.

## Notes

- The handbook previously claimed all three workflows push; this PR makes that true and documents the `pr-build.yml` rationale.
- No token changes: the CI `ATTIC_TOKEN` already has `--push main`.