### PR TITLE
chore(ci): bump actions/checkout to v7 and nix-quick-install-action to v35

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -85,7 +85,7 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 
@@ -97,7 +97,7 @@ jobs:
           nix-permission-edict: true
 
       - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
+        uses: nixbuild/nix-quick-install-action@v35
         with:
           nix_conf: |
             keep-outputs = true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 
@@ -59,7 +59,7 @@ jobs:
           nix-permission-edict: true
 
       - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
+        uses: nixbuild/nix-quick-install-action@v35
         with:
           nix_conf: |
             keep-outputs = true

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
+        uses: nixbuild/nix-quick-install-action@v35
         with:
           nix_conf: |
             keep-outputs = true

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
+        uses: nixbuild/nix-quick-install-action@v35
 
       - name: Evaluate configuration
         run: |
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - uses: wimpysworld/nothing-but-nix@v10
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
@@ -91,7 +91,7 @@ jobs:
           nix-permission-edict: true
 
       - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v34
+        uses: nixbuild/nix-quick-install-action@v35
         with:
           nix_conf: |
             keep-outputs = true


### PR DESCRIPTION
Bumps two GitHub Actions, combining what Dependabot proposed in #324 and #325 into a single first-party PR.

- `actions/checkout` v6 → v7
- `nixbuild/nix-quick-install-action` v34 → v35 (default Nix 2.29.2 → 2.34.7)

Applied across all four workflows (`build`, `build-package`, `flake-update`, `pr-build`). Diff is identical to the two Dependabot PRs combined.

Opened by hand rather than merging the Dependabot PRs because Dependabot-context runs don't receive the repo's Actions secrets (`ATTIC_CACHE_URL`/`ATTIC_TOKEN`), so the `Configure Attic cache` step failed with `relative URL without a base`. This PR runs with secrets and exercises the bumped actions properly.

Supersedes #324 and #325.
