### PR TITLE
feat(brightfalls): restore sunshine, drop stale monitors.xml block

### DIFF
--- a/hosts/Brightfalls/gaming.nix
+++ b/hosts/Brightfalls/gaming.nix
@@ -72,4 +72,33 @@
       "$@"
     '')
   ];
+
+  services.sunshine = {
+    enable = true;
+    openFirewall = true;
+    autoStart = true;
+    capSysAdmin = true;
+    applications = {
+      apps = [
+        {
+          name = "Desktop";
+          image-path = "desktop.png";
+        }
+      ];
+    };
+    settings = {
+      sunshine_name = "BrightFalls Sunshine";
+      global_prep_cmd = builtins.toJSON [
+        {
+          # Switch to HDMI for streaming (e.g., TV via capture card)
+          do = "${pkgs.mutter}/bin/gdctl set --logical-monitor --primary --monitor HDMI-1 --mode 3840x2160@59.940";
+          # Restore dual DP monitors when streaming ends
+          undo = "${pkgs.mutter}/bin/gdctl set --logical-monitor --primary --monitor DP-1 --mode 2560x1440@143.998 --logical-monitor --monitor DP-2 --right-of DP-1 --mode 2560x1440@59.951";
+        }
+      ];
+      audio_sink = "alsa_output.usb-Schiit_Audio_USB_Modi_Device-00.iec958-stereo";
+      fec_percentage = 10;
+      qp = 10;
+    };
+  };
 }

--- a/hosts/Brightfalls/monitors.xml
+++ b/hosts/Brightfalls/monitors.xml
@@ -1,49 +1,5 @@
 <monitors version="2">
   <configuration>
-    <layoutmode>physical</layoutmode>
-    <logicalmonitor>
-      <x>2560</x>
-      <y>0</y>
-      <scale>1</scale>
-      <transform>
-        <rotation>left</rotation>
-        <flipped>no</flipped>
-      </transform>
-      <monitor>
-        <monitorspec>
-          <connector>DP-2</connector>
-          <vendor>DEL</vendor>
-          <product>DELL U2719D</product>
-          <serial>7CGY223</serial>
-        </monitorspec>
-        <mode>
-          <width>2560</width>
-          <height>1440</height>
-          <rate>59.951</rate>
-        </mode>
-      </monitor>
-    </logicalmonitor>
-    <logicalmonitor>
-      <x>0</x>
-      <y>1120</y>
-      <scale>1</scale>
-      <primary>yes</primary>
-      <monitor>
-        <monitorspec>
-          <connector>DP-1</connector>
-          <vendor>AUS</vendor>
-          <product>ROG PG278QR</product>
-          <serial>#ASO0f7HLJ+Pd</serial>
-        </monitorspec>
-        <mode>
-          <width>2560</width>
-          <height>1440</height>
-          <rate>143.998</rate>
-        </mode>
-      </monitor>
-    </logicalmonitor>
-  </configuration>
-  <configuration>
     <layoutmode>logical</layoutmode>
     <logicalmonitor>
       <x>0</x>


### PR DESCRIPTION
Restores the `services.sunshine` block removed in ff546c5, verbatim (gdctl HDMI-1 prep/undo, Schiit Modi audio_sink, openFirewall).

Also removes the stale first `<configuration>` block from `monitors.xml` (old portrait-DP-2 layout, no HDMI-1 disabled entry). Remaining two blocks: DP-1 primary, HDMI-1 (Evanlak dummy) disabled.

Verified: `nix build .#nixosConfigurations.BrightFalls...toplevel` green, monitors.xml xmllint-clean.