### PR TITLE
chore: weekly flake update - 2026-06-25T21:46:46Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782358560,
-        "narHash": "sha256-vCcLh9pw3XO/+Lxk8r6xv6QnoCrTfGqiACcI7O637Wg=",
+        "lastModified": 1782423922,
+        "narHash": "sha256-qPNd6lUohHP5gcJhqQ7rLV87RwIx0xYR2A4Frb9Zjc4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3a70e333f2950c302e875c44cfcfaff3f80f36bc",
+        "rev": "5d320ab301cfaaca7d32514f13815d19d109f5f4",
         "type": "github"
       },
       "original": {
@@ -403,11 +403,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1782368001,
-        "narHash": "sha256-xNz9v8X02WJ69PdnudEuXCIX176h+h+zZAhuhpJeI0k=",
+        "lastModified": 1782429654,
+        "narHash": "sha256-ZQws92/GTDgxp4dBOlDD4PEcToOgM+fFrZ5ZNl0VY8g=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "10ae6135ce27f023eca7d64d3def7efc3ddac424",
+        "rev": "27485669252720cf610ef29f817f41d829968769",
         "type": "github"
       },
       "original": {
@@ -419,11 +419,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1782371609,
-        "narHash": "sha256-wlZK3g+8sZx89vZZn4u/5gFAr1JeIW3QW+/oy1/lHqM=",
+        "lastModified": 1782431202,
+        "narHash": "sha256-b69gNsVo8vzVBfpimLSuskyBwxf8++V5eVuDqCEqwUc=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "3cedcd7aaefa1ffda99a25a1b87e41f5e85a3975",
+        "rev": "5342a1ecfbc6cdefdd48fb8d5816a42c4d566a1c",
         "type": "github"
       },
       "original": {
@@ -562,11 +562,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1782371641,
-        "narHash": "sha256-qDHJgbfS4N/AKk/IKs37A+3QZcJZmXAmn2qhxIxUvrg=",
+        "lastModified": 1782431322,
+        "narHash": "sha256-MR396R6ka7O//oj2IFAqsvEtHz7NTOgNLkvmCife+WE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfe0a400bbb39c1e378844230d8319601b52115a",
+        "rev": "19e056881cad0187f3361e5792acb4d6e9d9add8",
         "type": "github"
       },
       "original": {
@@ -664,11 +664,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782372509,
-        "narHash": "sha256-+hT+UhtaXHHtEbiuAL8XdzudCgAdbbkuBhKuBm49zTk=",
+        "lastModified": 1782433860,
+        "narHash": "sha256-3tGQ7R+l5VKDP8ppKuWan2xhHXBwx1tx3IQKziPDeHw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "872b893b05b4e28f766e436e0a734c4cfc8e6713",
+        "rev": "e265cb8c811731b8228d4261823dbe3d0810219f",
         "type": "github"
       },
       "original": {
@@ -709,11 +709,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1782371403,
-        "narHash": "sha256-5BKvPfBltf7Wt/9FkaMFbxvvlnBxFFH016Lu3WRLrp8=",
+        "lastModified": 1782402280,
+        "narHash": "sha256-LtyeMBTY2BYXPl97xSNCe3RRRZk3kImlinqFBSKRgHI=",
         "owner": "nexu-io",
         "repo": "open-design",
-        "rev": "a5e2f1bcff4fd9bd6f000a07fc0ebac7eb99cca8",
+        "rev": "4bfe4ba8ca694723424ae17cfbf2953e90f15a73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:firelzrd/bore-scheduler/b3d32d475646ab95d7c1e59f210117d71ed5046d' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/981bd332015397fb1ca033fa982bd61635160c78' into the Git cache...
unpacking 'github:nix-community/home-manager/5d320ab301cfaaca7d32514f13815d19d109f5f4' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/27485669252720cf610ef29f817f41d829968769' into the Git cache...
unpacking 'github:homebrew/homebrew-core/5342a1ecfbc6cdefdd48fb8d5816a42c4d566a1c' into the Git cache...
unpacking 'github:hraban/mac-app-util/4747968574ea58512c5385466400b2364c85d2d0' into the Git cache...
unpacking 'github:lnl7/nix-darwin/a1fa429e945becaf60468600daf649be4ba0350c' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/de7953a08ed4bb9245be043e468561c17b89130d' into the Git cache...
unpacking 'github:nix-community/nix-index-database/3017088b49efd404f78e3b104f553b97e4af786b' into the Git cache...
unpacking 'github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f' into the Git cache...
unpacking 'github:NixOS/nixpkgs/19e056881cad0187f3361e5792acb4d6e9d9add8' into the Git cache...
unpacking 'github:nix-community/NUR/e265cb8c811731b8228d4261823dbe3d0810219f' into the Git cache...
unpacking 'github:NotAShelf/nvf/096045d0e927bf7064989e9181a89b47c1b8779c' into the Git cache...
unpacking 'github:nexu-io/open-design/4bfe4ba8ca694723424ae17cfbf2953e90f15a73' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/3a70e333f2950c302e875c44cfcfaff3f80f36bc?narHash=sha256-vCcLh9pw3XO/%2BLxk8r6xv6QnoCrTfGqiACcI7O637Wg%3D' (2026-06-25)
  → 'github:nix-community/home-manager/5d320ab301cfaaca7d32514f13815d19d109f5f4?narHash=sha256-qPNd6lUohHP5gcJhqQ7rLV87RwIx0xYR2A4Frb9Zjc4%3D' (2026-06-25)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/10ae6135ce27f023eca7d64d3def7efc3ddac424?narHash=sha256-xNz9v8X02WJ69PdnudEuXCIX176h%2Bh%2BzZAhuhpJeI0k%3D' (2026-06-25)
  → 'github:homebrew/homebrew-cask/27485669252720cf610ef29f817f41d829968769?narHash=sha256-ZQws92/GTDgxp4dBOlDD4PEcToOgM%2BfFrZ5ZNl0VY8g%3D' (2026-06-25)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/3cedcd7aaefa1ffda99a25a1b87e41f5e85a3975?narHash=sha256-wlZK3g%2B8sZx89vZZn4u/5gFAr1JeIW3QW%2B/oy1/lHqM%3D' (2026-06-25)
  → 'github:homebrew/homebrew-core/5342a1ecfbc6cdefdd48fb8d5816a42c4d566a1c?narHash=sha256-b69gNsVo8vzVBfpimLSuskyBwxf8%2B%2BV5eVuDqCEqwUc%3D' (2026-06-25)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/dfe0a400bbb39c1e378844230d8319601b52115a?narHash=sha256-qDHJgbfS4N/AKk/IKs37A%2B3QZcJZmXAmn2qhxIxUvrg%3D' (2026-06-25)
  → 'github:NixOS/nixpkgs/19e056881cad0187f3361e5792acb4d6e9d9add8?narHash=sha256-MR396R6ka7O//oj2IFAqsvEtHz7NTOgNLkvmCife%2BWE%3D' (2026-06-25)
• Updated input 'nur':
    'github:nix-community/NUR/872b893b05b4e28f766e436e0a734c4cfc8e6713?narHash=sha256-%2BhT%2BUhtaXHHtEbiuAL8XdzudCgAdbbkuBhKuBm49zTk%3D' (2026-06-25)
  → 'github:nix-community/NUR/e265cb8c811731b8228d4261823dbe3d0810219f?narHash=sha256-3tGQ7R%2Bl5VKDP8ppKuWan2xhHXBwx1tx3IQKziPDeHw%3D' (2026-06-26)
• Updated input 'open-design':
    'github:nexu-io/open-design/a5e2f1bcff4fd9bd6f000a07fc0ebac7eb99cca8?narHash=sha256-5BKvPfBltf7Wt/9FkaMFbxvvlnBxFFH016Lu3WRLrp8%3D' (2026-06-25)
  → 'github:nexu-io/open-design/4bfe4ba8ca694723424ae17cfbf2953e90f15a73?narHash=sha256-LtyeMBTY2BYXPl97xSNCe3RRRZk3kImlinqFBSKRgHI%3D' (2026-06-25)
```
