### PR TITLE
feat(opencode): sidebar whole-tree cost total + bespoke home caption

### DIFF
--- a/modules/home-manager/opencode/patches/bespoke-caption.patch
+++ b/modules/home-manager/opencode/patches/bespoke-caption.patch
@@ -1,0 +1,40 @@
+Add a "Matteo Pacini's Bespoke" caption above the home-screen logo.
+
+Renders a muted caption line directly above the <Logo> on the home route, so the
+home screen reads "Matteo Pacini's Bespoke" / [opencode logo] -- "bespoke" as the
+adjective modifying the wordmark below. Pulls theme.textMuted (same tone as the
+sidebar's secondary text) via useTheme; nothing else on the home route changes.
+
+Targets the opencode TUI (anomalyco/opencode). Verified to apply cleanly against
+v1.17.7 with `git apply --check`.
+
+diff --git a/packages/tui/src/routes/home.tsx b/packages/tui/src/routes/home.tsx
+index d4145e2..c0c62cc 100644
+--- a/packages/tui/src/routes/home.tsx
++++ b/packages/tui/src/routes/home.tsx
+@@ -1,6 +1,7 @@
+ import { Prompt, type PromptRef } from "../component/prompt"
+ import { createEffect, createMemo, createSignal, onMount } from "solid-js"
+ import { Logo } from "../component/logo"
++import { useTheme } from "../context/theme"
+ import { useSync } from "../context/sync"
+ import { Toast } from "../ui/toast"
+ import { useArgs } from "../context/args"
+@@ -21,6 +22,7 @@ const placeholder = {
+ 
+ export function Home() {
+   const pluginRuntime = usePluginRuntime()
++  const { theme } = useTheme()
+   const sync = useSync()
+   const route = useRouteData("home")
+   const promptRef = usePromptRef()
+@@ -72,6 +74,9 @@ export function Home() {
+       <box flexGrow={1} alignItems="center" paddingLeft={2} paddingRight={2}>
+         <box flexGrow={1} minHeight={0} />
+         <box height={4} minHeight={0} flexShrink={1} />
++        <box flexShrink={0} paddingBottom={1}>
++          <text fg={theme.textMuted}>Matteo Pacini's Bespoke</text>
++        </box>
+         <box flexShrink={0}>
+           <pluginRuntime.Slot name="home_logo" mode="replace">
+             <Logo />

--- a/modules/home-manager/opencode/patches/openrouter-real-cost.patch
+++ b/modules/home-manager/opencode/patches/openrouter-real-cost.patch
@@ -10,7 +10,9 @@ providerMetadata.openrouter.usage.cost (opencode enables usage accounting for
 valid finite number; otherwise fall back to the existing per-token calculation,
 so this is a no-op for providers/turns that do not surface a real cost.
 
-Targets opencode 1.16.2 (anomalyco/opencode).
+Applies cleanly across opencode 1.16.2–1.17.7 (anomalyco/opencode) — the
+getUsage hunk context is unchanged over that range (verified with
+`git apply --check` against v1.17.7).
 
 --- a/packages/opencode/src/session/session.ts
 +++ b/packages/opencode/src/session/session.ts

--- a/modules/home-manager/opencode/patches/subagent-total-cost.patch
+++ b/modules/home-manager/opencode/patches/subagent-total-cost.patch
@@ -1,0 +1,84 @@
+Show the whole-agent-tree cost total in the sidebar, next to the session title.
+
+opencode tracks cost per session. Subagents spawned by the Task tool are
+separate child sessions linked to the parent by parentID, and a parent's cost
+column is never rolled up with its descendants' (the projector's applyUsage in
+packages/core only increments the session whose part is being projected). So the
+sidebar "spent" line and the subagent footer both show per-agent cost only, and
+there is no single number for "what this whole run cost". Upstream is aware but
+has not fixed it: issue #11027 (bot-closed stale), RFC #12377 (maintainer-closed
+"completed" over objection), TUI feature #22103 (open), foundation PR #7763
+(open, unmerged).
+
+This adds a derived total — the current session walked up to its tree root, then
+summed over the root and every transitive descendant — rendered under the title
+in the sidebar (the right column where the session id lives). The existing
+per-agent cost in the Context section and the subagent footer is left untouched.
+This is purely client-side: the TUI's sync store already holds every session in
+the project (session.list runs without the `roots` filter), so no server, schema
+or SDK change is needed. It does inherit session.list's 100-row / 30-day window,
+so very deep/old trees can undercount — noted in the code comment.
+
+Targets the opencode TUI (anomalyco/opencode). Verified to apply cleanly against
+v1.17.7 with `git apply --check`.
+
+diff --git a/packages/tui/src/routes/session/sidebar.tsx b/packages/tui/src/routes/session/sidebar.tsx
+index 0c5d2b3..bfbcb16 100644
+--- a/packages/tui/src/routes/session/sidebar.tsx
++++ b/packages/tui/src/routes/session/sidebar.tsx
+@@ -9,6 +9,8 @@ import { usePluginRuntime } from "../../plugin/runtime"
+ import { getScrollAcceleration } from "../../util/scroll"
+ import { WorkspaceLabel } from "../../component/workspace-label"
+
++const money = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" })
++
+ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
+   const pluginRuntime = usePluginRuntime()
+   const project = useProject()
+@@ -16,6 +18,36 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
+   const { theme } = useTheme()
+   const tuiConfig = useTuiConfig()
+   const session = createMemo(() => sync.session.get(props.sessionID))
++  // Total cost across the whole agent tree (main session + every subagent).
++  // Subagents are separate sessions linked by parentID; the per-agent cost still
++  // shows in the Context / subagent footer. Walk up to the tree root so the
++  // number is stable whichever node is in view. Bounded by session.list's
++  // 100-row / 30-day window (context/sync.tsx), so very deep trees may undercount.
++  const totalCost = createMemo(() => {
++    const all = sync.data.session
++    let root = session()
++    const guard = new Set<string>()
++    while (root?.parentID && !guard.has(root.id)) {
++      guard.add(root.id)
++      const parent = all.find((s) => s.id === root!.parentID)
++      if (!parent) break
++      root = parent
++    }
++    if (!root) return 0
++    let total = 0
++    const seen = new Set<string>()
++    const stack = [root.id]
++    while (stack.length) {
++      const id = stack.pop()!
++      if (seen.has(id)) continue
++      seen.add(id)
++      const node = all.find((s) => s.id === id)
++      if (!node) continue
++      total += node.cost ?? 0
++      for (const child of all) if (child.parentID === id) stack.push(child.id)
++    }
++    return total
++  })
+   const workspace = () => {
+     const workspaceID = session()?.workspaceID
+     if (!workspaceID) return
+@@ -57,6 +89,9 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
+                 <text fg={theme.text}>
+                   <b>{session()!.title}</b>
+                 </text>
++                <Show when={totalCost() > 0}>
++                  <text fg={theme.textMuted}>{money.format(totalCost())} total</text>
++                </Show>
+                 <Show when={InstallationChannel !== "latest"}>
+                   <text fg={theme.textMuted}>{props.sessionID}</text>
+                 </Show>

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -75,7 +75,8 @@
     # `modules/home-manager/update-rtk.sh` (refreshes the Claude hook).
     rtk = masterPkgs.rtk;
 
-    # opencode sourced from the master pin (1.16.2) so it matches the patch below.
+    # opencode sourced from the master pin (currently 1.17.7) so it matches the
+    # patches below, which apply cleanly across opencode 1.16.2–1.17.7.
     opencode = masterPkgs.opencode.overrideAttrs (old: {
       patches = (old.patches or [ ]) ++ [
         # opencode's getUsage prices a turn as (model rate × tokens) and ignores
@@ -84,6 +85,13 @@
         # for the openrouter provider) so per-turn cost reflects OpenRouter's real
         # billing.
         ../modules/home-manager/opencode/patches/openrouter-real-cost.patch
+        # Subagent (child-session) cost isn't rolled up into the parent, so no
+        # single number shows what a whole run cost. Render a derived whole-tree
+        # total in the sidebar next to the session title; per-agent cost stays as
+        # is. Client-side only (the TUI already holds every session). See header.
+        ../modules/home-manager/opencode/patches/subagent-total-cost.patch
+        # Caption "Matteo Pacini's Bespoke" above the home-screen logo.
+        ../modules/home-manager/opencode/patches/bespoke-caption.patch
       ];
     });
 


### PR DESCRIPTION
Adds two opencode overlay patches and a doc-comment touch-up, all verified against a clean opencode 1.17.7 build (`opencode-kimi`).

## Changes
- **`subagent-total-cost.patch`** — subagent (child-session) cost isn't rolled up into the parent, so no single number shows what a whole run cost. Renders a derived whole-tree total in the TUI sidebar next to the session title; the per-agent cost stays as-is. Client-side only (the TUI already holds every session via `session.list` without the `roots` filter), so no server/schema/SDK change. Bounded by `session.list`'s 100-row / 30-day window (noted in the patch).
- **`bespoke-caption.patch`** — "Matteo Pacini's Bespoke" caption above the home-screen logo (`home.tsx`), in `theme.textMuted`.
- **`openrouter-real-cost.patch`** — comment-only: record the verified apply range (opencode 1.16.2–1.17.7).
- **`overlays/shared.nix`** — wire the two new patches into the `opencode` override.

## Upstream context
The subagent-cost gap is known upstream but unfixed: [#11027](https://github.com/anomalyco/opencode/issues/11027) (bot-closed stale), RFC [#12377](https://github.com/anomalyco/opencode/issues/12377) (maintainer-closed over objection), TUI [#22103](https://github.com/anomalyco/opencode/issues/22103) (open), foundation PR [#7763](https://github.com/anomalyco/opencode/pull/7763) (open).