### PR TITLE
feat(nexus): migrate Home Assistant Volvo to core integration

### DIFF
--- a/hosts/Nexus/services/home-assistant.nix
+++ b/hosts/Nexus/services/home-assistant.nix
@@ -88,11 +88,12 @@ in
       "shelly"
       # SmartThings
       "smartthings"
+      # Volvo (core integration, OAuth via Application Credentials)
+      "volvo"
     ];
     customComponents = with pkgs.home-assistant-custom-components; [
       waste_collection_schedule
       smartthinq-sensors
-      volvo_cars
       octopus_energy
       localtuya
       (pkgs.buildHomeAssistantComponent rec {


### PR DESCRIPTION
## What

Replace the EOL `volvo_cars` HACS custom component with Home Assistant's **core `volvo` integration**.

## Why

`thomasddn/ha-volvo-cars` (`volvo_cars`) is **end-of-life** — v1.5.7 is a "we've gone official" stub — and its OTP re-auth flow is broken: the OTP code is rejected on every re-auth attempt. The same author wrote the official core `volvo` integration (HA 2025.8+), which uses **OAuth2/PKCE via Application Credentials — no OTP**.

## Change

- Add `"volvo"` to `extraComponents`
- Drop `volvo_cars` from `customComponents`

`volvocarsapi` 0.4.3 (matches the integration manifest) and `application_credentials` are already in the pin and pulled in transitively — no override or extra package needed.

## Verification

`nix eval .#nixosConfigurations.Nexus.config.system.build.toplevel` evaluates clean.

## Post-merge (manual, on host)

1. Volvo developer portal: create + **publish** an API app → `client_id` / `client_secret` (redirect URI `https://my.home-assistant.io/redirect/oauth`, select all scopes) and grab the **API key**.
2. `nixos-rebuild switch` → delete the orphaned `volvo_cars` entry in HA.
3. Settings → Devices & Services → Application Credentials → add `volvo` client_id/secret; then add the **Volvo** integration (OAuth login → paste API key).
4. Entity IDs differ from the HACS version — update dashboards/automations referencing `volvo_cars.*`.