### PR TITLE
chore(claude-code): drop fable aliases, tune model delegation

### DIFF
--- a/modules/home-manager/claude-code.nix
+++ b/modules/home-manager/claude-code.nix
@@ -14,13 +14,6 @@ let
   # a full model ID (e.g. "claude-opus-4-8") when you need a specific version.
   # Empty list = model does not support --effort.
   modelEfforts = {
-    fable = [
-      "low"
-      "medium"
-      "high"
-      "xhigh"
-      "max"
-    ];
     opus = [
       "low"
       "medium"
@@ -55,7 +48,6 @@ let
   # (`claude-<slug>` and `claude-<slug>-<effort>`). Pinned IDs get a compact
   # slug to avoid dash ambiguity with the effort suffix.
   modelAliasSlug = {
-    fable = "fable";
     opus = "opus";
     sonnet = "sonnet";
     haiku = "haiku";
@@ -68,7 +60,6 @@ let
   # When true, an additional set of `claude-<slug>-1m[-<effort>]` aliases is
   # generated, invoking the model with the `[1m]` suffix.
   model1mContext = {
-    fable = true;
     opus = true;
     sonnet = true;
     haiku = false;

--- a/modules/home-manager/claude-code/claude-md/04-model-delegation.md
+++ b/modules/home-manager/claude-code/claude-md/04-model-delegation.md
@@ -1,27 +1,27 @@
 ## Model delegation
 
-Guidance last updated 12/06/2026. If this is clearly out of date or
+Guidance last updated 13/06/2026. If this is clearly out of date or
 you know a better current option, prefer that over this section.
 
 When spawning subagents or choosing a model for a task:
 
 | Task | Model |
 |------|-------|
-| Orchestration, multi-agent coordination | fable |
+| Orchestration, multi-agent coordination | opus (xhigh) |
 | Hardest bugs, architecture, security review, deep planning | opus |
 | Normal coding, tests, refactors, intermediate reasoning | sonnet |
 | Search, file discovery, mechanical edits, summaries | haiku |
 
-- Fable leaves coding plans on 22/06/2026 — when unavailable,
-  orchestrate with opus at xhigh effort (the `best` alias encodes
-  this fallback).
 - Use aliases, never pinned model IDs — pinned IDs fail when models
   retire.
-- Effort: default is high; use xhigh for hard agentic coding; avoid
-  max (diminishing returns, overthinking); low for simple subagents.
+- Effort: default is high; sonnet's balanced default is medium (bump
+  to high only when needed); use xhigh for hard agentic coding (opus
+  only — sonnet has no xhigh); avoid max (diminishing returns,
+  overthinking); low for simple subagents.
 - Haiku has no effort parameter and a 200K context window.
 - Plan with opus, execute with sonnet when cost matters (`opusplan`
-  automates this).
+  automates this). Switching model mid-session costs one full
+  uncached context re-read — don't switch frivolously.
 - Before acting on web-research or multi-source claims, spawn one
   opus skeptic prompted to refute them; drop anything refuted or
   unverifiable. Skip for trivial lookups or primary-doc reads.


### PR DESCRIPTION
## What

- **Drop Fable model** from the Claude Code alias generator (account lost access). Removes `fable` from `modelEfforts`, `modelAliasSlug`, `model1mContext` → no more `claude-fable*` shell aliases. Orchestration row in the delegation guidance now `opus (xhigh)`.
- **Tune model-delegation guidance** in `04-model-delegation.md` against current Anthropic docs (June 2026, opus-vetted):
  - sonnet's balanced default = `medium`; sonnet has no `xhigh`
  - note: switching model mid-session costs one full uncached context re-read

## Verification

- `nix eval .#nixosConfigurations.BrightFalls...toplevel` → clean
- 0 `claude-fable*` aliases remain (45 `claude-*` aliases total)
- opus/sonnet/haiku effort + 1M-context maps already matched docs — unchanged

Guidance changes confirmed against primary docs (effort levels, `low`=subagents, `opusplan` official, sonnet no-xhigh). Dropped unverifiable blog claims (opusplan % savings, "Fable for orchestration", Fable-vs-Opus benchmark pairings).