### PR TITLE
feat(opencode): glm-5.2 for build+plan roles

### DIFF
--- a/modules/home-manager/opencode/model-prices.nix
+++ b/modules/home-manager/opencode/model-prices.nix
@@ -39,6 +39,18 @@
     };
   };
   # z-ai GLM family
+  "z-ai/glm-5.2" = {
+    name = "GLM 5.2";
+    limit = {
+      context = 1048576;
+      output = 131072;
+    };
+    cost = {
+      input = 1.4;
+      output = 4.4;
+      cache_read = 0.26;
+    };
+  };
   "z-ai/glm-5.1" = {
     name = "GLM 5.1";
     limit = {

--- a/modules/home-manager/opencode/profiles/glm.nix
+++ b/modules/home-manager/opencode/profiles/glm.nix
@@ -1,5 +1,7 @@
 # GLM profile — all-GLM agentic roster. Prices come from ../model-prices.nix.
-# glm-5.1: SWE-bench Pro SOTA (58.4), 8h autonomous execution. Primary coder.
+# glm-5.2: 1M-token context (vs 5.1's ~200K), vendor-claimed SWE-bench Pro 62.1
+#   (no independent verify). Primary coder for build + plan.
+# glm-5.1: SWE-bench Pro SOTA (58.4), 8h autonomous execution. Debug fallback.
 # glm-5: strong family code index, cheaper, good for read-only review.
 # glm-4.7-flash: ultra-cheap ($0.06/Mtok) for navigation and summaries.
 # Default sampling: temp=1.0, top_p=0.95 per Z.AI official recommendation.
@@ -33,17 +35,18 @@
   # tool-capable ZDR GLM endpoint exposes both temperature + top_p, no reject
   # pattern. explore (glm-4.7-flash) omits both and inherits server-side defaults.
   roles = {
-    # glm-5.1: SWE-bench Pro SOTA (58.4), 8h autonomous execution, strongest
-    # family agentic. Primary 50-step coder — cost $0.98/Mtok justified.
+    # glm-5.2: 1M-token context + vendor-claimed SWE-bench Pro 62.1 (vs 5.1's
+    # 58.4). Primary 50-step coder; ZDR-confirmed, $1.40/Mtok in.
     build = {
-      model = "openrouter/z-ai/glm-5.1";
+      model = "openrouter/z-ai/glm-5.2";
       temperature = 1.0;
       topP = 0.95;
     };
-    # glm-5.1: same agentic strength + thinking-on by default; plan is read-only
-    # so cost parity with build is fine for architecture sketches.
+    # glm-5.2: 1M-token context (vs 5.1's 202752) suits whole-codebase
+    # architecture sketches; plan is read-only so it can't poison the 50-step
+    # build chain. ZDR-confirmed (Z.AI/Io Net/Novita/Friendli, fp8, tools+temp+top_p).
     plan = {
-      model = "openrouter/z-ai/glm-5.1";
+      model = "openrouter/z-ai/glm-5.2";
       temperature = 1.0;
       topP = 0.95;
     };


### PR DESCRIPTION
Adds `z-ai/glm-5.2` to the opencode price catalog and routes the glm profile's **build** + **plan** roles to it.

## What

- `model-prices.nix`: new `z-ai/glm-5.2` entry — 1M-token context (1048576), 131072 max output, $1.40 in / $4.40 out / $0.26 cache_read per Mtok.
- `glm.nix`: `build` + `plan` → glm-5.2 (temp 1.0 / top_p 0.95). `debug` stays glm-5.1 (fallback), `review` keeps glm-5, `explore`/small keep glm-4.7-flash.

## Why

- **ZDR gate passed** (live-verified 2026-06-16): `z-ai/glm-5.2` is in OpenRouter's ZDR endpoint list — Z.AI, Io Net, Novita, Friendli, all fp8, all accept tools + temperature + top_p. Routes fine under the profile's `zdr=true` + `data_collection=deny`.
- Hard win = **5x context** (1M vs 5.1's ~200K) for long-horizon build/plan work.
- Benchmark gains (SWE-bench Pro 62.1 vs 58.4, Terminal-Bench 2.1 81.0 vs 62.0) are **vendor self-report**, no independent/Scale verify — hence glm-5.1 retained as debug + fallback rather than fully retired.

## Verify

- `nix eval` BrightFalls (NixOS) + WorkLaptop (darwin) toplevel: clean.
- Role wiring confirmed: build=glm-5.2, plan=glm-5.2, debug=glm-5.1, review=glm-5.

Risks: ZDR landed release-day (propagation may be flaky); Io Net endpoint has full-ctx maxout (runaway-cost risk if routing pins it).