### PR TITLE
fix(gnome): patch gnome-shell gvc NULL active_profile segfault at session start

### DIFF
--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -156,6 +156,19 @@
       doCheck = false;
     });
 
+    # gnome-shell 50.2: racy SIGSEGV at session start in the vendored gvc
+    # subproject — update_card() derefs pa_card_info.active_profile->name, but
+    # pipewire-pulse can transiently report a card with zero profiles during
+    # bring-up ("profiles inconsistent"), making active_profile NULL. Kills the
+    # autologin session on the GNOME hosts (BrightFalls, CauldronLake).
+    # Unfixed on libgvc master and pipewire 1.6.7 as of 2026-07-09; see the
+    # patch header for full context. Drop once the vendored gvc gains the guard.
+    gnome-shell = super.gnome-shell.overrideAttrs (old: {
+      patches = (old.patches or [ ]) ++ [
+        ../patches/gnome-shell/001-gvc-null-active-profile.patch
+      ];
+    });
+
     # jellyfin-tui: cover art flickers on every redraw when launched inside a
     # zellij pane because zellij's Kitty/Sixel passthrough is unreliable
     # (zellij-org/zellij#2814, #2576). The patch forces Picker::halfblocks() when

--- a/patches/gnome-shell/001-gvc-null-active-profile.patch
+++ b/patches/gnome-shell/001-gvc-null-active-profile.patch
@@ -1,0 +1,50 @@
+gvc: guard NULL active_profile in update_card
+=============================================
+
+Problem
+-------
+gnome-shell 50.2 segfaults ~3s into session start (SIGSEGV in libgvc.so,
+_pa_context_get_card_info_by_index_cb), killing the autologin session and
+dropping to the GDM greeter. Racy: only some boots hit it.
+
+Root cause
+----------
+During startup pipewire-pulse (>=1.6.x) can transiently emit a card with
+ports but zero profiles — it logs "card N port M profiles inconsistent
+(0 < X)" (module-protocol-pulse). libpulse then hands gvc a pa_card_info
+with active_profile == NULL, and update_card() dereferences
+info->active_profile->name unconditionally. Observed on the AMD dGPU
+HDMI/DP audio card, whose profile enumeration races display init.
+
+Unfixed upstream as of 2026-07-09: the deref is present on libgvc master
+(rev 0a4eda0, vendored by gnome-shell 50.2/50.3/main), and pipewire
+1.6.6/1.6.7 do not fix the zero-profiles race. No upstream issue filed
+for this signature; nearest relatives are gvc MR !36 and issue #46.
+
+Fix
+---
+NULL-guard both active_profile derefs, mirroring how nixpkgs PR #482791
+carried gvc MR !31 patches on the vendored subproject. Drop when the
+vendored gvc grows the guard upstream.
+--- a/subprojects/gvc/gvc-mixer-control.c
++++ b/subprojects/gvc/gvc-mixer-control.c
+@@ -2608,7 +2608,8 @@
+                 struct pa_card_profile_info pi = info->profiles[i];
+                 gboolean is_default;
+ 
+-                is_default = (g_strcmp0 (pi.name, info->active_profile->name) == 0);
++                is_default = (info->active_profile != NULL &&
++                              g_strcmp0 (pi.name, info->active_profile->name) == 0);
+                 g_debug ("\tProfile '%s': %d sources %d sinks%s",
+                          pi.name, pi.n_sources, pi.n_sinks,
+                          is_default ? " (Current)" : "");
+@@ -2646,7 +2647,8 @@
+         gvc_mixer_card_set_profiles (card, profile_list);
+         gvc_mixer_card_set_name (card, pa_proplist_gets (info->proplist, "device.description"));
+         gvc_mixer_card_set_icon_name (card, pa_proplist_gets (info->proplist, "device.icon_name"));
+-        gvc_mixer_card_set_profile (card, info->active_profile->name);
++        if (info->active_profile != NULL)
++                gvc_mixer_card_set_profile (card, info->active_profile->name);
+ 
+         if (is_new) {
+                 g_hash_table_insert (control->priv->cards,


### PR DESCRIPTION
## Problem

gnome-shell 50.2 segfaults ~3s into session start (SIGSEGV in `libgvc.so`, `_pa_context_get_card_info_by_index_cb`), killing the autologin session and dropping to the GDM greeter. Racy — roughly half of recent BrightFalls boots hit it. Affects both GNOME hosts (BrightFalls, CauldronLake).

## Root cause

During startup pipewire-pulse (1.6.5) can transiently emit a card with ports but zero profiles — it logs `card N port M profiles inconsistent (0 < X)`. libpulse then hands gvc a `pa_card_info` with `active_profile == NULL`, and `update_card()` in the vendored gvc subproject dereferences `info->active_profile->name` unconditionally. Trigger card on BrightFalls: Navi 21/23 HDMI/DP audio (dGPU), whose profile enumeration races display init.

Unfixed upstream as of 2026-07-09:
- deref present on libgvc master (rev `0a4eda0`, pinned by gnome-shell 50.2/50.3/main) — shell bump won't help
- pipewire 1.6.6/1.6.7 don't fix the zero-profiles race — pipewire bump won't help
- no upstream issue filed for this signature; nearest relatives: gvc [MR !36](https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/merge_requests/36), [issue #46](https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/work_items/46)

## Fix

Two-line NULL guard on both `active_profile` derefs in `update_card()`, carried as a patch on gnome-shell's vendored `subprojects/gvc` via the shared overlay — same approach nixpkgs [PR #482791](https://github.com/NixOS/nixpkgs/pull/482791) used to carry gvc MR !31. Drop when the vendored gvc gains the guard.

## Verification

- Patched gnome-shell 50.2 builds (`libgvc.so` present in output)
- CauldronLake toplevel evals clean; NightSprings (darwin) evals clean
- Real-world confirmation needs deploy + several autologin cycles (crash is racy)