### PR TITLE
chore: weekly flake update - 2026-07-06T11:57:01Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1766810506,
-        "narHash": "sha256-I4BxozsEu205tA7jazufztI8ZQ5p7hcCnjqrSKPz9nI=",
+        "lastModified": 1782994178,
+        "narHash": "sha256-VGc3/2fe6hnOmNSLlOygEAbeS69v7A7rjKDKRzAgE2Q=",
         "owner": "hraban",
         "repo": "cl-nix-lite",
-        "rev": "038e341cede255a83a8f04af114dc95717461d32",
+        "rev": "eb584721e5e799bafe0c6210a8a1a398f90e8ac0",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1782007937,
-        "narHash": "sha256-PbnJr+eB+9Czol3ReI83dUgEhcn0sDK6TSy6ODTQm88=",
+        "lastModified": 1783570805,
+        "narHash": "sha256-ptl5aRlCv9/uRSv2u8Hq8UFVFeZ6Q/bT049bpqNgc3w=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "981bd332015397fb1ca033fa982bd61635160c78",
+        "rev": "5602ed62d638142c1ab31dccd01dfbfb28841225",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1730663653,
-        "narHash": "sha256-kFCUWettiFHDIqxCWWQ9qY8pVh+Lj+XL0Giyy/kdomg=",
+        "lastModified": 1766808011,
+        "narHash": "sha256-s83BS0abtIj7vzUf8JE0209KphfHA6qRw/92D9k/F+0=",
         "owner": "hraban",
         "repo": "flake-compat",
-        "rev": "e5b16676185cb7548581c852f51ce7f3a49bba5e",
+        "rev": "6e0aafdc4c4c2043c66f756d5045374b42184fc5",
         "type": "github"
       },
       "original": {
@@ -279,27 +279,6 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nvf",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": [
@@ -322,7 +301,7 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -366,11 +345,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783024095,
-        "narHash": "sha256-oE+TNK98Pl7nHW4VU1oBvUKD5JR45U+py/NJmLoTNHI=",
+        "lastModified": 1783550008,
+        "narHash": "sha256-qbbZUk9IG9dLNwCPwdPBs6I5clxwugRpP+1YU+GPK20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a4d410db95a6416d1008049330bd86b85b5db45a",
+        "rev": "f4d01c1d87c7c2ec909549165d5a8338f1bd3315",
         "type": "github"
       },
       "original": {
@@ -403,11 +382,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1783037844,
-        "narHash": "sha256-CT8bsXHBJ5+WKSFqiSK23qCWJ0XkvWBIC6fwJjxd62Q=",
+        "lastModified": 1783582689,
+        "narHash": "sha256-RsFG2JfSnzDK49tVginO72if590gOheXJTzcCQXDMZQ=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "1ffb9c4f194432383f7e9e3f762f065786cbbcb0",
+        "rev": "6b08a1dca9f3c15470d8220d7d4ba69f2c210df9",
         "type": "github"
       },
       "original": {
@@ -419,11 +398,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1783038066,
-        "narHash": "sha256-RiHOJwEJIqOeQxj460/G4r/+KPoSJlD7RitgBEfonfY=",
+        "lastModified": 1783580556,
+        "narHash": "sha256-yJppQOt56e0EWk6iKjdgszQ+TVVwhU5eFcwLQUwFdQo=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "930a0bb63bf27ad0698329bf4a2cb43e10c3eb41",
+        "rev": "67ad1046fbdc9a98837c0260aad88ee899801be5",
         "type": "github"
       },
       "original": {
@@ -442,11 +421,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1766810876,
-        "narHash": "sha256-VPElWFQIiP31lXQXEom+L4sl85alZpZn33O4hewsP9k=",
+        "lastModified": 1783182903,
+        "narHash": "sha256-7IteXipJZfFepi5zakxe0jQ5i3vRBQguk0+Gtte1Fu4=",
         "owner": "hraban",
         "repo": "mac-app-util",
-        "rev": "4747968574ea58512c5385466400b2364c85d2d0",
+        "rev": "039f33deef21782d4db97087f426504951239887",
         "type": "github"
       },
       "original": {
@@ -477,11 +456,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781761792,
-        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "lastModified": 1783395956,
+        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
         "type": "github"
       },
       "original": {
@@ -516,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783023993,
-        "narHash": "sha256-gaOvvY/lL1eWoSmSRO17pWry8R49AuPMrF4nzu47K5o=",
+        "lastModified": 1783414108,
+        "narHash": "sha256-RY8e+gR2/DhXsYDxGDL6Hhe9+POD9u4+llwxMBqMQDs=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074",
+        "rev": "96d6de10eb281b98f5cfcd1841394c03da5df77c",
         "type": "github"
       },
       "original": {
@@ -531,11 +510,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766736597,
-        "narHash": "sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ=",
+        "lastModified": 1779796641,
+        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f560ccec6b1116b22e6ed15f4c510997d99d5852",
+        "rev": "25f538306313eae3927264466c70d7001dcea1df",
         "type": "github"
       },
       "original": {
@@ -562,11 +541,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1783110564,
-        "narHash": "sha256-9/rkVSh0wIe/87Xkq7zGt/TD9VdtlakAZcAs241Fya0=",
+        "lastModified": 1783580878,
+        "narHash": "sha256-mNSMIcwv6yw0MCX9FiytexfJscX8IZ4VppaV5ONO9Kw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3062c0412a49a04a5dbfda63e911944f9917cf6c",
+        "rev": "d65b116ca7a6f0c568e628e84ab819954d627a49",
         "type": "github"
       },
       "original": {
@@ -594,27 +573,27 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1732617236,
-        "narHash": "sha256-PYkz6U0bSEaEB1al7O1XsqVNeSNS+s3NVclJw7YC43w=",
+        "lastModified": 1782999065,
+        "narHash": "sha256-5Dgj5+pIQYZKrXUGaLCk7CKfN3MmpwIhO94++WVxvng=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af51545ec9a44eadf3fe3547610a5cdd882bc34e",
+        "rev": "80d591ed473cfc46329932c2aadac9b435342c7c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
-        "rev": "af51545ec9a44eadf3fe3547610a5cdd882bc34e",
         "type": "github"
       }
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1761236834,
-        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
         "type": "github"
       },
       "original": {
@@ -626,11 +605,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {
@@ -664,11 +643,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783038279,
-        "narHash": "sha256-oGef/R5pir7Xf4kKuPp/eyZ/O9qTzfusZj2tCxLLQyw=",
+        "lastModified": 1783581051,
+        "narHash": "sha256-23ouasHqej9n3qGGqnq682pEBfYcmCGHVPUnm6WDf8U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "50568da312ee2ce0623c94f0cf6cb48f65d57490",
+        "rev": "21d8513f565042678d71826adffd25fa1ac9418b",
         "type": "github"
       },
       "original": {
@@ -680,19 +659,17 @@
     "nvf": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-parts": "flake-parts_3",
         "mnw": "mnw",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "systems": "systems_4"
+        ]
       },
       "locked": {
-        "lastModified": 1783020948,
-        "narHash": "sha256-72w8cZWJhcIo8ThuxP6Mh/hwvnjnO03c8C80h6iAfFE=",
+        "lastModified": 1783551490,
+        "narHash": "sha256-IgOE1Dh70GnGPWvrwiwUZkmzJURKM40oru0vvRPSu/M=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "1f0b98b404daac6635d766455ab3dd06f6c85866",
+        "rev": "84af0c160f0c1c83179809277124f6dc4712b2b3",
         "type": "github"
       },
       "original": {
@@ -709,11 +686,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1783006351,
-        "narHash": "sha256-rhHjAL9QldPQ4x36Cbjb0267qHij5S/wOHbtqJgJCK0=",
+        "lastModified": 1783582597,
+        "narHash": "sha256-GCbCv0rzd/X0FYsfHloBPelCT54oFdvyEr6eo3e1dN8=",
         "owner": "nexu-io",
         "repo": "open-design",
-        "rev": "0b88ef56144b5a42dc427c1292ae22676d698a34",
+        "rev": "7193e48618689e5397b17fca2482fa1470ce41b9",
         "type": "github"
       },
       "original": {
@@ -891,21 +868,6 @@
         "type": "github"
       }
     },
-    "systems_5": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_2"
@@ -929,11 +891,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1766000401,
-        "narHash": "sha256-+cqN4PJz9y0JQXfAK5J1drd0U05D5fcAGhzhfVrDlsI=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "42d96e75aa56a3f70cab7e7dc4a32868db28e8fd",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:firelzrd/bore-scheduler/b3d32d475646ab95d7c1e59f210117d71ed5046d' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/5602ed62d638142c1ab31dccd01dfbfb28841225' into the Git cache...
unpacking 'github:nix-community/home-manager/f4d01c1d87c7c2ec909549165d5a8338f1bd3315' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/6b08a1dca9f3c15470d8220d7d4ba69f2c210df9' into the Git cache...
unpacking 'github:homebrew/homebrew-core/67ad1046fbdc9a98837c0260aad88ee899801be5' into the Git cache...
unpacking 'github:hraban/mac-app-util/039f33deef21782d4db97087f426504951239887' into the Git cache...
unpacking 'github:lnl7/nix-darwin/d5bd9cd77aea4c0a8f49e7fd85545671a208ed15' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/de7953a08ed4bb9245be043e468561c17b89130d' into the Git cache...
unpacking 'github:nix-community/nix-index-database/96d6de10eb281b98f5cfcd1841394c03da5df77c' into the Git cache...
unpacking 'github:NixOS/nixpkgs/d407951447dcd00442e97087bf374aad70c04cea' into the Git cache...
unpacking 'github:NixOS/nixpkgs/d65b116ca7a6f0c568e628e84ab819954d627a49' into the Git cache...
unpacking 'github:nix-community/NUR/21d8513f565042678d71826adffd25fa1ac9418b' into the Git cache...
unpacking 'github:NotAShelf/nvf/84af0c160f0c1c83179809277124f6dc4712b2b3' into the Git cache...
unpacking 'github:nexu-io/open-design/7193e48618689e5397b17fca2482fa1470ce41b9' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'firefox-gnome-theme':
    'github:rafaelmardojai/firefox-gnome-theme/981bd332015397fb1ca033fa982bd61635160c78?narHash=sha256-PbnJr%2BeB%2B9Czol3ReI83dUgEhcn0sDK6TSy6ODTQm88%3D' (2026-06-21)
  → 'github:rafaelmardojai/firefox-gnome-theme/5602ed62d638142c1ab31dccd01dfbfb28841225?narHash=sha256-ptl5aRlCv9/uRSv2u8Hq8UFVFeZ6Q/bT049bpqNgc3w%3D' (2026-07-09)
• Updated input 'home-manager':
    'github:nix-community/home-manager/a4d410db95a6416d1008049330bd86b85b5db45a?narHash=sha256-oE%2BTNK98Pl7nHW4VU1oBvUKD5JR45U%2Bpy/NJmLoTNHI%3D' (2026-07-02)
  → 'github:nix-community/home-manager/f4d01c1d87c7c2ec909549165d5a8338f1bd3315?narHash=sha256-qbbZUk9IG9dLNwCPwdPBs6I5clxwugRpP%2B1YU%2BGPK20%3D' (2026-07-08)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/1ffb9c4f194432383f7e9e3f762f065786cbbcb0?narHash=sha256-CT8bsXHBJ5%2BWKSFqiSK23qCWJ0XkvWBIC6fwJjxd62Q%3D' (2026-07-03)
  → 'github:homebrew/homebrew-cask/6b08a1dca9f3c15470d8220d7d4ba69f2c210df9?narHash=sha256-RsFG2JfSnzDK49tVginO72if590gOheXJTzcCQXDMZQ%3D' (2026-07-09)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/930a0bb63bf27ad0698329bf4a2cb43e10c3eb41?narHash=sha256-RiHOJwEJIqOeQxj460/G4r/%2BKPoSJlD7RitgBEfonfY%3D' (2026-07-03)
  → 'github:homebrew/homebrew-core/67ad1046fbdc9a98837c0260aad88ee899801be5?narHash=sha256-yJppQOt56e0EWk6iKjdgszQ%2BTVVwhU5eFcwLQUwFdQo%3D' (2026-07-09)
• Updated input 'mac-app-util':
    'github:hraban/mac-app-util/4747968574ea58512c5385466400b2364c85d2d0?narHash=sha256-VPElWFQIiP31lXQXEom%2BL4sl85alZpZn33O4hewsP9k%3D' (2025-12-27)
  → 'github:hraban/mac-app-util/039f33deef21782d4db97087f426504951239887?narHash=sha256-7IteXipJZfFepi5zakxe0jQ5i3vRBQguk0%2BGtte1Fu4%3D' (2026-07-04)
• Updated input 'mac-app-util/cl-nix-lite':
    'github:hraban/cl-nix-lite/038e341cede255a83a8f04af114dc95717461d32?narHash=sha256-I4BxozsEu205tA7jazufztI8ZQ5p7hcCnjqrSKPz9nI%3D' (2025-12-27)
  → 'github:hraban/cl-nix-lite/eb584721e5e799bafe0c6210a8a1a398f90e8ac0?narHash=sha256-VGc3/2fe6hnOmNSLlOygEAbeS69v7A7rjKDKRzAgE2Q%3D' (2026-07-02)
• Updated input 'mac-app-util/cl-nix-lite/nixpkgs':
    'github:nixos/nixpkgs/f560ccec6b1116b22e6ed15f4c510997d99d5852?narHash=sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ%3D' (2025-12-26)
  → 'github:nixos/nixpkgs/25f538306313eae3927264466c70d7001dcea1df?narHash=sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY%3D' (2026-05-26)
• Updated input 'mac-app-util/flake-compat':
    'github:hraban/flake-compat/e5b16676185cb7548581c852f51ce7f3a49bba5e?narHash=sha256-kFCUWettiFHDIqxCWWQ9qY8pVh%2BLj%2BXL0Giyy/kdomg%3D' (2024-11-03)
  → 'github:hraban/flake-compat/6e0aafdc4c4c2043c66f756d5045374b42184fc5?narHash=sha256-s83BS0abtIj7vzUf8JE0209KphfHA6qRw/92D9k/F%2B0%3D' (2025-12-27)
• Updated input 'mac-app-util/nixpkgs':
    'github:NixOS/nixpkgs/af51545ec9a44eadf3fe3547610a5cdd882bc34e?narHash=sha256-PYkz6U0bSEaEB1al7O1XsqVNeSNS%2Bs3NVclJw7YC43w%3D' (2024-11-26)
  → 'github:NixOS/nixpkgs/80d591ed473cfc46329932c2aadac9b435342c7c?narHash=sha256-5Dgj5%2BpIQYZKrXUGaLCk7CKfN3MmpwIhO94%2B%2BWVxvng%3D' (2026-07-02)
• Updated input 'mac-app-util/treefmt-nix':
    'github:numtide/treefmt-nix/42d96e75aa56a3f70cab7e7dc4a32868db28e8fd?narHash=sha256-%2BcqN4PJz9y0JQXfAK5J1drd0U05D5fcAGhzhfVrDlsI%3D' (2025-12-17)
  → 'github:numtide/treefmt-nix/db947814a175b7ca6ded66e21383d938df01c227?narHash=sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM%3D' (2026-05-31)
• Updated input 'mac-app-util/treefmt-nix/nixpkgs':
    'github:nixos/nixpkgs/d5faa84122bc0a1fd5d378492efce4e289f8eac1?narHash=sha256-%2Bpthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE%2BfV2Q%3D' (2025-10-23)
  → 'github:nixos/nixpkgs/4533d9293756b63904b7238acb84ac8fe4c8c2c4?narHash=sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g%3D' (2026-02-03)
• Updated input 'nix-darwin':
    'github:lnl7/nix-darwin/a1fa429e945becaf60468600daf649be4ba0350c?narHash=sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14%3D' (2026-06-18)
  → 'github:lnl7/nix-darwin/d5bd9cd77aea4c0a8f49e7fd85545671a208ed15?narHash=sha256-AAbexQvDoK%2B6GFJdhY6kqjA%2B6ECKRkidgWxkn4gMwAA%3D' (2026-07-07)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074?narHash=sha256-gaOvvY/lL1eWoSmSRO17pWry8R49AuPMrF4nzu47K5o%3D' (2026-07-02)
  → 'github:nix-community/nix-index-database/96d6de10eb281b98f5cfcd1841394c03da5df77c?narHash=sha256-RY8e%2BgR2/DhXsYDxGDL6Hhe9%2BPOD9u4%2BllwxMBqMQDs%3D' (2026-07-07)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/b5aa0fbd538984f6e3d201be0005b4463d8b09f8?narHash=sha256-oPXCU/SSUokcGaJREHibG1CBX3%2Bs/W7orDWQOZDsEeQ%3D' (2026-06-29)
  → 'github:NixOS/nixpkgs/d407951447dcd00442e97087bf374aad70c04cea?narHash=sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU%2BK27sk%3D' (2026-07-05)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/3062c0412a49a04a5dbfda63e911944f9917cf6c?narHash=sha256-9/rkVSh0wIe/87Xkq7zGt/TD9VdtlakAZcAs241Fya0%3D' (2026-07-03)
  → 'github:NixOS/nixpkgs/d65b116ca7a6f0c568e628e84ab819954d627a49?narHash=sha256-mNSMIcwv6yw0MCX9FiytexfJscX8IZ4VppaV5ONO9Kw%3D' (2026-07-09)
• Updated input 'nur':
    'github:nix-community/NUR/50568da312ee2ce0623c94f0cf6cb48f65d57490?narHash=sha256-oGef/R5pir7Xf4kKuPp/eyZ/O9qTzfusZj2tCxLLQyw%3D' (2026-07-03)
  → 'github:nix-community/NUR/21d8513f565042678d71826adffd25fa1ac9418b?narHash=sha256-23ouasHqej9n3qGGqnq682pEBfYcmCGHVPUnm6WDf8U%3D' (2026-07-09)
• Updated input 'nvf':
    'github:NotAShelf/nvf/1f0b98b404daac6635d766455ab3dd06f6c85866?narHash=sha256-72w8cZWJhcIo8ThuxP6Mh/hwvnjnO03c8C80h6iAfFE%3D' (2026-07-02)
  → 'github:NotAShelf/nvf/84af0c160f0c1c83179809277124f6dc4712b2b3?narHash=sha256-IgOE1Dh70GnGPWvrwiwUZkmzJURKM40oru0vvRPSu/M%3D' (2026-07-08)
• Removed input 'nvf/flake-parts'
• Removed input 'nvf/flake-parts/nixpkgs-lib'
• Removed input 'nvf/systems'
• Updated input 'open-design':
    'github:nexu-io/open-design/0b88ef56144b5a42dc427c1292ae22676d698a34?narHash=sha256-rhHjAL9QldPQ4x36Cbjb0267qHij5S/wOHbtqJgJCK0%3D' (2026-07-02)
  → 'github:nexu-io/open-design/7193e48618689e5397b17fca2482fa1470ce41b9?narHash=sha256-GCbCv0rzd/X0FYsfHloBPelCT54oFdvyEr6eo3e1dN8%3D' (2026-07-09)
```
