### PR TITLE
feat(nix-core): scheduled GC + store optimisation across all hosts

### DIFF
--- a/hosts/Brightfalls/default.nix
+++ b/hosts/Brightfalls/default.nix
@@ -46,6 +46,7 @@
     efiSupport = true;
     device = "nodev";
     memtest86.enable = pkgs.stdenv.hostPlatform.isx86;
+    configurationLimit = 5;
   };
   boot.loader.efi.canTouchEfiVariables = true;
 

--- a/hosts/CauldronLake/hardware.nix
+++ b/hosts/CauldronLake/hardware.nix
@@ -28,6 +28,7 @@
     efiSupport = true;
     device = "nodev";
     memtest86.enable = true;
+    configurationLimit = 5;
   };
   boot.loader.efi.canTouchEfiVariables = true;
 

--- a/hosts/Nexus/default.nix
+++ b/hosts/Nexus/default.nix
@@ -33,6 +33,7 @@
     # First SSD
     device = "/dev/disk/by-id/ata-CT2000MX500SSD1_2308E6B0D773";
     memtest86.enable = true;
+    configurationLimit = 5;
   };
 
   environment.systemPackages = with pkgs; [

--- a/hosts/Nexus/storage-tuning.nix
+++ b/hosts/Nexus/storage-tuning.nix
@@ -23,4 +23,12 @@
     max-jobs = 8;
     cores = 8;
   };
+
+  # Always-on host: fixed daily GC/optimise instead of the weekly module
+  # default, staggered after the backup timer cluster (~03:00–07:00) to
+  # avoid root-SSD vs /diskpool I/O contention. Shorter retention since
+  # daily local rebuilds churn /nix/store (separate fs from the attic pool).
+  custom.nix-core.gc.deleteOlderThan = "14d";
+  nix.gc.dates = "*-*-* 08:00:00";
+  nix.optimise.dates = [ "*-*-* 09:00:00" ];
 }

--- a/hosts/WorkLaptop/default.nix
+++ b/hosts/WorkLaptop/default.nix
@@ -12,6 +12,8 @@
 
   custom.nix-core = {
     enable = true;
+    # Disk-pressured work SSD: stricter retention than the 30d default.
+    gc.deleteOlderThan = "7d";
     trustedUsers = [
       "@admin"
     ];
@@ -20,6 +22,13 @@
       enable = true;
       netrcFile = config.age.secrets."worklaptop/attic-netrc".path;
     };
+  };
+
+  # Free disk mid-build when it runs low (platform-agnostic daemon GC),
+  # complementing the weekly scheduled GC on this space-constrained host.
+  nix.settings = {
+    min-free = 3221225472; # 3 GiB
+    max-free = 10737418240; # 10 GiB
   };
 
   custom.fonts.enable = true;

--- a/modules/darwin/nix-core.nix
+++ b/modules/darwin/nix-core.nix
@@ -16,6 +16,11 @@ in
 {
   options.custom.nix-core = {
     enable = lib.mkEnableOption "Shared Nix and Nixpkgs configuration for Darwin hosts";
+    gc.deleteOlderThan = lib.mkOption {
+      type = lib.types.str;
+      default = "30d";
+      description = "Age passed to nix-collect-garbage --delete-older-than.";
+    };
     trustedUsers = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ "root" ];
@@ -52,6 +57,32 @@ in
           };
         };
         nixpkgs.config.allowUnfree = true;
+      }
+      {
+        # Scheduled GC + store optimisation via launchd. Darwin has no
+        # dates/persistent/randomizedDelaySec (removed options); launchd
+        # coalesces a missed calendar job and fires it once on next wake.
+        nix.gc = {
+          automatic = true;
+          interval = lib.mkDefault [
+            {
+              Weekday = 7;
+              Hour = 4;
+              Minute = 0;
+            }
+          ];
+          options = "--delete-older-than ${cfg.gc.deleteOlderThan}";
+        };
+        nix.optimise = {
+          automatic = true;
+          interval = lib.mkDefault [
+            {
+              Weekday = 7;
+              Hour = 5;
+              Minute = 0;
+            }
+          ];
+        };
       }
       # System-level so the substituter applies to every user (the
       # nix-daemon performs all downloads), with no flake nixConfig

--- a/modules/nixos/nix-core.nix
+++ b/modules/nixos/nix-core.nix
@@ -16,6 +16,11 @@ in
 {
   options.custom.nix-core = {
     enable = lib.mkEnableOption "Shared Nix and Nixpkgs configuration for NixOS hosts";
+    gc.deleteOlderThan = lib.mkOption {
+      type = lib.types.str;
+      default = "30d";
+      description = "Age passed to nix-collect-garbage --delete-older-than.";
+    };
     trustedUsers = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ "root" ];
@@ -58,6 +63,23 @@ in
           };
         };
         nixpkgs.config.allowUnfree = true;
+      }
+      {
+        # Scheduled garbage collection + store optimisation. persistent so
+        # intermittent hosts catch up a missed timer on next boot; jitter
+        # softens the post-boot I/O spike. Hosts override dates/retention.
+        nix.gc = {
+          automatic = true;
+          dates = lib.mkDefault "Sun 04:00";
+          options = "--delete-older-than ${cfg.gc.deleteOlderThan}";
+          persistent = true;
+          randomizedDelaySec = "30min";
+        };
+        nix.optimise = {
+          automatic = true;
+          dates = lib.mkDefault [ "Sun 05:00" ];
+          randomizedDelaySec = "30min";
+        };
       }
       (lib.mkIf (cfg.extraPlatforms != [ ]) {
         nix.settings.extra-platforms = cfg.extraPlatforms;


### PR DESCRIPTION
## What

Adds automatic Nix garbage collection and store optimisation to every host. Previously nothing was automated — only a manual `nix-gc` zsh alias.

Native `nix.gc` + `nix.optimise` (not `nh`) live in the shared `custom.nix-core` modules, with a single per-host retention knob `custom.nix-core.gc.deleteOlderThan` (default `30d`). Tuned per host power profile / disk pressure.

## Per-host

| Host | Retention | Schedule | Extra |
|------|-----------|----------|-------|
| Nexus | 14d | daily 08:00 GC / 09:00 optimise (after backup window) | `configurationLimit=5` |
| BrightFalls | 30d | weekly Sun (persistent catch-up) | `configurationLimit=5` |
| CauldronLake | 30d | weekly Sun (persistent catch-up) | `configurationLimit=5` |
| NightSprings | 30d | weekly Sun (launchd) | — |
| WorkLaptop | 7d | weekly Sun (launchd) | `min-free` 3 GiB / `max-free` 10 GiB |

## Notes

- NixOS uses `nix.gc.dates`/`persistent`/`randomizedDelaySec` (intermittent hosts catch up a missed timer on next boot). Darwin uses launchd `interval` — the other three options are `mkRemovedOptionModule` on nix-darwin and would hard-error.
- `--delete-older-than` keeps the current generation **and** the generation active at the cutoff, so ≥1 rollback generation is always retained.
- `min-free`/`max-free` on WorkLaptop trigger reactive GC mid-build when disk runs low; respects gc roots (direnv devshells safe).
- `auto-optimise-store` deliberately unset (store-corruption history; scheduled `nix.optimise` does a single batch pass).
- Manual `nix-gc` alias kept for emergencies.

## Verification

All 5 configs eval clean (`nix eval ...config.system.build.toplevel`): Nexus, BrightFalls, CauldronLake (build), NightSprings, WorkLaptop (foreign-platform eval).