### PR TITLE
feat(brightfalls): package optiscaler-client Avalonia GUI

### DIFF
--- a/hosts/Brightfalls/users/matteo/default.nix
+++ b/hosts/Brightfalls/users/matteo/default.nix
@@ -58,6 +58,7 @@
       bottles
       pcsx2
       reshade-steam-proton
+      optiscaler-client
       heroic
       # Other
       discord

--- a/overlays/brightfalls.nix
+++ b/overlays/brightfalls.nix
@@ -11,6 +11,7 @@ let
 in
 {
   reshade-steam-proton = super.callPackage ../packages/reshade-steam-proton.nix { };
+  optiscaler-client = super.callPackage ../packages/optiscaler-client.nix { };
 
   qemu = optimizedForBrightFalls (
     super.qemu.override ({

--- a/packages/optiscaler-client-deps.json
+++ b/packages/optiscaler-client-deps.json
@@ -1,0 +1,152 @@
+[
+  {
+    "pname": "Avalonia",
+    "version": "11.3.12",
+    "hash": "sha256-T2y8aoKUSfXqmV2RL1QStytzJkc/SZYfIdJihB5UWR0="
+  },
+  {
+    "pname": "Avalonia.Angle.Windows.Natives",
+    "version": "2.1.25547.20250602",
+    "hash": "sha256-LE/lENAHptmz6t3T/AoJwnhpda+xs7PqriNGzdcfg8M="
+  },
+  {
+    "pname": "Avalonia.BuildServices",
+    "version": "11.3.2",
+    "hash": "sha256-6wx06tjSKWQOlX2czdp6Wh0nuwVapx5qf/s8Qj5we40="
+  },
+  {
+    "pname": "Avalonia.Controls.ColorPicker",
+    "version": "11.3.12",
+    "hash": "sha256-zNpmfOTfw+gKZp8VPpfHe2hjqhrRmExf7lxqLf5OvDg="
+  },
+  {
+    "pname": "Avalonia.Desktop",
+    "version": "11.3.12",
+    "hash": "sha256-IY6TkpVh0GiCkKbestdwH8KEJ0Embxy+JYe7lww0xBA="
+  },
+  {
+    "pname": "Avalonia.Diagnostics",
+    "version": "11.3.12",
+    "hash": "sha256-iDH6DjRKqm4YLXBq2JGg9IkkEGm3Rq1FQWyr/L+VaVA="
+  },
+  {
+    "pname": "Avalonia.Fonts.Inter",
+    "version": "11.3.12",
+    "hash": "sha256-yr4/zpUbmQuVzdupV5v87qNO24sPOVhnnJ1SeiLxMx8="
+  },
+  {
+    "pname": "Avalonia.FreeDesktop",
+    "version": "11.3.12",
+    "hash": "sha256-NTcYVHn13lFQjTNezmpmPGjxsBzryXorK0K6hl4ZZto="
+  },
+  {
+    "pname": "Avalonia.Native",
+    "version": "11.3.12",
+    "hash": "sha256-1ujLmYaL1zTgtlsNerBDtTuoaJX7c7HukNLJIalrB4Q="
+  },
+  {
+    "pname": "Avalonia.Remote.Protocol",
+    "version": "11.3.12",
+    "hash": "sha256-dF93nP1Cd7ZdzrO7ScGHchxYxCjWN45AjiqiO1J+cmU="
+  },
+  {
+    "pname": "Avalonia.Skia",
+    "version": "11.3.12",
+    "hash": "sha256-gRMjH7igRIm22zQV0WxtwFHe8AiMTcaPlR0sC5lJy+w="
+  },
+  {
+    "pname": "Avalonia.Themes.Fluent",
+    "version": "11.3.12",
+    "hash": "sha256-4TTsW7zLF0Z9C1lzPsPfekHpHrSx7RB7I63j/cKUX8U="
+  },
+  {
+    "pname": "Avalonia.Themes.Simple",
+    "version": "11.3.12",
+    "hash": "sha256-EIuAcUmoL7/y4lUfdSg120/l/v3zQytC2rfr0b6jKiM="
+  },
+  {
+    "pname": "Avalonia.Win32",
+    "version": "11.3.12",
+    "hash": "sha256-haIKvJ1SD17+EUJHILoFJMy+WJJtXr9I+ZYMFtwEuTc="
+  },
+  {
+    "pname": "Avalonia.X11",
+    "version": "11.3.12",
+    "hash": "sha256-SEc0GaZTh1eGNFWHT6lGiN6LD0qE+ubTK7Efl0H/Q2w="
+  },
+  {
+    "pname": "HarfBuzzSharp",
+    "version": "8.3.1.1",
+    "hash": "sha256-614yv6bK9ynhdUnvW4wIkgpBe2sqTh28U9cDZzdhPc0="
+  },
+  {
+    "pname": "HarfBuzzSharp.NativeAssets.Linux",
+    "version": "8.3.1.1",
+    "hash": "sha256-sBbez6fc9axVcsBbIHbpQh/MM5NHlMJgSu6FyuZzVyU="
+  },
+  {
+    "pname": "HarfBuzzSharp.NativeAssets.macOS",
+    "version": "8.3.1.1",
+    "hash": "sha256-hK20KbX2OpewIO5qG5gWw5Ih6GoLcIDgFOqCJIjXR/Q="
+  },
+  {
+    "pname": "HarfBuzzSharp.NativeAssets.WebAssembly",
+    "version": "8.3.1.1",
+    "hash": "sha256-mLKoLqI47ZHXqTMLwP1UCm7faDptUfQukNvdq6w/xxw="
+  },
+  {
+    "pname": "HarfBuzzSharp.NativeAssets.Win32",
+    "version": "8.3.1.1",
+    "hash": "sha256-Um4iwLdz9XtaDSAsthNZdev6dMiy7OBoHOrorMrMYyo="
+  },
+  {
+    "pname": "MicroCom.Runtime",
+    "version": "0.11.0",
+    "hash": "sha256-VdwpP5fsclvNqJuppaOvwEwv2ofnAI5ZSz2V+UEdLF0="
+  },
+  {
+    "pname": "SharpCompress",
+    "version": "0.44.5",
+    "hash": "sha256-aukmJzrgVS2hugVUNH+FHJuaC2VomBNFy6g8furI3tE="
+  },
+  {
+    "pname": "SkiaSharp",
+    "version": "2.88.9",
+    "hash": "sha256-jZ/4nVXYJtrz9SBf6sYc/s0FxS7ReIYM4kMkrhZS+24="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Linux",
+    "version": "2.88.9",
+    "hash": "sha256-mQ/oBaqRR71WfS66mJCvcc3uKW7CNEHoPN2JilDbw/A="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.macOS",
+    "version": "2.88.9",
+    "hash": "sha256-qvGuAmjXGjGKMzOPBvP9VWRVOICSGb7aNVejU0lLe/g="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.WebAssembly",
+    "version": "2.88.9",
+    "hash": "sha256-vgFL4Pdy3O1RKBp+T9N3W4nkH9yurZ0suo8u3gPmmhY="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Win32",
+    "version": "2.88.9",
+    "hash": "sha256-kP5XM5GgwHGfNJfe4T2yO5NIZtiF71Ddp0pd1vG5V/4="
+  },
+  {
+    "pname": "System.CodeDom",
+    "version": "10.0.0",
+    "hash": "sha256-ffMXe35XVE49Gd6bbz2QRmTkCDeTuSnGYfKTZ6/MtS8="
+  },
+  {
+    "pname": "System.Management",
+    "version": "10.0.0",
+    "hash": "sha256-Nh3KOlsv6AxGkrWiHhuuTbRuIi2tp13NrbBwgQgKuSg="
+  },
+  {
+    "pname": "Tmds.DBus.Protocol",
+    "version": "0.21.2",
+    "hash": "sha256-gaK/5aAummyin6ptnhaJbnA0ih4+2xADrtrLfFbHwYI="
+  }
+]

--- a/packages/optiscaler-client.nix
+++ b/packages/optiscaler-client.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  buildDotnetModule,
+  fetchFromGitHub,
+  dotnetCorePackages,
+  copyDesktopItems,
+  makeDesktopItem,
+
+  # Avalonia 11 runtime libs (dlopen-ed → wrapped into LD_LIBRARY_PATH).
+  libx11,
+  libice,
+  libsm,
+  libxi,
+  libxcursor,
+  libxext,
+  libxrandr,
+  fontconfig,
+  glew,
+  libGL,
+}:
+
+buildDotnetModule (finalAttrs: {
+  pname = "optiscaler-client";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "Agustinm28";
+    repo = "Optiscaler-Client";
+    rev = "5072a0761bb6dfbf7e52cc9e4b5c0cde49e1d209";
+    hash = "sha256-1Cs6DHR7f5MtklmKY96+uOi4esFP2VkAWsR/j9bwdqs=";
+  };
+
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.runtime_10_0;
+
+  nugetDeps = ./optiscaler-client-deps.json;
+
+  projectFile = [ "OptiscalerClient.csproj" ];
+
+  # Pin a single RID so deps are gathered for linux-x64 only.
+  runtimeId = "linux-x64";
+
+  # csproj forces self-contained single-file publish (PublishSingleFile /
+  # SelfContained / PublishReadyToRun / EnableCompressionInSingleFile), which
+  # fights buildDotnetModule's framework-dependent model. Neutralize them.
+  dotnetFlags = [
+    "-p:PublishSingleFile=false"
+    "-p:SelfContained=false"
+    "-p:PublishReadyToRun=false"
+    "-p:EnableCompressionInSingleFile=false"
+  ];
+
+  executables = [ "OptiscalerClient" ];
+
+  nativeBuildInputs = [ copyDesktopItems ];
+
+  # Avalonia desktop on Linux dlopens these at runtime.
+  # libGL = GPU rendering (software fallback without it); X11 set + fontconfig
+  # for windowing/text; glew for GL extension loading.
+  runtimeDeps = [
+    libx11
+    libice
+    libsm
+    libxi
+    libxcursor
+    libxext
+    libxrandr
+    fontconfig
+    glew
+    libGL
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "OptiscalerClient";
+      exec = "OptiscalerClient";
+      icon = "OptiscalerClient";
+      desktopName = "OptiScaler Client";
+      comment = finalAttrs.meta.description;
+      categories = [ "Utility" ];
+      terminal = false;
+    })
+  ];
+
+  postInstall = ''
+    install -Dm644 assets/icon.png \
+      $out/share/icons/hicolor/256x256/apps/OptiscalerClient.png
+  '';
+
+  meta = {
+    description = "Desktop GUI for installing, managing, and updating the OptiScaler upscaling mod across a game library";
+    homepage = "https://github.com/Agustinm28/Optiscaler-Client";
+    license = lib.licenses.gpl3Plus;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "OptiscalerClient";
+  };
+})


### PR DESCRIPTION
Packages [Optiscaler-Client](https://github.com/Agustinm28/Optiscaler-Client) — a .NET 10 / Avalonia 11 desktop GUI for installing, updating, and managing the OptiScaler upscaling mod (DLSS/FSR/XeSS) across a game library — and wires it into the BrightFalls host.

- `packages/optiscaler-client.nix`: `buildDotnetModule` (`sdk_10_0`/`runtime_10_0`, RID `linux-x64`), Avalonia runtime deps (X11 set + fontconfig + glew + libGL), desktop item + icon. `dotnetFlags` disable the csproj's self-contained single-file publish, which conflicts with `buildDotnetModule`'s framework-dependent layout.
- `packages/optiscaler-client-deps.json`: 30 NuGet deps (real `dotnet restore`).
- `overlays/brightfalls.nix` + BrightFalls `home.packages`: wired in (x86_64 only).

Builds green: `nix build '.#nixosConfigurations.BrightFalls.pkgs.optiscaler-client'`.