### PR TITLE
chore: weekly flake update - 2026-06-27T14:59:44Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1783037836,
-        "narHash": "sha256-lGJSxn4T798kID3FsAUAeIheUhVzXhSqZjNHHsJXiwQ=",
+        "lastModified": 1783110564,
+        "narHash": "sha256-9/rkVSh0wIe/87Xkq7zGt/TD9VdtlakAZcAs241Fya0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9778ed56742b4080a2cbe033c0ba2ad1732a6ce3",
+        "rev": "3062c0412a49a04a5dbfda63e911944f9917cf6c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782423922,
-        "narHash": "sha256-qPNd6lUohHP5gcJhqQ7rLV87RwIx0xYR2A4Frb9Zjc4=",
+        "lastModified": 1783024095,
+        "narHash": "sha256-oE+TNK98Pl7nHW4VU1oBvUKD5JR45U+py/NJmLoTNHI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d320ab301cfaaca7d32514f13815d19d109f5f4",
+        "rev": "a4d410db95a6416d1008049330bd86b85b5db45a",
         "type": "github"
       },
       "original": {
@@ -403,11 +403,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1782429654,
-        "narHash": "sha256-ZQws92/GTDgxp4dBOlDD4PEcToOgM+fFrZ5ZNl0VY8g=",
+        "lastModified": 1783037844,
+        "narHash": "sha256-CT8bsXHBJ5+WKSFqiSK23qCWJ0XkvWBIC6fwJjxd62Q=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "27485669252720cf610ef29f817f41d829968769",
+        "rev": "1ffb9c4f194432383f7e9e3f762f065786cbbcb0",
         "type": "github"
       },
       "original": {
@@ -419,11 +419,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1782431202,
-        "narHash": "sha256-b69gNsVo8vzVBfpimLSuskyBwxf8++V5eVuDqCEqwUc=",
+        "lastModified": 1783038066,
+        "narHash": "sha256-RiHOJwEJIqOeQxj460/G4r/+KPoSJlD7RitgBEfonfY=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "5342a1ecfbc6cdefdd48fb8d5816a42c4d566a1c",
+        "rev": "930a0bb63bf27ad0698329bf4a2cb43e10c3eb41",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782030356,
-        "narHash": "sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4=",
+        "lastModified": 1783023993,
+        "narHash": "sha256-gaOvvY/lL1eWoSmSRO17pWry8R49AuPMrF4nzu47K5o=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "3017088b49efd404f78e3b104f553b97e4af786b",
+        "rev": "f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074",
         "type": "github"
       },
       "original": {
@@ -562,11 +562,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1782431322,
-        "narHash": "sha256-MR396R6ka7O//oj2IFAqsvEtHz7NTOgNLkvmCife+WE=",
+        "lastModified": 1783037836,
+        "narHash": "sha256-lGJSxn4T798kID3FsAUAeIheUhVzXhSqZjNHHsJXiwQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "19e056881cad0187f3361e5792acb4d6e9d9add8",
+        "rev": "9778ed56742b4080a2cbe033c0ba2ad1732a6ce3",
         "type": "github"
       },
       "original": {
@@ -626,11 +626,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -664,11 +664,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782433860,
-        "narHash": "sha256-3tGQ7R+l5VKDP8ppKuWan2xhHXBwx1tx3IQKziPDeHw=",
+        "lastModified": 1783038279,
+        "narHash": "sha256-oGef/R5pir7Xf4kKuPp/eyZ/O9qTzfusZj2tCxLLQyw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e265cb8c811731b8228d4261823dbe3d0810219f",
+        "rev": "50568da312ee2ce0623c94f0cf6cb48f65d57490",
         "type": "github"
       },
       "original": {
@@ -688,11 +688,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1782369036,
-        "narHash": "sha256-jxbvrIvE+NklSd6HPNSdEhGr8RvwNj4b7Gd5tgEXwSQ=",
+        "lastModified": 1783020948,
+        "narHash": "sha256-72w8cZWJhcIo8ThuxP6Mh/hwvnjnO03c8C80h6iAfFE=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "096045d0e927bf7064989e9181a89b47c1b8779c",
+        "rev": "1f0b98b404daac6635d766455ab3dd06f6c85866",
         "type": "github"
       },
       "original": {
@@ -709,11 +709,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1782402280,
-        "narHash": "sha256-LtyeMBTY2BYXPl97xSNCe3RRRZk3kImlinqFBSKRgHI=",
+        "lastModified": 1783006351,
+        "narHash": "sha256-rhHjAL9QldPQ4x36Cbjb0267qHij5S/wOHbtqJgJCK0=",
         "owner": "nexu-io",
         "repo": "open-design",
-        "rev": "4bfe4ba8ca694723424ae17cfbf2953e90f15a73",
+        "rev": "0b88ef56144b5a42dc427c1292ae22676d698a34",
         "type": "github"
       },
       "original": {

--- a/hosts/Nexus/services/caddy.nix
+++ b/hosts/Nexus/services/caddy.nix
@@ -19,7 +19,7 @@ in
     # DNS-01 challenge instead of HTTP-01 — no inbound port 80 needed.
     package = pkgs.caddy.withPlugins {
       plugins = [ "github.com/caddy-dns/route53@v1.6.2" ];
-      hash = "sha256-gYHZQQ8Ca3hTTVAeJ9vKzIi7O/iKShmBQR46G3aFY0c=";
+      hash = "sha256-dxrfc6o6PBxRqMRUDpenHDctHUNQx4ZmAy9577RTTKg=";
     };
 
     # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for the Route53 plugin.

--- a/hosts/Nexus/services/zigbee2mqtt.nix
+++ b/hosts/Nexus/services/zigbee2mqtt.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, ... }:
+{ pkgs, config, lib, ... }:
 {
   systemd.services.zigbee2mqtt = {
     serviceConfig = {
@@ -6,7 +6,7 @@
         config.age.secrets."nexus/zigbee2mqtt.env".path
       ];
       Restart = "on-failure";
-      RestartSec = "60";
+      RestartSec = lib.mkForce "60";
     };
     unitConfig = {
       StartLimitBurst = 3;

--- a/modules/home-manager/claude-code.nix
+++ b/modules/home-manager/claude-code.nix
@@ -17,6 +17,13 @@ let
   # a full model ID (e.g. "claude-opus-4-8") when you need a specific version.
   # Empty list = model does not support --effort.
   modelEfforts = {
+    fable = [
+      "low"
+      "medium"
+      "high"
+      "xhigh"
+      "max"
+    ];
     opus = [
       "low"
       "medium"
@@ -28,6 +35,7 @@ let
       "low"
       "medium"
       "high"
+      "xhigh"
       "max"
     ];
     haiku = [ ];
@@ -45,17 +53,25 @@ let
       "high"
       "max"
     ];
+    "claude-sonnet-4-6" = [
+      "low"
+      "medium"
+      "high"
+      "max"
+    ];
   };
 
   # Maps each modelEfforts key to the slug used in the shell alias name
   # (`claude-<slug>` and `claude-<slug>-<effort>`). Pinned IDs get a compact
   # slug to avoid dash ambiguity with the effort suffix.
   modelAliasSlug = {
+    fable = "fable";
     opus = "opus";
     sonnet = "sonnet";
     haiku = "haiku";
     "claude-opus-4-7" = "opus47";
     "claude-opus-4-6" = "opus46";
+    "claude-sonnet-4-6" = "sonnet46";
   };
 
   # Whether each model supports the 1M-token context window. Source:
@@ -63,11 +79,13 @@ let
   # When true, an additional set of `claude-<slug>-1m[-<effort>]` aliases is
   # generated, invoking the model with the `[1m]` suffix.
   model1mContext = {
+    fable = true;
     opus = true;
-    sonnet = true;
+    sonnet = false; # Sonnet 5 is natively 1M; no [1m] variant
     haiku = false;
     "claude-opus-4-7" = true;
     "claude-opus-4-6" = true;
+    "claude-sonnet-4-6" = true;
   };
 
   # Generate `claude-<slug>[-<effort>]` for the default context window, plus


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:firelzrd/bore-scheduler/b3d32d475646ab95d7c1e59f210117d71ed5046d' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/981bd332015397fb1ca033fa982bd61635160c78' into the Git cache...
unpacking 'github:nix-community/home-manager/a4d410db95a6416d1008049330bd86b85b5db45a' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/1ffb9c4f194432383f7e9e3f762f065786cbbcb0' into the Git cache...
unpacking 'github:homebrew/homebrew-core/930a0bb63bf27ad0698329bf4a2cb43e10c3eb41' into the Git cache...
unpacking 'github:hraban/mac-app-util/4747968574ea58512c5385466400b2364c85d2d0' into the Git cache...
unpacking 'github:lnl7/nix-darwin/a1fa429e945becaf60468600daf649be4ba0350c' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/de7953a08ed4bb9245be043e468561c17b89130d' into the Git cache...
unpacking 'github:nix-community/nix-index-database/f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074' into the Git cache...
unpacking 'github:NixOS/nixpkgs/b5aa0fbd538984f6e3d201be0005b4463d8b09f8' into the Git cache...
unpacking 'github:NixOS/nixpkgs/9778ed56742b4080a2cbe033c0ba2ad1732a6ce3' into the Git cache...
unpacking 'github:nix-community/NUR/50568da312ee2ce0623c94f0cf6cb48f65d57490' into the Git cache...
unpacking 'github:NotAShelf/nvf/1f0b98b404daac6635d766455ab3dd06f6c85866' into the Git cache...
unpacking 'github:nexu-io/open-design/0b88ef56144b5a42dc427c1292ae22676d698a34' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/5d320ab301cfaaca7d32514f13815d19d109f5f4?narHash=sha256-qPNd6lUohHP5gcJhqQ7rLV87RwIx0xYR2A4Frb9Zjc4%3D' (2026-06-25)
  → 'github:nix-community/home-manager/a4d410db95a6416d1008049330bd86b85b5db45a?narHash=sha256-oE%2BTNK98Pl7nHW4VU1oBvUKD5JR45U%2Bpy/NJmLoTNHI%3D' (2026-07-02)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/27485669252720cf610ef29f817f41d829968769?narHash=sha256-ZQws92/GTDgxp4dBOlDD4PEcToOgM%2BfFrZ5ZNl0VY8g%3D' (2026-06-25)
  → 'github:homebrew/homebrew-cask/1ffb9c4f194432383f7e9e3f762f065786cbbcb0?narHash=sha256-CT8bsXHBJ5%2BWKSFqiSK23qCWJ0XkvWBIC6fwJjxd62Q%3D' (2026-07-03)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/5342a1ecfbc6cdefdd48fb8d5816a42c4d566a1c?narHash=sha256-b69gNsVo8vzVBfpimLSuskyBwxf8%2B%2BV5eVuDqCEqwUc%3D' (2026-06-25)
  → 'github:homebrew/homebrew-core/930a0bb63bf27ad0698329bf4a2cb43e10c3eb41?narHash=sha256-RiHOJwEJIqOeQxj460/G4r/%2BKPoSJlD7RitgBEfonfY%3D' (2026-07-03)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/3017088b49efd404f78e3b104f553b97e4af786b?narHash=sha256-h4WpMr455AfRub0FXBaon6Vcpe0waUyJ4GivIW6oyd4%3D' (2026-06-21)
  → 'github:nix-community/nix-index-database/f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074?narHash=sha256-gaOvvY/lL1eWoSmSRO17pWry8R49AuPMrF4nzu47K5o%3D' (2026-07-02)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f?narHash=sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H%2BCNW1Ck8B%2B8%3D' (2026-06-16)
  → 'github:NixOS/nixpkgs/b5aa0fbd538984f6e3d201be0005b4463d8b09f8?narHash=sha256-oPXCU/SSUokcGaJREHibG1CBX3%2Bs/W7orDWQOZDsEeQ%3D' (2026-06-29)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/19e056881cad0187f3361e5792acb4d6e9d9add8?narHash=sha256-MR396R6ka7O//oj2IFAqsvEtHz7NTOgNLkvmCife%2BWE%3D' (2026-06-25)
  → 'github:NixOS/nixpkgs/9778ed56742b4080a2cbe033c0ba2ad1732a6ce3?narHash=sha256-lGJSxn4T798kID3FsAUAeIheUhVzXhSqZjNHHsJXiwQ%3D' (2026-07-03)
• Updated input 'nur':
    'github:nix-community/NUR/e265cb8c811731b8228d4261823dbe3d0810219f?narHash=sha256-3tGQ7R%2Bl5VKDP8ppKuWan2xhHXBwx1tx3IQKziPDeHw%3D' (2026-06-26)
  → 'github:nix-community/NUR/50568da312ee2ce0623c94f0cf6cb48f65d57490?narHash=sha256-oGef/R5pir7Xf4kKuPp/eyZ/O9qTzfusZj2tCxLLQyw%3D' (2026-07-03)
• Updated input 'nvf':
    'github:NotAShelf/nvf/096045d0e927bf7064989e9181a89b47c1b8779c?narHash=sha256-jxbvrIvE%2BNklSd6HPNSdEhGr8RvwNj4b7Gd5tgEXwSQ%3D' (2026-06-25)
  → 'github:NotAShelf/nvf/1f0b98b404daac6635d766455ab3dd06f6c85866?narHash=sha256-72w8cZWJhcIo8ThuxP6Mh/hwvnjnO03c8C80h6iAfFE%3D' (2026-07-02)
• Updated input 'open-design':
    'github:nexu-io/open-design/4bfe4ba8ca694723424ae17cfbf2953e90f15a73?narHash=sha256-LtyeMBTY2BYXPl97xSNCe3RRRZk3kImlinqFBSKRgHI%3D' (2026-06-25)
  → 'github:nexu-io/open-design/0b88ef56144b5a42dc427c1292ae22676d698a34?narHash=sha256-rhHjAL9QldPQ4x36Cbjb0267qHij5S/wOHbtqJgJCK0%3D' (2026-07-02)
```
