### PR TITLE
feat(opencode): visible-rewrite RTK awareness prompt for opencode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,10 @@ instruction fragments are shared: they live in
 generator in `modules/home-manager/agents-md.nix`, which is consumed by
 **both** the claude-code and opencode modules. `claude-code.nix` refines
 the base with the `@RTK.md` include (after fragment 01) and the
-model-delegation tier (04); `opencode.nix` augments it with per-profile
-steering instead, dropping RTK and model-delegation. To change a section,
-edit the matching fragment in `modules/home-manager/agents-md/`:
+model-delegation tier (04); `opencode.nix` opts into a *different* RTK
+prompt via `needsRtkPrompt` (the integrations differ — see below) and
+drops model-delegation. To change a section, edit the matching fragment in
+`modules/home-manager/agents-md/`:
 
 - `01-role-tone.md` — role, tone, confidence
 - `02-working-on-code.md` — workflow, output format
@@ -28,7 +29,7 @@ weights conflicts:
 ```
 1. ROLE / TONE / COMMUNICATION   ← frames everything below
         ↓
-2. RTK.md INCLUSION              ← stable global token-efficiency rules
+2. RTK AWARENESS PROMPT          ← rtk shell-rewrite awareness (opt-in)
         ↓
 3. WORKING ON CODE / OUTPUT      ← specific workflow guidance
         ↓
@@ -47,7 +48,12 @@ overlaps; create a new numbered fragment only for a genuinely new
 layer, and weave it into the `mkDoc` cascade in
 `modules/home-manager/agents-md.nix` (shared by both consumers) — or, if
 it's tool-specific, inject it via the `afterRoleTone` / `afterSimplicity`
-hooks from `claude-code.nix` or `opencode.nix`. `RTK.md` is
-Claude-Code-specific: it lives in `modules/home-manager/claude-code/`,
-is `@`-included by claude-code only, and is deployed separately to
-`~/.claude/RTK.md`.
+hooks from `claude-code.nix` or `opencode.nix`. The two modules use
+*different* RTK prompts on purpose: Claude's hook rewrites invisibly, so
+claude-code `@`-includes upstream's `RTK.md` (in
+`modules/home-manager/claude-code/`, deployed to `~/.claude/RTK.md`);
+OpenCode's plugin rewrites visibly, so opencode opts into the `rtkPrompt`
+fragment in `agents-md.nix` via `needsRtkPrompt`. The rtk *executables*
+(the Claude `rtk-rewrite.sh` hook and the OpenCode `rtk.ts` plugin) and
+`RTK.md` are vendored and refreshed by
+`modules/home-manager/update-rtk.sh`.

--- a/modules/home-manager/agents-md.nix
+++ b/modules/home-manager/agents-md.nix
@@ -6,34 +6,62 @@
 #
 #   claude-code.nix:
 #     mkDoc { afterRoleTone = [ "@RTK.md\n" ]; includeModelDelegation = true; }
-#     → refines the base with the RTK include + the Claude model-dispatching
-#       tier (04). Deployed to ~/.claude/CLAUDE.md.
+#     → base + the upstream RTK awareness doc (via @RTK.md, after 01) + the
+#       Claude model-dispatching tier (04). Deployed to ~/.claude/CLAUDE.md.
 #
 #   opencode.nix:
-#     mkDoc { afterSimplicity = [ <profile-specific steering> ]; }
-#     → augments the base with per-profile data; no RTK (the rtk.ts plugin
-#       rewrites bash transparently — the awareness prose is Claude-specific)
-#       and no model-delegation (Claude model tiers, irrelevant to OpenRouter).
-#       Deployed to <OPENCODE_CONFIG_DIR>/AGENTS.md.
+#     mkDoc { needsRtkPrompt = true; afterSimplicity = [ <profile steering> ]; }
+#     → base + the rtkPrompt fragment (after 01) + per-profile data; no
+#       model-delegation. Deployed to <OPENCODE_CONFIG_DIR>/AGENTS.md.
+#
+# Why two different RTK prompts, not one shared fragment: the integrations
+# differ. Claude Code's hook rewrites commands INVISIBLY (the agent never sees
+# `rtk`), so it uses upstream's `rtk-awareness.md` via @RTK.md — auto-refreshed
+# and legitimately Claude-specific (e.g. `rtk discover`). OpenCode's plugin
+# mutates the command in place, so the model DOES see `rtk`-prefixed commands
+# and the `--- Changes ---` output; `rtkPrompt` below tells it that's expected.
+# The upstream doc is neither tool-neutral nor covers the visible-rewrite case.
 #
 # Fragment cascade (general → specific); see the repo CLAUDE.md for rationale:
-#   01 role/tone → 02 working-on-code → 03 simplicity → [04 model-delegation]
-#   → 05 git → 06 non-negotiables. Injection points: `afterRoleTone` (after 01)
-#   and `afterSimplicity` (after 03/04).
+#   01 role/tone → [RTK] → 02 working-on-code → 03 simplicity →
+#   [04 model-delegation] → 05 git → 06 non-negotiables. Injection points:
+#   `afterRoleTone` (after 01/RTK) and `afterSimplicity` (after 03/04).
 { lib }:
 let
   dir = ./agents-md;
   frag = name: builtins.readFile (dir + "/${name}");
+
+  # RTK awareness for tools whose rewrite is VISIBLE to the model (opencode's
+  # plugin). Claude Code's hook is invisible, so it uses upstream rtk-awareness
+  # via @RTK.md instead — see header.
+  rtkPrompt = ''
+    ## RTK — token-optimized shell
+
+    A plugin automatically routes your shell commands through `rtk`, a
+    token-saving proxy — e.g. it runs `git status` as `rtk git status` (60-90%
+    fewer tokens on dev commands). You WILL see this: `rtk` prepended to your
+    commands, and compact results under a `--- Changes ---` header, are
+    EXPECTED and correct. Do not strip `rtk`, treat it as an error, or re-run
+    the raw command to bypass it.
+
+    Run these directly (not auto-rewritten):
+    - `rtk gain` — token-savings stats
+    - `rtk proxy <cmd>` — run a command raw, without rewriting (for debugging)
+  '';
 in
 {
+  inherit rtkPrompt;
+
   mkDoc =
     {
       afterRoleTone ? [ ],
       afterSimplicity ? [ ],
       includeModelDelegation ? false,
+      needsRtkPrompt ? false,
     }:
     lib.concatStringsSep "\n" (
       [ (frag "01-role-tone.md") ]
+      ++ lib.optional needsRtkPrompt rtkPrompt
       ++ afterRoleTone
       ++ [
         (frag "02-working-on-code.md")

--- a/modules/home-manager/claude-code.nix
+++ b/modules/home-manager/claude-code.nix
@@ -152,8 +152,9 @@ in
 
     # CLAUDE.md is assembled from the shared fragment base (../agents-md/),
     # refined with the Claude-only specializations: the @RTK.md include (after
-    # role/tone) and the model-delegation tier (after simplicity). Order matches
-    # the cascade documented in the repo's root CLAUDE.md.
+    # role/tone — Claude's hook rewrites invisibly, so it uses upstream's
+    # auto-refreshed rtk-awareness doc) and the model-delegation tier (after
+    # simplicity). Order matches the cascade documented in the root CLAUDE.md.
     home.file.".claude/CLAUDE.md".text = agentsMd.mkDoc {
       afterRoleTone = [ "@RTK.md\n" ];
       includeModelDelegation = true;

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -24,14 +24,16 @@ let
   '';
 
   # opencode's auto-loaded AGENTS.md: the shared fragment base (../agents-md/)
-  # augmented with the per-profile Kimi steering. No RTK.md (the rtk.ts plugin
-  # rewrites bash transparently; the awareness prose is Claude-hook-specific)
-  # and no model-delegation (Claude model tiers).
+  # plus the RTK awareness prompt (so Kimi doesn't trip over the rtk.ts plugin
+  # VISIBLY rewriting its shell commands — it sees `rtk`-prefixed commands and
+  # `--- Changes ---` output) and the per-profile Kimi steering. No
+  # model-delegation (Claude model tiers).
   #
   # Placed at <OPENCODE_CONFIG_DIR>/AGENTS.md, this shadows ~/.claude/CLAUDE.md:
   # opencode's instruction loader takes the first existing file in
   # [<config>/AGENTS.md, ~/.claude/CLAUDE.md] and stops.
   sharedInstructions = (import ./agents-md.nix { inherit lib; }).mkDoc {
+    needsRtkPrompt = true;
     afterSimplicity = [ kimiReasoningBudget ];
   };
   agentsMd = pkgs.writeText "opencode-AGENTS.md" sharedInstructions;

--- a/modules/home-manager/update-rtk.sh
+++ b/modules/home-manager/update-rtk.sh
@@ -5,6 +5,8 @@
 # master while the binary lags behind upstream causes the runtime check to
 # fail, so always fetch from the tag the binary was built from. OpenCode's
 # plugin has no integrity check but is pinned for the same consistency reason.
+# (Claude uses RTK.md as its awareness prompt via @RTK.md; opencode uses a
+# separate fragment in agents-md.nix — see that file for why they differ.)
 # Overwrites claude-code/{RTK.md,rtk-rewrite.sh} and opencode/rtk.ts — any
 # local edits are lost.
 set -euo pipefail


### PR DESCRIPTION
## Why

opencode's `rtk.ts` plugin rewrites shell commands **in place** (`tool.execute.before` mutates `args.command`), so the model **sees** `rtk`-prefixed commands and rtk's `--- Changes ---` output. With no awareness prompt (upstream ships none for opencode — only `rtk.ts`), Kimi was confused by this and tried to "fix" it.

## What

- Add a tool-neutral `rtkPrompt` fragment + a `needsRtkPrompt` flag to the shared `agents-md.nix` `mkDoc` generator. The fragment tells the model the `rtk` prefix + `--- Changes ---` output are expected and must not be undone, and lists `rtk gain` / `rtk proxy`.
- opencode opts in (`needsRtkPrompt = true`) → the fragment lands in its auto-loaded `AGENTS.md` after the role/tone fragment.

## Why Claude is left on `@RTK.md` (not unified)

The integrations differ fundamentally:
- **Claude** hook returns `updatedInput` JSON → rewrite is **invisible** ("agent doesn't know RTK is involved"). It keeps upstream's auto-refreshed, Claude-accurate `rtk-awareness.md` via `@RTK.md` (incl. `rtk discover`, which analyzes *Claude Code* history).
- **OpenCode** plugin rewrite is **visible** → needs the "this is expected" prompt, which the upstream doc doesn't contain.

A single shared fragment can't be correct for both, so they intentionally diverge. Rationale documented in `agents-md.nix`.

## Verification

- BrightFalls + Nexus `nix build` toplevel: green.
- claude `CLAUDE.md`: `@RTK.md` after role/tone, RTK.md still deployed — unchanged.
- opencode `AGENTS.md`: carries the visible-rewrite RTK fragment; no `@RTK`, no model-delegation.