### PR TITLE
feat(claude-code): restyle ccstatusline to match starship Dracula powerline

### DIFF
--- a/modules/home-manager/claude-code/ccstatusline.json
+++ b/modules/home-manager/claude-code/ccstatusline.json
@@ -5,53 +5,64 @@
       {
         "id": "1",
         "type": "model",
-        "color": "brightMagenta",
+        "color": "hex:282A36",
+        "backgroundColor": "hex:BD93F9",
         "rawValue": false
       },
       {
         "id": "3fcad138-2a6f-4494-a959-acf712a9f8f8",
         "type": "thinking-effort",
         "rawValue": false,
-        "color": "yellow"
+        "color": "hex:282A36",
+        "backgroundColor": "hex:FFB86C"
       },
       {
         "id": "44074cfe-3de0-49b1-8117-8ca038fc7479",
         "type": "context-length",
         "rawValue": false,
-        "color": "brightGreen"
+        "color": "hex:282A36",
+        "backgroundColor": "hex:50FA7B"
       },
       {
         "id": "a0c9bf61-0fd6-4269-8bd1-9faf77cb06d9",
         "type": "context-percentage-usable",
         "rawValue": true,
-        "color": "brightRed"
+        "color": "hex:F8F8F2",
+        "backgroundColor": "hex:FF5555"
       },
       {
         "id": "a3776b6e-f557-49dc-a105-1ddb51d1ef19",
-        "type": "compaction-counter"
+        "type": "compaction-counter",
+        "color": "hex:F8F8F2",
+        "backgroundColor": "hex:6272A4"
       }
     ],
     [
       {
         "id": "4727a801-a414-4994-a10a-35e6f4a2dd93",
         "type": "tokens-input",
-        "color": "brightBlack"
+        "color": "hex:F8F8F2",
+        "backgroundColor": "hex:6272A4"
       },
       {
         "id": "232557df-7ff5-46d4-8bc6-b78efb9f91c9",
         "type": "tokens-output",
-        "color": "brightBlack"
+        "color": "hex:F8F8F2",
+        "backgroundColor": "hex:6272A4"
       },
       {
-        "id": "69bc97d0-b2ad-4b21-ad32-c342d490ea92",
-        "type": "tokens-cached",
-        "color": "brightBlack"
+        "id": "tot-speed-01",
+        "type": "total-speed",
+        "color": "hex:282A36",
+        "backgroundColor": "hex:8BE9FD"
       }
     ],
     [
       {
         "id": "78b190b4-ed3d-4882-9f1d-f538638ef572",
         "type": "session-usage",
+        "color": "hex:282A36",
+        "backgroundColor": "hex:FF79C6",
         "metadata": {
           "display": "slider"
         }
@@ -59,6 +70,8 @@
       {
         "id": "3a320f3c-c0da-4482-9bee-6fba9f507498",
         "type": "weekly-usage",
+        "color": "hex:282A36",
+        "backgroundColor": "hex:FF79C6",
         "metadata": {
           "display": "slider"
         }
@@ -66,6 +79,8 @@
       {
         "id": "5372d63d-a8c2-4e28-b47d-57b21cdccbbb",
         "type": "reset-timer",
+        "color": "hex:F8F8F2",
+        "backgroundColor": "hex:44475A",
         "metadata": {
           "display": "time"
         }
@@ -79,18 +94,22 @@
   "globalBold": false,
   "minimalistMode": false,
   "powerline": {
-    "enabled": false,
+    "enabled": true,
     "separators": [
-      ""
+      ""
     ],
     "separatorInvertBackground": [
       false
     ],
-    "startCaps": [],
-    "endCaps": [],
+    "startCaps": [
+      ""
+    ],
+    "endCaps": [
+      ""
+    ],
     "autoAlign": false,
     "continueThemeAcrossLines": false,
-    "theme": "dracula"
+    "theme": "custom"
   },
   "defaultPadding": " "
 }


### PR DESCRIPTION
## Summary

- Enable powerline: arrow separators + round start/end caps
- Recolour every segment with the Dracula palette; `theme: "custom"` so per-segment hex wins
- Drop the cached-tokens segment (low signal)
- Add a `total-speed` (tok/s) widget in cyan

Mirrors the look of the starship prompt (same Dracula palette + powerline shapes). Verified via ccstatusline headless render.