### PR TITLE
chore: weekly flake update - 2026-06-18T16:42:58Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779646357,
-        "narHash": "sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k=",
+        "lastModified": 1781226006,
+        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "10a163ac127624caa80cc5cc5a705e97f3615b0e",
+        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.14",
+        "ref": "6.0.1",
         "repo": "brew",
         "type": "github"
       }
@@ -366,11 +366,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781189114,
-        "narHash": "sha256-5inaamLgUMWy+MOBE9ChF9QAF1o/74LFuHkI0W/9rqc=",
+        "lastModified": 1781810163,
+        "narHash": "sha256-dk8lIk0UnO8GD3e7e3HM1vSYXpbEDmhy67w7KztfdCg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "486595d2cf49cfcd649b58a284fa11ac0e34da22",
+        "rev": "c8f0b8ed441c95bfeaf33555e7631044bb09f384",
         "type": "github"
       },
       "original": {
@@ -403,11 +403,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1781222483,
-        "narHash": "sha256-UaKYM7ygwKQqM7P3hIUCqMI2pfG5uyi3l3S1VQnJlrE=",
+        "lastModified": 1781825415,
+        "narHash": "sha256-C06g7QoXlSpZBRJtjXkRHxuJ9DpcxYBnQABihpoA4WY=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "417f0ad94445f9b2a7ec05ad6c4a97309b1f7f15",
+        "rev": "07b41729b9a8b32e09e8be71dee91cfaf7d48479",
         "type": "github"
       },
       "original": {
@@ -419,11 +419,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1781224560,
-        "narHash": "sha256-nEjmopAFI3YbKA3vfx9Un5Xu28/T3nlEiXzHChVIz3E=",
+        "lastModified": 1781829607,
+        "narHash": "sha256-e0tTfcVQENdI5I29mwsN7A8PCFAkcbE9A+qUlOf6nG4=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "fe65786dce3a62cc55bc8fca7a82aca38b1f2cb6",
+        "rev": "6900d711fc299d7e4764ec8be9b6cd26a64fae99",
         "type": "github"
       },
       "original": {
@@ -499,11 +499,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781196189,
-        "narHash": "sha256-8ZFs9+ylq+YRDnkw9/ITEcxcl1GjMvIDgWUFIsKwJH8=",
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "d0d0978f34fbd7da190801f7549992718057a8d6",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
         "type": "github"
       },
       "original": {
@@ -518,11 +518,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1780492467,
-        "narHash": "sha256-zMEJwtQPmsPPgPczFkyjWHgd1z0HagOPS2Wt2WDYLJY=",
+        "lastModified": 1781389246,
+        "narHash": "sha256-ORqLAo/hoJdsZC7UPAuEHev6S0+XIqKEC7vjo5prz1k=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "562332f97de9f5ba51aa647d70462e88222b2988",
+        "rev": "de7953a08ed4bb9245be043e468561c17b89130d",
         "type": "github"
       },
       "original": {
@@ -538,11 +538,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780816331,
-        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
+        "lastModified": 1781422160,
+        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
+        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
         "type": "github"
       },
       "original": {
@@ -584,11 +584,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1781595207,
-        "narHash": "sha256-lJjo01/K+l7IgHdsxv7mZd/CcGcIYAk5mmwf+ElGOfc=",
+        "lastModified": 1781828611,
+        "narHash": "sha256-UsXZLbds7f/pcs9y4gm3WkHrS9bOtb7jXsOZn5fmQts=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b38530584b29cc6adb99ed995efd30d4fc9fa2d2",
+        "rev": "ecd22f91ea9baf622b4f538b16357fa5c52af4a0",
         "type": "github"
       },
       "original": {
@@ -686,11 +686,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781221603,
-        "narHash": "sha256-K79t1ESN/OzDGfIXJgpKfiHTDVI21dLqP4XXq0QDTkA=",
+        "lastModified": 1781828819,
+        "narHash": "sha256-UiiYjtGWIqwR4eTXrbkOOTlIsidEoj3GHqxDffy+Lpw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4af9139dd607f18f14818fa8a76f676dfb62fdb3",
+        "rev": "e5ac01eebec0c35177f10b568d031a220a41695e",
         "type": "github"
       },
       "original": {
@@ -711,11 +711,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1781204315,
-        "narHash": "sha256-0mEWVih7Aq2tdyZwHL91tZMsIitFIocGMvtfaenOSPc=",
+        "lastModified": 1781534482,
+        "narHash": "sha256-d3UIqXuigQhsc7amQkZ7F+SWnaJFAxIROE2f2X+pzUs=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "5727a5b9a76f6540d93a26cfc96c6ec2b47fa4f3",
+        "rev": "63d8fc82d652c23419a837e2b2934dd4bead04f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:firelzrd/bore-scheduler/b3d32d475646ab95d7c1e59f210117d71ed5046d' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/942159e73e40bf785816f7f1f5feed9ef3d7c8f9' into the Git cache...
unpacking 'github:nix-community/home-manager/c8f0b8ed441c95bfeaf33555e7631044bb09f384' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/07b41729b9a8b32e09e8be71dee91cfaf7d48479' into the Git cache...
unpacking 'github:homebrew/homebrew-core/6900d711fc299d7e4764ec8be9b6cd26a64fae99' into the Git cache...
unpacking 'github:hraban/mac-app-util/4747968574ea58512c5385466400b2364c85d2d0' into the Git cache...
unpacking 'github:lnl7/nix-darwin/a1fa429e945becaf60468600daf649be4ba0350c' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/de7953a08ed4bb9245be043e468561c17b89130d' into the Git cache...
unpacking 'github:nix-community/nix-index-database/854d04e2368fb2e9c328a36b3c0a04cd713bfae1' into the Git cache...
unpacking 'github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f' into the Git cache...
unpacking 'github:NixOS/nixpkgs/ecd22f91ea9baf622b4f538b16357fa5c52af4a0' into the Git cache...
unpacking 'github:nix-community/NUR/e5ac01eebec0c35177f10b568d031a220a41695e' into the Git cache...
unpacking 'github:NotAShelf/nvf/63d8fc82d652c23419a837e2b2934dd4bead04f3' into the Git cache...
unpacking 'github:nexu-io/open-design/c87934d4678f4f587bad5b124c8445230a554f21' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/486595d2cf49cfcd649b58a284fa11ac0e34da22?narHash=sha256-5inaamLgUMWy%2BMOBE9ChF9QAF1o/74LFuHkI0W/9rqc%3D' (2026-06-11)
  → 'github:nix-community/home-manager/c8f0b8ed441c95bfeaf33555e7631044bb09f384?narHash=sha256-dk8lIk0UnO8GD3e7e3HM1vSYXpbEDmhy67w7KztfdCg%3D' (2026-06-18)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/417f0ad94445f9b2a7ec05ad6c4a97309b1f7f15?narHash=sha256-UaKYM7ygwKQqM7P3hIUCqMI2pfG5uyi3l3S1VQnJlrE%3D' (2026-06-12)
  → 'github:homebrew/homebrew-cask/07b41729b9a8b32e09e8be71dee91cfaf7d48479?narHash=sha256-C06g7QoXlSpZBRJtjXkRHxuJ9DpcxYBnQABihpoA4WY%3D' (2026-06-18)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/fe65786dce3a62cc55bc8fca7a82aca38b1f2cb6?narHash=sha256-nEjmopAFI3YbKA3vfx9Un5Xu28/T3nlEiXzHChVIz3E%3D' (2026-06-12)
  → 'github:homebrew/homebrew-core/6900d711fc299d7e4764ec8be9b6cd26a64fae99?narHash=sha256-e0tTfcVQENdI5I29mwsN7A8PCFAkcbE9A%2BqUlOf6nG4%3D' (2026-06-19)
• Updated input 'nix-darwin':
    'github:lnl7/nix-darwin/d0d0978f34fbd7da190801f7549992718057a8d6?narHash=sha256-8ZFs9%2Bylq%2BYRDnkw9/ITEcxcl1GjMvIDgWUFIsKwJH8%3D' (2026-06-11)
  → 'github:lnl7/nix-darwin/a1fa429e945becaf60468600daf649be4ba0350c?narHash=sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14%3D' (2026-06-18)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/562332f97de9f5ba51aa647d70462e88222b2988?narHash=sha256-zMEJwtQPmsPPgPczFkyjWHgd1z0HagOPS2Wt2WDYLJY%3D' (2026-06-03)
  → 'github:zhaofengli/nix-homebrew/de7953a08ed4bb9245be043e468561c17b89130d?narHash=sha256-ORqLAo/hoJdsZC7UPAuEHev6S0%2BXIqKEC7vjo5prz1k%3D' (2026-06-13)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/10a163ac127624caa80cc5cc5a705e97f3615b0e?narHash=sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k%3D' (2026-05-24)
  → 'github:Homebrew/brew/109191be4988470b51a60a5ef1998520aa24c01b?narHash=sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y%3D' (2026-06-12)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/1a2ea89c917781e88508d9fd2b507f2d2a0e173c?narHash=sha256-0BYqs8yKWkOz2Q7%2BSP18N5E5gmDKSo6LSxIVIa0wWes%3D' (2026-06-07)
  → 'github:nix-community/nix-index-database/854d04e2368fb2e9c328a36b3c0a04cd713bfae1?narHash=sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0%3D' (2026-06-14)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/b38530584b29cc6adb99ed995efd30d4fc9fa2d2?narHash=sha256-lJjo01/K%2Bl7IgHdsxv7mZd/CcGcIYAk5mmwf%2BElGOfc%3D' (2026-06-16)
  → 'github:NixOS/nixpkgs/ecd22f91ea9baf622b4f538b16357fa5c52af4a0?narHash=sha256-UsXZLbds7f/pcs9y4gm3WkHrS9bOtb7jXsOZn5fmQts%3D' (2026-06-19)
• Updated input 'nur':
    'github:nix-community/NUR/4af9139dd607f18f14818fa8a76f676dfb62fdb3?narHash=sha256-K79t1ESN/OzDGfIXJgpKfiHTDVI21dLqP4XXq0QDTkA%3D' (2026-06-11)
  → 'github:nix-community/NUR/e5ac01eebec0c35177f10b568d031a220a41695e?narHash=sha256-UiiYjtGWIqwR4eTXrbkOOTlIsidEoj3GHqxDffy%2BLpw%3D' (2026-06-19)
• Updated input 'nvf':
    'github:NotAShelf/nvf/5727a5b9a76f6540d93a26cfc96c6ec2b47fa4f3?narHash=sha256-0mEWVih7Aq2tdyZwHL91tZMsIitFIocGMvtfaenOSPc%3D' (2026-06-11)
  → 'github:NotAShelf/nvf/63d8fc82d652c23419a837e2b2934dd4bead04f3?narHash=sha256-d3UIqXuigQhsc7amQkZ7F%2BSWnaJFAxIROE2f2X%2BpzUs%3D' (2026-06-15)
```
