### PR TITLE
feat(nexus): self-hosted open-design on Claude subscription auth

### DIFF
--- a/docs/nexus/README.md
+++ b/docs/nexus/README.md
@@ -8,4 +8,5 @@ Documentation for the Nexus host.
 - [Disk Failure Handbook](disk-failure-handbook.md)
 - [Paperless-ngx Recovery](paperless-ngx-recovery.md)
 - [Attic Cache Handbook](attic-cache-handbook.md)
+- [Open Design Handbook](open-design-handbook.md)
 

--- a/docs/nexus/open-design-handbook.md
+++ b/docs/nexus/open-design-handbook.md
@@ -1,0 +1,136 @@
+# Open Design Handbook
+
+Initial (one-time) setup for the [open-design](https://github.com/nexu-io/open-design)
+daemon on Nexus. The service itself is declarative — these are the manual steps
+Nix can't do: the Claude Code login, the LAN DNS record, and verification.
+
+## Quick Reference
+
+| Item | Value |
+|------|-------|
+| Web UI | `https://design.matteopacini.me` (LAN-only) |
+| Daemon | `127.0.0.1:7457` (loopback) |
+| Bundled web Caddy | `127.0.0.1:5174` (loopback, plain HTTP) |
+| Front TLS proxy | `services.caddy` vhost in `hosts/Nexus/services/caddy.nix` |
+| Service config | `hosts/Nexus/services/open-design.nix` |
+| Service user | `open-design` (system user) |
+| Data dir / `$HOME` | `/var/lib/open-design` |
+| Claude session | `/var/lib/open-design/.claude/.credentials.json` |
+| systemd units | `open-design.service`, `open-design-web.service` |
+
+---
+
+## 1. Prerequisites
+
+The config (`open-design.nix` + the Caddy vhost + the flake input) is merged and
+switched:
+
+```bash
+nix build ".#nixosConfigurations.Nexus.config.system.build.toplevel"
+sudo nixos-rebuild switch --flake .#Nexus
+```
+
+`claude` is on the system profile (`environment.systemPackages`), so the daemon
+can find it on its `PATH`. The daemon's `PATH` does **not** include any per-user
+Home Manager profile — matteo's own `claude` is invisible to it.
+
+---
+
+## 2. Add the LAN DNS record
+
+There is **no public A record** for `design.matteopacini.me`. Add a local
+override on the LAN resolver (router / Pi-hole / Blocky):
+
+```
+design.matteopacini.me  →  <Nexus LAN IP>
+```
+
+The cert is still minted via the Route53 DNS-01 challenge (the `_acme-challenge`
+TXT record in the public `matteopacini.me` zone) — that is independent of the A
+record, so the service stays unreachable and unresolvable from outside the LAN.
+
+---
+
+## 3. One-time Claude Code login (subscription, not API billing)
+
+The daemon spawns the genuine `claude` binary, which authenticates with its own
+`/login` session. Run the login **as the `open-design` user with the matching
+`$HOME`** so the credentials land where the daemon reads them at runtime:
+
+```bash
+sudo -u open-design env HOME=/var/lib/open-design claude
+# inside the TUI: /login → open the printed URL on another machine, paste the code
+```
+
+Leave `ANTHROPIC_API_KEY` **unset** (do not put it in an `environmentFile`). The
+daemon strips that var when spawning the `claude` adapter so it falls back to the
+subscription OAuth session — but keeping it unset avoids any ambiguity, and a set
+key would be billed against pay-as-you-go API credits instead.
+
+> Running the real `claude` binary on your own subscription is ordinary CLI use.
+> Do **not** inject a subscription OAuth token into a third-party tool — that is
+> the path Anthropic prohibits.
+
+---
+
+## 4. Verify
+
+```bash
+# Credentials written to the daemon's HOME
+sudo -u open-design ls -l /var/lib/open-design/.claude/.credentials.json
+
+# Services healthy
+systemctl status open-design open-design-web
+
+# Cert issued (DNS-01 via Route53)
+journalctl -u caddy --since "10 min ago" | grep -i "design.matteopacini.me"
+
+# From a LAN client
+curl -I https://design.matteopacini.me
+```
+
+Restart the daemon after the first login so it picks up the new session:
+
+```bash
+sudo systemctl restart open-design
+```
+
+---
+
+## 5. (Optional) OpenRouter / other BYOK keys
+
+open-design has no first-class OpenRouter integration. Route through its generic
+**OpenAI-compatible** provider in **Settings → Execution mode → "OpenAI API"**:
+
+| Field | Value |
+|-------|-------|
+| Base URL | `https://openrouter.ai/api/v1` |
+| API key | your OpenRouter key |
+| Model ID | `vendor/slug`, e.g. `anthropic/claude-3.5-sonnet` |
+
+For keys that must persist, store them in an agenix secret and point the module's
+`services.open-design.environmentFile` at it (decrypted to `/run/agenix/...`),
+`KEY=VALUE` per line. Never put keys directly in the Nix store (world-readable).
+
+---
+
+## Notes
+
+- This is a NixOS system service (`nixosModules.open-design`), so it starts at
+  boot — **no `users.users.<u>.linger`** is needed (that only applies to the
+  Home Manager / `systemd --user` variant).
+- The daemon and bundled Caddy both bind loopback; the front `services.caddy`
+  vhost terminates TLS and gates access by source IP (`remote_ip` allowlist:
+  LAN + tailnet). Do not set `OD_BIND_HOST` or `openFirewall` on the module.
+- `webFrontend.allowedOrigins` must list `https://design.matteopacini.me`, or the
+  daemon's origin check returns 403 on write actions.
+- "No agents detected" in the UI → `claude` is not on the daemon's `PATH`.
+  Confirm `environment.systemPackages` has `pkgs.claude-code`, then restart
+  `open-design`.
+- AWS Route53 credentials for the cert are shared with the DDNS service via the
+  existing `nexus/route53-env` agenix secret — nothing new to provision.
+- **Backups:** all state lives under `/var/lib/open-design` (the systemd sandbox
+  confines writes there). The nightly `backupJob` stops `open-design` to quiesce
+  `app.sqlite`, rsyncs the dir into `/diskpool/configuration/open-design`, and the
+  restic `config` repo pushes it off-site to B2. If the generated `artifacts/` /
+  `frames/` grow large, exclude them via `configExcludes` in `backup.nix`.

--- a/flake.lock
+++ b/flake.lock
@@ -152,6 +152,29 @@
         "type": "github"
       }
     },
+    "dream2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "open-design",
+          "nixpkgs"
+        ],
+        "purescript-overlay": "purescript-overlay",
+        "pyproject-nix": "pyproject-nix"
+      },
+      "locked": {
+        "lastModified": 1765953015,
+        "narHash": "sha256-5FBZbbWR1Csp3Y2icfRkxMJw/a/5FGg8hCXej2//bbI=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "69eb01fa0995e1e90add49d8ca5bcba213b0416f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
@@ -199,6 +222,22 @@
       "original": {
         "type": "git",
         "url": "https://git.lix.systems/lix-project/flake-compat.git"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
       }
     },
     "flake-parts": {
@@ -281,6 +320,24 @@
         "type": "indirect"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_5"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -314,6 +371,27 @@
         "owner": "nix-community",
         "repo": "home-manager",
         "rev": "486595d2cf49cfcd649b58a284fa11ac0e34da22",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_3": {
+      "inputs": {
+        "nixpkgs": [
+          "open-design",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777679572,
+        "narHash": "sha256-egYNbRrkn+6SwTHinhdb6WUfzzdC3nXfCRqS321VylY=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "9cb587ade2aa1b4a7257f0238d41072690b0ca4f",
         "type": "github"
       },
       "original": {
@@ -584,6 +662,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_2",
@@ -630,6 +724,73 @@
         "type": "github"
       }
     },
+    "open-design": {
+      "inputs": {
+        "dream2nix": "dream2nix",
+        "flake-utils": "flake-utils_2",
+        "home-manager": "home-manager_3",
+        "nixpkgs": "nixpkgs_6"
+      },
+      "locked": {
+        "lastModified": 1781773101,
+        "narHash": "sha256-ZGRiuQ4bH3ESJ3CICuRbyOV9UBerxXWtCuR4C5GbuY8=",
+        "owner": "nexu-io",
+        "repo": "open-design",
+        "rev": "c87934d4678f4f587bad5b124c8445230a554f21",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nexu-io",
+        "repo": "open-design",
+        "type": "github"
+      }
+    },
+    "purescript-overlay": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "nixpkgs": [
+          "open-design",
+          "dream2nix",
+          "nixpkgs"
+        ],
+        "slimlock": "slimlock"
+      },
+      "locked": {
+        "lastModified": 1728546539,
+        "narHash": "sha256-Sws7w0tlnjD+Bjck1nv29NjC5DbL6nH5auL9Ex9Iz2A=",
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "rev": "4ad4c15d07bd899d7346b331f377606631eb0ee4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "open-design",
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763017646,
+        "narHash": "sha256-Z+R2lveIp6Skn1VPH3taQIuMhABg1IizJd8oVdmdHsQ=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "47bd6f296502842643078d66128f7b5e5370790c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "agenix": "agenix",
@@ -649,8 +810,32 @@
         "nixpkgs-master": "nixpkgs-master",
         "nur": "nur",
         "nvf": "nvf",
+        "open-design": "open-design",
         "sublime-dracula-theme": "sublime-dracula-theme",
         "xcode-dracula-theme": "xcode-dracula-theme"
+      }
+    },
+    "slimlock": {
+      "inputs": {
+        "nixpkgs": [
+          "open-design",
+          "dream2nix",
+          "purescript-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688756706,
+        "narHash": "sha256-xzkkMv3neJJJ89zo3o2ojp7nFeaZc2G0fYwNXNJRFlo=",
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "rev": "cf72723f59e2340d24881fd7bf61cb113b4c407c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "type": "github"
       }
     },
     "sublime-dracula-theme": {
@@ -715,6 +900,21 @@
       }
     },
     "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,12 @@
     #####################
     nix-index-database.url = "github:nix-community/nix-index-database";
     nix-index-database.inputs.nixpkgs.follows = "nixpkgs";
+    ###############
+    # Open Design #
+    ###############
+    # No nixpkgs.follows: the daemon/web packages build against the flake's own
+    # pinned nixpkgs (the combo upstream tested), which is lower build risk.
+    open-design.url = "github:nexu-io/open-design";
   };
 
   outputs =

--- a/hosts/Nexus/services/backup.nix
+++ b/hosts/Nexus/services/backup.nix
@@ -27,6 +27,7 @@ let
     "paperless-task-queue"
     "phpfpm-nextcloud"
     "nginx"
+    "open-design" # quiesce app.sqlite before rsync; restarted by cleanup trap
   ];
   affectedComposeTargets = [
     "nexus-n8n"
@@ -153,7 +154,7 @@ let
     ${notify} "Home Assistant services back online, starting full backup..."
   '';
 
-  backupJob = pkgs.writeShellScriptBin "backupJob_20" ''
+  backupJob = pkgs.writeShellScriptBin "backupJob_21" ''
     set -eo pipefail
     export TELEGRAM_ENV_FILE="${envFile}"
 
@@ -209,6 +210,8 @@ let
     ''${RSYNC_CMD} /var/lib/n8n ${backupDestination}/
     # n8n - PostgreSQL database
     ''${RSYNC_CMD} /var/lib/postgresql_n8n ${backupDestination}/
+    # open-design - daemon state (app.sqlite, projects, artifacts, claude session)
+    ''${RSYNC_CMD} /var/lib/open-design ${backupDestination}/
     # nextcloud
     ''${RSYNC_CMD} /diskpool/nextcloud ${backupDestination}/
 

--- a/hosts/Nexus/services/caddy.nix
+++ b/hosts/Nexus/services/caddy.nix
@@ -139,6 +139,33 @@ in
           reverse_proxy 127.0.0.1:8123
         '';
       };
+
+      "design.matteopacini.me" = {
+        logFormat = ''
+          output file /var/log/caddy/access.log
+          format json
+        '';
+        extraConfig = ''
+          ${securityHeaders}
+
+          # LAN-only: no public A record exists, and this gates by source IP
+          # (LAN + tailnet) so the shared, WAN-forwarded :443 can't reach it.
+          @external not remote_ip 192.168.0.0/16 100.64.0.0/10 127.0.0.1/8
+          respond @external 403
+
+          # Reference images / asset uploads for open-design
+          request_body {
+            max_size 32MB
+          }
+
+          # Reverse proxy to the open-design bundled Caddy (SPA + /api,
+          # /artifacts, /frames → daemon 7457). flush_interval -1 keeps the
+          # SSE artifact stream unbuffered.
+          reverse_proxy 127.0.0.1:5174 {
+            flush_interval -1
+          }
+        '';
+      };
     };
   };
 }

--- a/hosts/Nexus/services/default.nix
+++ b/hosts/Nexus/services/default.nix
@@ -12,6 +12,7 @@
     ./n8n
     ./ddns.nix
     ./caddy.nix
+    ./open-design.nix
     ./fail2ban.nix
     ./tailscale.nix
     ./zigbee2mqtt.nix

--- a/hosts/Nexus/services/open-design.nix
+++ b/hosts/Nexus/services/open-design.nix
@@ -1,0 +1,51 @@
+{
+  config,
+  inputs,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  imports = [ inputs.open-design.nixosModules.open-design ];
+
+  # The upstream NixOS module assigns systemd.services.open-design.environment.PATH
+  # directly, which collides (normal priority) with the base systemd module's
+  # default unit PATH on current nixpkgs, so plain eval aborts. Force the
+  # module's intended value (its `daemonPathEntries`, verbatim) —
+  # /run/current-system/sw/bin carries claude + the usual coreutils, so nothing
+  # the daemon spawns loses its tools. Gated on autoStart because upstream only
+  # defines the unit under `mkIf cfg.autoStart`; without the guard a false
+  # autoStart would synthesise a phantom ExecStart-less unit.
+  systemd.services.open-design.environment.PATH = lib.mkIf config.services.open-design.autoStart (
+    lib.mkForce (
+      lib.concatStringsSep ":" [
+        "/run/wrappers/bin"
+        "/run/current-system/sw/bin"
+        "/nix/var/nix/profiles/default/bin"
+        "/usr/local/bin"
+        "/usr/bin"
+        "/bin"
+      ]
+    )
+  );
+
+  # The daemon runs as the `open-design` system user (not matteo), so its PATH
+  # excludes matteo's Home Manager profile. Put claude on the system profile so
+  # the daemon can spawn it; subscription auth is set up out-of-band (one-time
+  # `/login` as the open-design user) — see docs/nexus/open-design-handbook.md.
+  environment.systemPackages = [ pkgs.claude-code ];
+
+  services.open-design = {
+    enable = true;
+    autoStart = true;
+    port = 7457; # daemon, loopback
+    webFrontend = {
+      enable = true;
+      host = "127.0.0.1"; # bundled Caddy stays loopback; front via services.caddy
+      port = 5174;
+      # Browser Origin when served via the TLS vhost; without it the daemon's
+      # origin check 403s write actions.
+      allowedOrigins = [ "https://design.matteopacini.me" ];
+    };
+  };
+}


### PR DESCRIPTION
## What

Self-host [nexu-io/open-design](https://github.com/nexu-io/open-design) on Nexus as a NixOS service, reachable at `https://design.matteopacini.me` on the LAN only.

- **flake**: new input `open-design` (no `nixpkgs.follows` — the daemon/web packages build against the nixpkgs upstream pinned/tested).
- **`hosts/Nexus/services/open-design.nix`**: enable the daemon (loopback `:7457`) + bundled web Caddy (loopback `:5174`); put `claude` on the system profile so the `open-design` system user can spawn it; `mkForce` the systemd unit `PATH` to resolve an upstream `environment.PATH` collision that otherwise aborts eval (gated on `autoStart`).
- **`caddy.nix`**: LAN/tailnet-only vhost (`remote_ip` gate → 403 external), TLS via the existing Route53 DNS-01 ACME, reverse-proxy to the bundled Caddy `:5174`.
- **`backup.nix`**: quiesce `open-design` and rsync `/var/lib/open-design` into `/diskpool/configuration` (→ off-site restic `config` repo), capturing `app.sqlite`, projects, artifacts and the Claude session.
- **`docs/nexus/open-design-handbook.md`**: one-time manual setup (Claude `/login`, LAN DNS record, verification).

## Why subscription, not API

The daemon spawns the genuine `claude` binary, which uses its own `/login` OAuth session, so this runs on the Claude **subscription** rather than metered API billing. `ANTHROPIC_API_KEY` is left unset (and upstream strips it for the claude adapter anyway). Running the real binary on your own subscription is ordinary CLI use — no subscription token is injected into a third-party tool.

## Verification

- `nix eval .#nixosConfigurations.Nexus.config.system.build.toplevel.drvPath` — **green** (correct foreign-platform gate; this host is aarch64-darwin, Nexus is x86_64-linux, so the full Linux build runs in CI).
- Caddy LAN-only gate confirmed via `caddy adapt`: the `403` for `not remote_ip` is ordered **before** the catch-all `reverse_proxy`, so external requests are rejected and only LAN/tailnet is proxied.
- Adversarial review (correctness, security, backup) — no blockers; the one real finding (PATH override outside the `autoStart` guard) is fixed in this PR.

## Residual risk

The open-design `daemon`/`web` packages (dream2nix + pnpm, with vendored FOD hashes matching the locked rev) could **not** be built locally on darwin — the Linux build is exercised by the all-configs CI build on `master`.

## Notes

- No new agenix secret: certs reuse `nexus/route53-env`; subscription auth is set up out-of-band per the handbook.
- LAN reachability requires a local DNS record `design.matteopacini.me → <Nexus LAN IP>` (no public A record); the cert is minted via the DNS-01 TXT independently.
