### PR TITLE
feat(kernel): bump shared kernel to 7.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,17 +26,17 @@
     "bore-scheduler-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1776284856,
-        "narHash": "sha256-vCcaidQexvJcoyYBYqgikiX4jTOVcgFNGZgsVALuIxc=",
+        "lastModified": 1777633487,
+        "narHash": "sha256-KdeMUJ0Sp0PgS/ZA2q3VK2Nf0mTtcncEwZr4meepOwI=",
         "owner": "firelzrd",
         "repo": "bore-scheduler",
-        "rev": "09075221d81b27cc6ba4dc0d1be14a62555fde85",
+        "rev": "b3d32d475646ab95d7c1e59f210117d71ed5046d",
         "type": "github"
       },
       "original": {
         "owner": "firelzrd",
         "repo": "bore-scheduler",
-        "rev": "09075221d81b27cc6ba4dc0d1be14a62555fde85",
+        "rev": "b3d32d475646ab95d7c1e59f210117d71ed5046d",
         "type": "github"
       }
     },
@@ -570,11 +570,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
     # Bore Scheduler #
     ##################
     bore-scheduler-src = {
-      url = "github:firelzrd/bore-scheduler?rev=09075221d81b27cc6ba4dc0d1be14a62555fde85";
+      url = "github:firelzrd/bore-scheduler?rev=b3d32d475646ab95d7c1e59f210117d71ed5046d";
       flake = false;
     };
     ################

--- a/modules/nixos/kernel.nix
+++ b/modules/nixos/kernel.nix
@@ -22,13 +22,13 @@
 
   config = lib.mkIf config.custom.kernel.enable {
     # Kernel version used across all Linux hosts
-    boot.kernelPackages = pkgs.linuxPackages_7_0;
+    boot.kernelPackages = pkgs.linuxPackages_7_1;
 
     boot.kernelPatches =
       let
-        # Use pkgs.linuxPackages_7_0.kernel.version instead of config.boot.kernelPackages.kernel.version
+        # Use pkgs.linuxPackages_7_1.kernel.version instead of config.boot.kernelPackages.kernel.version
         # to avoid infinite recursion (boot.kernelPatches affects boot.kernelPackages)
-        kernelVersion = lib.versions.majorMinor pkgs.linuxPackages_7_0.kernel.version;
+        kernelVersion = lib.versions.majorMinor pkgs.linuxPackages_7_1.kernel.version;
         patchesDir = "${inputs.bore-scheduler-src}/patches/stable/linux-${kernelVersion}-bore";
 
         borePatches = lib.optionals config.custom.kernel.useBorePatches (


### PR DESCRIPTION
Bumps the shared kernel used across all Linux hosts from 7.0 to **7.1**.

## Changes

- **`modules/nixos/kernel.nix`**: `linuxPackages_7_0` → `linuxPackages_7_1` (boot.kernelPackages, the explanatory comment, and the `kernelVersion` read). The `patchesDir` derivation auto-resolves to `patches/stable/linux-7.1-bore` from the package's major.minor version — not hardcoded.
- **`nixpkgs`**: pin moved to the nixos-unstable rev that introduced 7.1 (`567a49d1913ce81ac6e9582e3553dd90a955875f`). Exact kernel version: **7.1**.
- **`bore-scheduler-src`**: bumped to `b3d32d475646ab95d7c1e59f210117d71ed5046d`, the first upstream rev carrying `patches/stable/linux-7.1-bore` (the previously pinned rev only had patches up to 7.0).

## Verification

- Confirmed `linuxPackages_7_1.kernel.version` resolves in the pinned nixpkgs.
- Confirmed the bumped `bore-scheduler-src` store path contains `patches/stable/linux-7.1-bore`.
- `nix eval` of the toplevel succeeds for BrightFalls (`useBorePatches = true`, exercising the 7.1 patch dir) and Nexus. Kernels were not built locally — CI builds all 5 configs for review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J4pVDBWbgEsjcvSJ1GUkSF)_