### PR TITLE
feat(nexus): fix open-design npx renders and asset uploads

### DIFF
--- a/hosts/Nexus/services/caddy.nix
+++ b/hosts/Nexus/services/caddy.nix
@@ -150,18 +150,24 @@ in
 
           # LAN-only: no public A record exists, and this gates by source IP
           # (LAN + tailnet) so the shared, WAN-forwarded :443 can't reach it.
-          @external not remote_ip 192.168.0.0/16 100.64.0.0/10 127.0.0.1/8
+          @external not remote_ip 192.168.10.0/24 192.168.20.0/24 100.64.0.0/10 127.0.0.1/8
           respond @external 403
 
-          # Reference images / asset uploads for open-design
+          # Reference images / asset uploads for open-design. Match the
+          # daemon's projectUpload ceiling (server.ts: 200MB) so Caddy isn't
+          # the artificial bottleneck; leave headroom for multipart
+          # framing/boundary overhead.
           request_body {
-            max_size 32MB
+            max_size 210MB
           }
 
           # Reverse proxy to the open-design bundled Caddy (SPA + /api,
           # /artifacts, /frames → daemon 7457). flush_interval -1 keeps the
-          # SSE artifact stream unbuffered.
+          # SSE artifact stream unbuffered. The bundled Caddy's site is bound
+          # to 127.0.0.1:5174 and returns an empty 200 for any other Host, so
+          # rewrite the upstream Host (Caddy forwards the original by default).
           reverse_proxy 127.0.0.1:5174 {
+            header_up Host 127.0.0.1:5174
             flush_interval -1
           }
         '';

--- a/hosts/Nexus/services/open-design.nix
+++ b/hosts/Nexus/services/open-design.nix
@@ -11,21 +11,26 @@
   # The upstream NixOS module assigns systemd.services.open-design.environment.PATH
   # directly, which collides (normal priority) with the base systemd module's
   # default unit PATH on current nixpkgs, so plain eval aborts. Force the
-  # module's intended value (its `daemonPathEntries`, verbatim) —
-  # /run/current-system/sw/bin carries claude + the usual coreutils, so nothing
-  # the daemon spawns loses its tools. Gated on autoStart because upstream only
-  # defines the unit under `mkIf cfg.autoStart`; without the guard a false
-  # autoStart would synthesise a phantom ExecStart-less unit.
+  # module's intended value (its `daemonPathEntries`, verbatim — the default
+  # entries followed by `++ cfg.extraBinPaths`, which is how the daemon picks
+  # up the Node we add below) — /run/current-system/sw/bin carries claude + the
+  # usual coreutils, so nothing the daemon spawns loses its tools. Gated on
+  # autoStart because upstream only defines the unit under `mkIf cfg.autoStart`;
+  # without the guard a false autoStart would synthesise a phantom
+  # ExecStart-less unit.
   systemd.services.open-design.environment.PATH = lib.mkIf config.services.open-design.autoStart (
     lib.mkForce (
-      lib.concatStringsSep ":" [
-        "/run/wrappers/bin"
-        "/run/current-system/sw/bin"
-        "/nix/var/nix/profiles/default/bin"
-        "/usr/local/bin"
-        "/usr/bin"
-        "/bin"
-      ]
+      lib.concatStringsSep ":" (
+        [
+          "/run/wrappers/bin"
+          "/run/current-system/sw/bin"
+          "/nix/var/nix/profiles/default/bin"
+          "/usr/local/bin"
+          "/usr/bin"
+          "/bin"
+        ]
+        ++ config.services.open-design.extraBinPaths
+      )
     )
   );
 
@@ -38,6 +43,12 @@
   services.open-design = {
     enable = true;
     autoStart = true;
+    # The hyperframes renderer shells out to `npx`, which isn't otherwise on
+    # the daemon's PATH — renders fail with `spawn npx ENOENT`. Add Node to the
+    # daemon PATH only (not the system) via the module's own extraBinPaths,
+    # pinned to the exact Node the daemon was built against (engines: node ~24)
+    # so the spawned npx matches the daemon runtime.
+    extraBinPaths = [ "${config.services.open-design.package.nodejs}/bin" ];
     port = 7457; # daemon, loopback
     webFrontend = {
       enable = true;


### PR DESCRIPTION
Three Nexus open-design fixes surfaced from the daemon journal and the web UI:

- **npx ENOENT** — the hyperframes renderer shells out to `npx`, which wasn't on the daemon's PATH, so renders failed with `spawn npx ENOENT`. Add Node via the module's own `extraBinPaths` (daemon PATH only, not the system), pinned to the exact `~24` build the daemon ships, and make the forced PATH override honour `extraBinPaths`.
- **413 on attachment upload** — the `design.matteopacini.me` vhost capped request bodies at 32MB, but the daemon's `projectUpload` accepts 200MB. Raise the Caddy cap to 210MB so the daemon is the real limit.
- **Allowlist** — narrow the design vhost LAN gate from `192.168.0.0/16` to `192.168.10.0/24` + `192.168.20.0/24` (tailnet + loopback unchanged).