### PR TITLE
feat(nexus): Caddy ACME via Route53 DNS-01, drop inbound port 80

### DIFF
--- a/hosts/Nexus/networking.nix
+++ b/hosts/Nexus/networking.nix
@@ -27,9 +27,9 @@
       # Access control is handled by Tailscale ACLs instead.
       trustedInterfaces = [ "tailscale0" ];
 
-      # Allow HTTP/HTTPS for Caddy (ACME certificate validation and web services)
+      # HTTPS only — Caddy solves ACME via the DNS-01 challenge (Route53),
+      # so no inbound port 80 is required for certificate validation.
       allowedTCPPorts = [
-        80 # HTTP (ACME challenges, redirects to HTTPS)
         443 # HTTPS (Caddy reverse proxy for all services)
       ]
       ++ config.services.openssh.ports

--- a/hosts/Nexus/services/caddy.nix
+++ b/hosts/Nexus/services/caddy.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ config, pkgs, ... }:
 let
   # Security headers applied to all virtual hosts
   securityHeaders = ''
@@ -14,6 +14,23 @@ in
 {
   services.caddy = {
     enable = true;
+
+    # Caddy built with the Route53 DNS provider so ACME can solve the
+    # DNS-01 challenge instead of HTTP-01 — no inbound port 80 needed.
+    package = pkgs.caddy.withPlugins {
+      plugins = [ "github.com/caddy-dns/route53@v1.6.2" ];
+      hash = "sha256-gYHZQQ8Ca3hTTVAeJ9vKzIi7O/iKShmBQR46G3aFY0c=";
+    };
+
+    # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for the Route53 plugin.
+    # Same IAM user (router) and secret already used by r53-ddns.
+    environmentFile = config.age.secrets."nexus/route53-env".path;
+
+    # Solve every cert via DNS-01 over Route53. Plugin reads the AWS
+    # credentials from the environment (SDK default chain).
+    globalConfig = ''
+      acme_dns route53
+    '';
 
     # Email for Let's Encrypt ACME registration
     email = "m+acme@matteopacini.me";


### PR DESCRIPTION
## What

- Build Caddy with the `caddy-dns/route53` plugin (`v1.6.2`) via `caddy.withPlugins`.
- Switch the global ACME issuer to the DNS-01 challenge: `acme_dns route53`.
- Feed AWS creds through `environmentFile` = `nexus/route53-env` (same IAM user `router` already used by `r53-ddns`).
- Drop inbound port `80` from the firewall — DNS-01 needs no inbound HTTP. `443` TCP + `443` UDP (HTTP/3) remain.

## Why

HTTP-01 required exposing port 80. DNS-01 over Route53 removes that, letting the WAN :80 forward be retired on the router.

## Notes

- `hosted_zone_id` intentionally omitted — Caddy auto-discovers the zone via `ListHostedZonesByName`.
- Route53 IAM perms (`ListResourceRecordSets`, `GetChange`, `ChangeResourceRecordSets`, `ListHostedZonesByName`) verified against the live `router` credentials.
- Region not set — Route53 uses the global `us-east-1` endpoint by default.