### PR TITLE
feat(brightfalls): package Exiled Exchange 2 and Path of Building PoE2

### DIFF
--- a/hosts/Brightfalls/users/matteo/default.nix
+++ b/hosts/Brightfalls/users/matteo/default.nix
@@ -59,6 +59,9 @@
       reshade-steam-proton
       optiscaler-client
       heroic
+      # Path of Exile 2
+      exiled-exchange-2
+      path-of-building-poe2
       # Other
       discord
     ];

--- a/overlays/brightfalls.nix
+++ b/overlays/brightfalls.nix
@@ -12,6 +12,8 @@ in
 {
   reshade-steam-proton = super.callPackage ../packages/reshade-steam-proton.nix { };
   optiscaler-client = super.callPackage ../packages/optiscaler-client.nix { };
+  exiled-exchange-2 = super.callPackage ../packages/exiled-exchange-2.nix { };
+  path-of-building-poe2 = super.callPackage ../packages/path-of-building-poe2.nix { };
 
   qemu = optimizedForBrightFalls (
     super.qemu.override ({

--- a/packages/exiled-exchange-2.nix
+++ b/packages/exiled-exchange-2.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  makeWrapper,
+}:
+
+let
+  version = "0.15.8";
+in
+appimageTools.wrapType2 {
+  pname = "exiled-exchange-2";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/Kvan7/Exiled-Exchange-2/releases/download/v${version}/Exiled-Exchange-2-${version}.AppImage";
+    hash = "sha256-xmEvKJkRFJokzOa/6qRqT4+QKfnfjIoAfqP+oDqyxH8=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # ee2 wraps the FHS launcher, forcing X11 mode (Electron on Wayland is broken for this app).
+  extraInstallCommands = ''
+    makeWrapper $out/bin/exiled-exchange-2 $out/bin/ee2 \
+      --set XDG_SESSION_TYPE x11 \
+      --add-flags "--ozone-platform=x11"
+  '';
+
+  meta = {
+    description = "Path of Exile 2 trade overlay";
+    homepage = "https://github.com/Kvan7/Exiled-Exchange-2";
+    license = lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "ee2";
+  };
+}

--- a/packages/path-of-building-poe2.nix
+++ b/packages/path-of-building-poe2.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  rsync,
+  wineWow64Packages,
+  writeShellScript,
+}:
+
+let
+  version = "0.21.1";
+  wine = "${wineWow64Packages.staging}/bin/wine";
+  rsyncBin = "${rsync}/bin/rsync";
+
+  launcher = writeShellScript "pob2" ''
+    set -euo pipefail
+    export WINEPREFIX="''${XDG_DATA_HOME:-$HOME/.local/share}/path-of-building-poe2/prefix"
+    appdir="''${XDG_DATA_HOME:-$HOME/.local/share}/path-of-building-poe2/app"
+    mkdir -p "$appdir" "$WINEPREFIX"
+    # Store files are read-only; heal any prior copy and force the synced tree
+    # writable so PoB can save Settings.xml / builds.
+    chmod -R u+w "$appdir"
+    ${rsyncBin} -a --delete --chmod=u+w \
+      --exclude Builds --exclude Settings.xml --exclude imgui.ini \
+      --exclude poe_api_response.json --exclude Update \
+      "@shareDir@/" "$appdir/"
+    cd "$appdir"
+    exec ${wine} "Path of Building-PoE2.exe" "$@"
+  '';
+in
+
+stdenvNoCC.mkDerivation {
+  pname = "path-of-building-poe2";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/releases/download/v${version}/PathOfBuildingCommunity-PoE2-Portable.zip";
+    hash = "sha256-HTnjO60JEOTbt7xQzlnTX36hzghtYqgGjWxH8LkF61I=";
+    stripRoot = false;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    shareDir="$out/share/path-of-building-poe2"
+    mkdir -p "$shareDir" "$out/bin"
+    cp -r . "$shareDir/"
+    substitute ${launcher} "$out/bin/pob2" \
+      --replace-fail "@shareDir@" "$shareDir"
+    chmod +x "$out/bin/pob2"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Path of Building Community fork for Path of Exile 2, running under Wine";
+    homepage = "https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2";
+    license = lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "pob2";
+  };
+}

--- a/scripts/update-poe2-tools.sh
+++ b/scripts/update-poe2-tools.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq gnused
+# Bump the POE2 tool derivations to their latest GitHub releases.
+#   ./scripts/update-poe2-tools.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.." || exit 1
+
+# Exiled Exchange 2 (AppImage, fetchurl -> file hash)
+EE2_FILE="packages/exiled-exchange-2.nix"
+EE2_LATEST_VER="$(curl --fail -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/Kvan7/Exiled-Exchange-2/releases/latest" | jq -r '.tag_name' | sed 's/^v//')"
+EE2_CURRENT_VER="$(grep -oP 'version = "\K[^"]+' "$EE2_FILE")"
+
+if [[ "$EE2_LATEST_VER" == "$EE2_CURRENT_VER" ]]; then
+    echo "exiled-exchange-2 is up-to-date ($EE2_CURRENT_VER)"
+else
+    echo "Updating exiled-exchange-2 from $EE2_CURRENT_VER to $EE2_LATEST_VER"
+    EE2_URL="https://github.com/Kvan7/Exiled-Exchange-2/releases/download/v${EE2_LATEST_VER}/Exiled-Exchange-2-${EE2_LATEST_VER}.AppImage"
+    EE2_HASH="$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url --type sha256 "$EE2_URL")")"
+    sed -i "s#version = \".*\";#version = \"$EE2_LATEST_VER\";#g" "$EE2_FILE"
+    sed -i "s#hash = \".*\"#hash = \"$EE2_HASH\"#g" "$EE2_FILE"
+    echo "Updated exiled-exchange-2 to $EE2_LATEST_VER"
+fi
+
+# Path of Building (PoE2) (portable zip, fetchzip -> unpacked hash)
+POB2_FILE="packages/path-of-building-poe2.nix"
+POB2_LATEST_VER="$(curl --fail -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/PathOfBuildingCommunity/PathOfBuilding-PoE2/releases/latest" | jq -r '.tag_name' | sed 's/^v//')"
+POB2_CURRENT_VER="$(grep -oP 'version = "\K[^"]+' "$POB2_FILE")"
+
+if [[ "$POB2_LATEST_VER" == "$POB2_CURRENT_VER" ]]; then
+    echo "path-of-building-poe2 is up-to-date ($POB2_CURRENT_VER)"
+else
+    echo "Updating path-of-building-poe2 from $POB2_CURRENT_VER to $POB2_LATEST_VER"
+    POB2_URL="https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/releases/download/v${POB2_LATEST_VER}/PathOfBuildingCommunity-PoE2-Portable.zip"
+    POB2_HASH="$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url --unpack --type sha256 "$POB2_URL")")"
+    sed -i "s#version = \".*\";#version = \"$POB2_LATEST_VER\";#g" "$POB2_FILE"
+    sed -i "s#hash = \".*\"#hash = \"$POB2_HASH\"#g" "$POB2_FILE"
+    echo "Updated path-of-building-poe2 to $POB2_LATEST_VER"
+fi


### PR DESCRIPTION
Adds two POE2 tool derivations to the BrightFalls `matteo` HM config.

## Packages
- **exiled-exchange-2** (`ee2`) — AppImage wrapped via `appimageTools.wrapType2`, forced to X11 mode (`XDG_SESSION_TYPE=x11` + `--ozone-platform=x11`) since Electron-on-Wayland is broken for the overlay.
- **path-of-building-poe2** (`pob2`) — portable Windows build run under `wineWow64Packages.staging`. Launcher rsyncs the read-only store tree into `$XDG_DATA_HOME/path-of-building-poe2/app` with `--chmod=u+w`, excluding user files (`Builds`, `Settings.xml`, `imgui.ini`, `poe_api_response.json`, `Update`) so PoB can persist settings/builds without the store's read-only perms breaking saves.

## Wiring
- `overlays/brightfalls.nix` — `callPackage` both.
- `hosts/Brightfalls/users/matteo/default.nix` — added to the gaming package set.

## Updater
`scripts/update-poe2-tools.sh` bumps both to their latest GitHub releases (file hash for the AppImage, `--unpack` hash for the zip), matching the nixpkgs `update.sh` conventions. Version is `let`-bound and interpolated into the URL so the version+hash rewrite stays consistent.