### PR TITLE
chore: weekly flake update - 2026-06-23T11:02:35Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -178,11 +178,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1779670703,
-        "narHash": "sha256-UdfMivNMwCCqQsYDg5pSz8X2IOaOrIZLIIy+Bg3CO2o=",
+        "lastModified": 1782007937,
+        "narHash": "sha256-PbnJr+eB+9Czol3ReI83dUgEhcn0sDK6TSy6ODTQm88=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "942159e73e40bf785816f7f1f5feed9ef3d7c8f9",
+        "rev": "981bd332015397fb1ca033fa982bd61635160c78",
         "type": "github"
       },
       "original": {
@@ -366,11 +366,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781810163,
-        "narHash": "sha256-dk8lIk0UnO8GD3e7e3HM1vSYXpbEDmhy67w7KztfdCg=",
+        "lastModified": 1782358560,
+        "narHash": "sha256-vCcLh9pw3XO/+Lxk8r6xv6QnoCrTfGqiACcI7O637Wg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c8f0b8ed441c95bfeaf33555e7631044bb09f384",
+        "rev": "3a70e333f2950c302e875c44cfcfaff3f80f36bc",
         "type": "github"
       },
       "original": {
@@ -403,11 +403,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1781825415,
-        "narHash": "sha256-C06g7QoXlSpZBRJtjXkRHxuJ9DpcxYBnQABihpoA4WY=",
+        "lastModified": 1782368001,
+        "narHash": "sha256-xNz9v8X02WJ69PdnudEuXCIX176h+h+zZAhuhpJeI0k=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "07b41729b9a8b32e09e8be71dee91cfaf7d48479",
+        "rev": "10ae6135ce27f023eca7d64d3def7efc3ddac424",
         "type": "github"
       },
       "original": {
@@ -419,11 +419,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1781829607,
-        "narHash": "sha256-e0tTfcVQENdI5I29mwsN7A8PCFAkcbE9A+qUlOf6nG4=",
+        "lastModified": 1782371609,
+        "narHash": "sha256-wlZK3g+8sZx89vZZn4u/5gFAr1JeIW3QW+/oy1/lHqM=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "6900d711fc299d7e4764ec8be9b6cd26a64fae99",
+        "rev": "3cedcd7aaefa1ffda99a25a1b87e41f5e85a3975",
         "type": "github"
       },
       "original": {
@@ -467,28 +467,6 @@
       "original": {
         "owner": "Gerg-L",
         "repo": "mnw",
-        "type": "github"
-      }
-    },
-    "ndg": {
-      "inputs": {
-        "nixpkgs": [
-          "nvf",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779233504,
-        "narHash": "sha256-YIKEyzh0NFQlD0O92LQQNMoVCDwV8yw1Xz0Iu+4ZC5U=",
-        "owner": "feel-co",
-        "repo": "ndg",
-        "rev": "86f6644411a64d5413711895b7cf6e0e1be465b6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "feel-co",
-        "ref": "refs/tags/v2.8.0",
-        "repo": "ndg",
         "type": "github"
       }
     },
@@ -538,11 +516,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781422160,
-        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
+        "lastModified": 1782030356,
+        "narHash": "sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
+        "rev": "3017088b49efd404f78e3b104f553b97e4af786b",
         "type": "github"
       },
       "original": {
@@ -584,11 +562,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1781828611,
-        "narHash": "sha256-UsXZLbds7f/pcs9y4gm3WkHrS9bOtb7jXsOZn5fmQts=",
+        "lastModified": 1782371641,
+        "narHash": "sha256-qDHJgbfS4N/AKk/IKs37A+3QZcJZmXAmn2qhxIxUvrg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ecd22f91ea9baf622b4f538b16357fa5c52af4a0",
+        "rev": "dfe0a400bbb39c1e378844230d8319601b52115a",
         "type": "github"
       },
       "original": {
@@ -686,11 +664,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781828819,
-        "narHash": "sha256-UiiYjtGWIqwR4eTXrbkOOTlIsidEoj3GHqxDffy+Lpw=",
+        "lastModified": 1782372509,
+        "narHash": "sha256-+hT+UhtaXHHtEbiuAL8XdzudCgAdbbkuBhKuBm49zTk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e5ac01eebec0c35177f10b568d031a220a41695e",
+        "rev": "872b893b05b4e28f766e436e0a734c4cfc8e6713",
         "type": "github"
       },
       "original": {
@@ -704,18 +682,17 @@
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts_3",
         "mnw": "mnw",
-        "ndg": "ndg",
         "nixpkgs": [
           "nixpkgs"
         ],
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1781534482,
-        "narHash": "sha256-d3UIqXuigQhsc7amQkZ7F+SWnaJFAxIROE2f2X+pzUs=",
+        "lastModified": 1782369036,
+        "narHash": "sha256-jxbvrIvE+NklSd6HPNSdEhGr8RvwNj4b7Gd5tgEXwSQ=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "63d8fc82d652c23419a837e2b2934dd4bead04f3",
+        "rev": "096045d0e927bf7064989e9181a89b47c1b8779c",
         "type": "github"
       },
       "original": {
@@ -732,11 +709,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1781773101,
-        "narHash": "sha256-ZGRiuQ4bH3ESJ3CICuRbyOV9UBerxXWtCuR4C5GbuY8=",
+        "lastModified": 1782371403,
+        "narHash": "sha256-5BKvPfBltf7Wt/9FkaMFbxvvlnBxFFH016Lu3WRLrp8=",
         "owner": "nexu-io",
         "repo": "open-design",
-        "rev": "c87934d4678f4f587bad5b124c8445230a554f21",
+        "rev": "a5e2f1bcff4fd9bd6f000a07fc0ebac7eb99cca8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:firelzrd/bore-scheduler/b3d32d475646ab95d7c1e59f210117d71ed5046d' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/981bd332015397fb1ca033fa982bd61635160c78' into the Git cache...
unpacking 'github:nix-community/home-manager/3a70e333f2950c302e875c44cfcfaff3f80f36bc' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/10ae6135ce27f023eca7d64d3def7efc3ddac424' into the Git cache...
unpacking 'github:homebrew/homebrew-core/3cedcd7aaefa1ffda99a25a1b87e41f5e85a3975' into the Git cache...
unpacking 'github:hraban/mac-app-util/4747968574ea58512c5385466400b2364c85d2d0' into the Git cache...
unpacking 'github:lnl7/nix-darwin/a1fa429e945becaf60468600daf649be4ba0350c' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/de7953a08ed4bb9245be043e468561c17b89130d' into the Git cache...
unpacking 'github:nix-community/nix-index-database/3017088b49efd404f78e3b104f553b97e4af786b' into the Git cache...
unpacking 'github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f' into the Git cache...
unpacking 'github:NixOS/nixpkgs/dfe0a400bbb39c1e378844230d8319601b52115a' into the Git cache...
unpacking 'github:nix-community/NUR/872b893b05b4e28f766e436e0a734c4cfc8e6713' into the Git cache...
unpacking 'github:NotAShelf/nvf/096045d0e927bf7064989e9181a89b47c1b8779c' into the Git cache...
unpacking 'github:nexu-io/open-design/a5e2f1bcff4fd9bd6f000a07fc0ebac7eb99cca8' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'firefox-gnome-theme':
    'github:rafaelmardojai/firefox-gnome-theme/942159e73e40bf785816f7f1f5feed9ef3d7c8f9?narHash=sha256-UdfMivNMwCCqQsYDg5pSz8X2IOaOrIZLIIy%2BBg3CO2o%3D' (2026-05-25)
  → 'github:rafaelmardojai/firefox-gnome-theme/981bd332015397fb1ca033fa982bd61635160c78?narHash=sha256-PbnJr%2BeB%2B9Czol3ReI83dUgEhcn0sDK6TSy6ODTQm88%3D' (2026-06-21)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c8f0b8ed441c95bfeaf33555e7631044bb09f384?narHash=sha256-dk8lIk0UnO8GD3e7e3HM1vSYXpbEDmhy67w7KztfdCg%3D' (2026-06-18)
  → 'github:nix-community/home-manager/3a70e333f2950c302e875c44cfcfaff3f80f36bc?narHash=sha256-vCcLh9pw3XO/%2BLxk8r6xv6QnoCrTfGqiACcI7O637Wg%3D' (2026-06-25)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/07b41729b9a8b32e09e8be71dee91cfaf7d48479?narHash=sha256-C06g7QoXlSpZBRJtjXkRHxuJ9DpcxYBnQABihpoA4WY%3D' (2026-06-18)
  → 'github:homebrew/homebrew-cask/10ae6135ce27f023eca7d64d3def7efc3ddac424?narHash=sha256-xNz9v8X02WJ69PdnudEuXCIX176h%2Bh%2BzZAhuhpJeI0k%3D' (2026-06-25)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/6900d711fc299d7e4764ec8be9b6cd26a64fae99?narHash=sha256-e0tTfcVQENdI5I29mwsN7A8PCFAkcbE9A%2BqUlOf6nG4%3D' (2026-06-19)
  → 'github:homebrew/homebrew-core/3cedcd7aaefa1ffda99a25a1b87e41f5e85a3975?narHash=sha256-wlZK3g%2B8sZx89vZZn4u/5gFAr1JeIW3QW%2B/oy1/lHqM%3D' (2026-06-25)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/854d04e2368fb2e9c328a36b3c0a04cd713bfae1?narHash=sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0%3D' (2026-06-14)
  → 'github:nix-community/nix-index-database/3017088b49efd404f78e3b104f553b97e4af786b?narHash=sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4%3D' (2026-06-21)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/ecd22f91ea9baf622b4f538b16357fa5c52af4a0?narHash=sha256-UsXZLbds7f/pcs9y4gm3WkHrS9bOtb7jXsOZn5fmQts%3D' (2026-06-19)
  → 'github:NixOS/nixpkgs/dfe0a400bbb39c1e378844230d8319601b52115a?narHash=sha256-qDHJgbfS4N/AKk/IKs37A%2B3QZcJZmXAmn2qhxIxUvrg%3D' (2026-06-25)
• Updated input 'nur':
    'github:nix-community/NUR/e5ac01eebec0c35177f10b568d031a220a41695e?narHash=sha256-UiiYjtGWIqwR4eTXrbkOOTlIsidEoj3GHqxDffy%2BLpw%3D' (2026-06-19)
  → 'github:nix-community/NUR/872b893b05b4e28f766e436e0a734c4cfc8e6713?narHash=sha256-%2BhT%2BUhtaXHHtEbiuAL8XdzudCgAdbbkuBhKuBm49zTk%3D' (2026-06-25)
• Updated input 'nvf':
    'github:NotAShelf/nvf/63d8fc82d652c23419a837e2b2934dd4bead04f3?narHash=sha256-d3UIqXuigQhsc7amQkZ7F%2BSWnaJFAxIROE2f2X%2BpzUs%3D' (2026-06-15)
  → 'github:NotAShelf/nvf/096045d0e927bf7064989e9181a89b47c1b8779c?narHash=sha256-jxbvrIvE%2BNklSd6HPNSdEhGr8RvwNj4b7Gd5tgEXwSQ%3D' (2026-06-25)
• Removed input 'nvf/ndg'
• Removed input 'nvf/ndg/nixpkgs'
• Updated input 'open-design':
    'github:nexu-io/open-design/c87934d4678f4f587bad5b124c8445230a554f21?narHash=sha256-ZGRiuQ4bH3ESJ3CICuRbyOV9UBerxXWtCuR4C5GbuY8%3D' (2026-06-18)
  → 'github:nexu-io/open-design/a5e2f1bcff4fd9bd6f000a07fc0ebac7eb99cca8?narHash=sha256-5BKvPfBltf7Wt/9FkaMFbxvvlnBxFFH016Lu3WRLrp8%3D' (2026-06-25)
```
