### PR TITLE
feat(brightfalls): enable git commit signing; rotate nexus ssh key

### DIFF
--- a/hosts/Brightfalls/users/matteo/git.nix
+++ b/hosts/Brightfalls/users/matteo/git.nix
@@ -3,6 +3,12 @@ _:
   custom.git = {
     enable = true;
     diffMergeTool = "nvimdiff";
+    signing = {
+      enable = true;
+      allowedSignersContent = ''
+        * ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPtI1woCI1+svEObVH/zT+fp0R11loXEhEBYyuNtBJzN
+      '';
+    };
   };
 
   custom.ssh = {

--- a/hosts/Nexus/users.nix
+++ b/hosts/Nexus/users.nix
@@ -20,7 +20,7 @@
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIID8wJBTqQWKLy0RxQDuw8PAvD/KwYxSBcWHS434E3ar matteo@NightSprings"
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFPfaTw8AYPvjul32mIt64juaOn8wjmlJoplWxCzCZhi matteo.pacini@WorkLaptop"
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG+kL6LcApeIKrvJQIsewG95Q2XyzrvUSyRvBC9Ip3y5 matteo@BrightFalls"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDu9ZMKYAfbVvEvu4KKwwGaUc3XT3FxZlSIgE1jOpN7G matteo@BrightFalls"
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINm/ozPgRTmYmOVgkdNOw2deEOzBjoA4gGWLjWzrEC+u Pixel"
       ];
     };


### PR DESCRIPTION
- Enable SSH commit signing on BrightFalls using current ~/.ssh/github.pub; allowed_signers generated.
- Replace stale matteo@BrightFalls key in Nexus authorized_keys with freshly generated ~/.ssh/nexus key (old private key no longer exists).

Both configs eval clean.