### PR TITLE
feat(brightfalls): unencrypted dual-boot with Windows 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ nix fmt
 - GNOME on Wayland
 - Linux 7.0 with **BORE** scheduler patches
 - Per-host **znver4** overlay tuning the system for Zen 4
-- **Full-disk encryption** (LUKS2) using vault-based keyfile unlock
+- **Dual-boot** with Windows 11 (systemd-boot, shared ESP)
 - KVM/QEMU virtualization, **Sunshine** for game streaming, **LACT** for GPU control
 - Suspend disabled (the eGPU never recovers cleanly)
 
@@ -82,33 +82,32 @@ nix fmt
 <details>
 <summary><strong>Disk Layout</strong></summary>
 
-Single 4 TB NVMe partitioned with [disko](https://github.com/nix-community/disko):
+Single 4 TB NVMe partitioned with [disko](https://github.com/nix-community/disko), unencrypted (gaming PC), dual-booting Windows 11:
 
-| Mount | Size | FS | Encryption |
-|-------|------|----|------------|
-| `/boot` | 1 GB | FAT32 | none |
-| `/vault` | 64 MB | ext2 | LUKS2 (password) |
-| `swap` | 36 GB | swap | LUKS2 (keyfile) |
-| `/` | 200 GB | ext4 | LUKS2 (keyfile) |
-| `/home` | 1 TB | ext4 | LUKS2 (keyfile) |
-| `/games` | ~2.7 TB | XFS | LUKS2 (keyfile) |
+| Mount | Size | FS | Notes |
+|-------|------|----|-------|
+| `/boot` | 1 GB | FAT32 | EFI System Partition (shared with Windows) |
+| `swap` | 36 GB | swap | hibernation |
+| `/` | 200 GB | ext4 | NixOS system |
+| `/home` | 1 TB | ext4 | configs & code |
+| — | 16 MB | — | Microsoft Reserved (Windows 11) |
+| — | 512 GB | NTFS | Windows 11 (Win installer formats) |
+| `/games` | ~1.9 TB | XFS | Steam library |
 
-You enter the vault password once at boot. Everything else unlocks automatically from the keyfile stored in `/vault`. Initrd SSH on port `2222` is available for remote unlock.
+systemd-boot auto-detects the Windows Boot Manager on the shared ESP and lists it as a boot entry.
 
 **Fresh install:**
 
 ```bash
-# 1. Stage vault password and a random keyfile
-echo -n "your-vault-password" > /tmp/vault.key
-dd if=/dev/urandom of=/tmp/luks.key bs=4096 count=1 iflag=fullblock
-
-# 2. Partition, format, and mount
+# 1. Partition, format, and mount (WIPES DISK, incl. Windows)
 sudo nix run github:nix-community/disko/latest -- \
   --mode destroy,format,mount \
   --flake github:matteo-pacini/nixos-configs#BrightFalls
 
-# 3. Install
+# 2. Install
 sudo nixos-install --flake github:matteo-pacini/nixos-configs#BrightFalls
+
+# 3. Boot a Windows 11 USB and install into the 512 GB slot
 ```
 
 </details>

--- a/hosts/Brightfalls/default.nix
+++ b/hosts/Brightfalls/default.nix
@@ -39,16 +39,17 @@
     };
   };
 
-  # Boot loader
-
-  boot.loader.grub = {
+  # Boot loader — systemd-boot auto-detects Windows Boot Manager on the shared ESP (dual boot, no os-prober)
+  boot.loader.systemd-boot = {
     enable = true;
-    efiSupport = true;
-    device = "nodev";
     memtest86.enable = pkgs.stdenv.hostPlatform.isx86;
     configurationLimit = 5;
   };
   boot.loader.efi.canTouchEfiVariables = true;
+  boot.loader.timeout = 5;
+
+  # Dual boot: match Windows' localtime RTC so the clock doesn't skew each boot
+  time.hardwareClockInLocalTime = true;
 
   # System Packages
 

--- a/hosts/Brightfalls/desktop.nix
+++ b/hosts/Brightfalls/desktop.nix
@@ -7,7 +7,7 @@
   services.desktopManager.gnome.enable = true;
 
   services.displayManager = {
-    # Makes sense to me as the whole system is encrypted
+    # Single-user gaming box
     autoLogin = {
       enable = true;
       user = "matteo";

--- a/hosts/Brightfalls/disko.nix
+++ b/hosts/Brightfalls/disko.nix
@@ -1,42 +1,22 @@
 # Disk configuration for BrightFalls (physical machine)
 #
 # Hardware: Minisforum UM890 Pro (Zen4) + DEG1 eGPU Dock
-#
-# Physical Disk:
-#   4TB NVMe - Single system disk
+# Single 4TB NVMe, unencrypted (gaming PC), dual-boot with Windows 11.
 #
 # Layout:
-#   - boot:  1GB    vfat   EFI System Partition (unencrypted)
-#   - vault: 64MB   ext2   Keyfile storage (LUKS2, password, Serpent-XTS)
-#   - swap:  36GB   swap   Hibernation support (LUKS2, keyfile)
-#   - root:  200GB  ext4   NixOS system (LUKS2, keyfile)
-#   - home:  1TB    ext4   Configs & code repos (LUKS2, keyfile)
-#   - games: ~2.7TB XFS    Steam library (LUKS2, keyfile)
+#   - boot:  1GB    vfat   EFI System Partition (shared with Windows)
+#   - swap:  36GB   swap   Hibernation support
+#   - root:  200GB  ext4   NixOS system
+#   - home:  600GB  ext4   Configs & code repos
+#   - msr:   16MB   -      Microsoft Reserved (Windows 11)
+#   - win:   512GB  ntfs   Windows 11 (unformatted; Win installer formats)
+#   - games: ~2.5TB xfs    Steam library
 #
-# Boot sequence:
-#   1. User enters password → vault unlocks (Serpent-XTS, 4GB Argon2id)
-#   2. Vault mounts at /vault → keyfile becomes available
-#   3. swap/root/games auto-unlock using /vault/luks.key
-#   4. Hibernation supported (persistent swap encryption)
-#
-# Security Strategy:
-#   VAULT (Maximum Security):
-#     - Cipher: Serpent-XTS-plain64 (256-bit, higher security margin than AES)
-#     - Hash: SHA512
-#     - PBKDF: Argon2id with 4GB memory, 4 parallel threads
-#     - Iterations: 3000ms
-#
-#   SWAP/ROOT/GAMES (Standard Security):
-#     - Cipher: AES-XTS-plain64 (512-bit, hardware-accelerated)
-#     - Hash: SHA256
-#     - PBKDF: Argon2id with 2GB memory, 4 parallel threads
-#     - Iterations: 2000ms
-#
-# Installation:
-#   1. Create password file: echo -n "your-password" > /tmp/vault.key
-#   2. Generate keyfile: dd if=/dev/urandom of=/tmp/luks.key bs=4096 count=1 iflag=fullblock
-#   3. Run disko: sudo nix run github:nix-community/disko -- --mode destroy,format,mount ...
-#   4. Install: sudo nixos-install --flake ...
+# Install:
+#   1. Set `device` below to the real NVMe by-id path.
+#   2. sudo disko --mode destroy,format,mount   (WIPES DISK, incl. Windows)
+#   3. sudo nixos-install --flake ...
+#   4. Boot a Windows 11 USB, install into the 512G unformatted slot.
 #
 { ... }:
 {
@@ -44,14 +24,12 @@
     disk = {
       nvme = {
         type = "disk";
-        # TODO: Replace with actual NVMe device ID after booting installer
-        # Use: ls -l /dev/disk/by-id/ | grep nvme
-        device = "/dev/disk/by-id/PLACEHOLDER";
+        device = "/dev/disk/by-id/nvme-CT4000P310SSD8_25184FF48CDC";
         content = {
           type = "gpt";
           partitions = {
 
-            # Part 1: EFI Boot partition - 1GB - vfat (unencrypted)
+            # Part 1: EFI Boot partition - 1GB - vfat (shared with Windows)
             boot = {
               size = "1G";
               type = "EF00";
@@ -63,233 +41,67 @@
               };
             };
 
-            # Part 2: Vault partition - 64MB - ext2 on LUKS2
-            # Password-protected, stores keyfile for other volumes
-            vault = {
-              size = "64M";
-              content = {
-                type = "luks";
-                name = "cryptvault";
-                passwordFile = "/tmp/vault.key";
-                initrdUnlock = true;
-                settings = {
-                  allowDiscards = true;
-                };
-                extraFormatArgs = [
-                  "--type"
-                  "luks2"
-                  "--cipher"
-                  "serpent-xts-plain64"
-                  "--hash"
-                  "sha512"
-                  "--iter-time"
-                  "3000"
-                  "--key-size"
-                  "256"
-                  "--pbkdf"
-                  "argon2id"
-                  "--pbkdf-memory"
-                  "4194304"
-                  "--pbkdf-parallel"
-                  "4"
-                  "--sector-size"
-                  "4096"
-                ];
-                content = {
-                  type = "filesystem";
-                  format = "ext2";
-                  extraArgs = [
-                    "-F"
-                    "-L"
-                    "vault"
-                    "-m"
-                    "0"
-                  ];
-                  mountpoint = "/vault";
-                  mountOptions = [
-                    "noatime"
-                    "errors=remount-ro"
-                  ];
-                  postCreateHook = ''
-                    echo "Copying keyfile to vault..."
-                    MNTPOINT=$(mktemp -d)
-                    mount /dev/mapper/cryptvault $MNTPOINT
-                    cp /tmp/luks.key $MNTPOINT/luks.key
-                    chmod 400 $MNTPOINT/luks.key
-                    umount $MNTPOINT
-                    rmdir $MNTPOINT
-                  '';
-                };
-              };
-            };
-
-            # Part 3: Swap partition - 36GB - swap on LUKS2
-            # Persistent encryption for hibernation (RAM + 4GB headroom)
+            # Part 2: Swap partition - 36GB (hibernation: RAM + headroom)
             swap = {
               size = "36G";
               content = {
-                type = "luks";
-                name = "cryptswap";
-                initrdUnlock = true;
-                settings = {
-                  keyFile = "/tmp/luks.key";
-                  allowDiscards = true;
-                };
-                extraFormatArgs = [
-                  "--type"
-                  "luks2"
-                  "--cipher"
-                  "aes-xts-plain64"
-                  "--hash"
-                  "sha256"
-                  "--iter-time"
-                  "2000"
-                  "--key-size"
-                  "512"
-                  "--pbkdf"
-                  "argon2id"
-                  "--pbkdf-memory"
-                  "2097152"
-                  "--pbkdf-parallel"
-                  "4"
-                  "--sector-size"
-                  "4096"
-                ];
-                content = {
-                  type = "swap";
-                };
+                type = "swap";
               };
             };
 
-            # Part 4: Root partition - 200GB - ext4 on LUKS2
-            # Best for Nix store (small files, hardlinks)
+            # Part 3: Root partition - 200GB - ext4
             root = {
               size = "200G";
               content = {
-                type = "luks";
-                name = "cryptroot";
-                initrdUnlock = true;
-                settings = {
-                  keyFile = "/tmp/luks.key";
-                  allowDiscards = true;
-                };
-                extraFormatArgs = [
-                  "--type"
-                  "luks2"
-                  "--cipher"
-                  "aes-xts-plain64"
-                  "--hash"
-                  "sha256"
-                  "--iter-time"
-                  "2000"
-                  "--key-size"
-                  "512"
-                  "--pbkdf"
-                  "argon2id"
-                  "--pbkdf-memory"
-                  "2097152"
-                  "--pbkdf-parallel"
-                  "4"
-                  "--sector-size"
-                  "4096"
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+                mountOptions = [
+                  "defaults"
+                  "noatime"
                 ];
-                content = {
-                  type = "filesystem";
-                  format = "ext4";
-                  mountpoint = "/";
-                  mountOptions = [
-                    "defaults"
-                    "noatime"
-                  ];
-                };
               };
             };
 
-            # Part 5: Home partition - 1TB - ext4 on LUKS2
-            # Best for configs & code repos (small files, hardlinks)
+            # Part 4: Home partition - 600GB - ext4
             home = {
-              size = "1T";
+              size = "600G";
               content = {
-                type = "luks";
-                name = "crypthome";
-                initrdUnlock = true;
-                settings = {
-                  keyFile = "/tmp/luks.key";
-                  allowDiscards = true;
-                };
-                extraFormatArgs = [
-                  "--type"
-                  "luks2"
-                  "--cipher"
-                  "aes-xts-plain64"
-                  "--hash"
-                  "sha256"
-                  "--iter-time"
-                  "2000"
-                  "--key-size"
-                  "512"
-                  "--pbkdf"
-                  "argon2id"
-                  "--pbkdf-memory"
-                  "2097152"
-                  "--pbkdf-parallel"
-                  "4"
-                  "--sector-size"
-                  "4096"
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/home";
+                mountOptions = [
+                  "defaults"
+                  "noatime"
                 ];
-                content = {
-                  type = "filesystem";
-                  format = "ext4";
-                  mountpoint = "/home";
-                  mountOptions = [
-                    "defaults"
-                    "noatime"
-                  ];
-                };
               };
             };
 
-            # Part 6: Games partition - remaining space (~2.7TB) - XFS on LUKS2
-            # Best for large files (games), parallel I/O
+            # Part 5: Microsoft Reserved - 16MB - no filesystem (Windows 11)
+            msr = {
+              size = "16M";
+              type = "0C01";
+            };
+
+            # Part 6: Windows 11 - 512GB - NTFS, unformatted
+            # Left unformatted; the Windows installer creates the NTFS
+            # filesystem here and its own WinRE recovery partition.
+            windows = {
+              size = "512G";
+              type = "0700";
+            };
+
+            # Part 7: Games partition - remaining space (~2.5TB) - XFS
             games = {
               size = "100%";
               content = {
-                type = "luks";
-                name = "cryptgames";
-                initrdUnlock = true;
-                settings = {
-                  keyFile = "/tmp/luks.key";
-                  allowDiscards = true;
-                };
-                extraFormatArgs = [
-                  "--type"
-                  "luks2"
-                  "--cipher"
-                  "aes-xts-plain64"
-                  "--hash"
-                  "sha256"
-                  "--iter-time"
-                  "2000"
-                  "--key-size"
-                  "512"
-                  "--pbkdf"
-                  "argon2id"
-                  "--pbkdf-memory"
-                  "2097152"
-                  "--pbkdf-parallel"
-                  "4"
-                  "--sector-size"
-                  "4096"
+                type = "filesystem";
+                format = "xfs";
+                mountpoint = "/mnt/games";
+                mountOptions = [
+                  "defaults"
+                  "noatime"
                 ];
-                content = {
-                  type = "filesystem";
-                  format = "xfs";
-                  mountpoint = "/mnt/games";
-                  mountOptions = [
-                    "defaults"
-                    "noatime"
-                  ];
-                };
               };
             };
 

--- a/hosts/Brightfalls/hardware.nix
+++ b/hosts/Brightfalls/hardware.nix
@@ -1,6 +1,5 @@
 {
   pkgs,
-  lib,
   modulesPath,
   ...
 }:
@@ -10,16 +9,12 @@
   ];
 
   # Kernel modules for UM890 Pro (NVMe-only, no SATA)
-  # r8169: Realtek RTL8125 2.5GbE NIC for initrd SSH (remote LUKS unlock)
   boot.initrd.availableKernelModules = [
     "nvme"
     "xhci_pci"
     "usbhid"
     "sd_mod"
-    "r8169"
   ];
-  # ext2 required to mount vault partition in initrd
-  boot.initrd.supportedFilesystems = [ "ext2" ];
   boot.kernelModules = [
     "kvm-amd"
     "ntsync"
@@ -66,58 +61,4 @@
     SUBSYSTEM=="drm", KERNEL=="card*", ATTRS{device}=="0x73bf", ATTRS{vendor}=="0x1002", TAG+="mutter-device-preferred-primary"
   '';
 
-  # Use systemd in initrd for proper LUKS dependency ordering
-  # This ensures vault is mounted before other LUKS devices try to read keyfile
-  boot.initrd.systemd.enable = true;
-
-  # Flush initrd DHCP lease before stage 2 so NetworkManager can cleanly
-  # acquire its own lease and configure DNS in systemd-resolved
-  boot.initrd.network.flushBeforeStage2 = true;
-
-  # Initrd networking for remote LUKS unlock via SSH
-  boot.initrd.systemd.network = {
-    enable = true;
-    networks."10-enp2s0" = {
-      matchConfig.Name = "enp2s0";
-      networkConfig.DHCP = "ipv4";
-    };
-  };
-
-  # Initrd SSH for remote LUKS unlock (port 2222 to avoid known_hosts conflict with main SSH on 1788)
-  # Host key must be pre-generated: ssh-keygen -t ed25519 -N "" -f /etc/secrets/initrd/ssh_host_ed25519_key
-  boot.initrd.network.ssh = {
-    enable = true;
-    port = 2222;
-    authorizedKeys = [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILQiM93t9mXjpqdtY12ohNAELZNg1SOdE47bWNRb4HC0 matteo@MacBookPr"
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINm/ozPgRTmYmOVgkdNOw2deEOzBjoA4gGWLjWzrEC+u Pixel"
-    ];
-    hostKeys = [ "/etc/secrets/initrd/ssh_host_ed25519_key" ];
-    extraConfig = "StrictModes no";
-  };
-
-  # Set runtime keyfile path for all LUKS devices that use keyfile unlock
-  # (disko's settings.keyFile is only used during installation, not at boot)
-  boot.initrd.luks.devices = {
-    cryptswap.keyFile = lib.mkForce "/vault/luks.key";
-    cryptroot.keyFile = lib.mkForce "/vault/luks.key";
-    crypthome.keyFile = lib.mkForce "/vault/luks.key";
-    cryptgames.keyFile = lib.mkForce "/vault/luks.key";
-  };
-
-  # Mount the *decrypted* vault to /vault inside initrd
-  # This makes /vault/luks.key available for unlocking other LUKS devices
-  boot.initrd.systemd.mounts = [
-    {
-      what = "/dev/mapper/cryptvault";
-      where = "/vault";
-      type = "ext2";
-      options = "noatime,errors=remount-ro";
-      wantedBy = [ "initrd.target" ];
-      after = [ "systemd-cryptsetup@cryptvault.service" ];
-    }
-  ];
-
-  # Mark vault as needed early in boot so it's available for LUKS keyfile
-  fileSystems."/vault".neededForBoot = true;
 }


### PR DESCRIPTION
Rework BrightFalls disk layout for unencrypted dual-boot with Windows 11: simplified disko.nix, hardware.nix trim, small default.nix/desktop.nix adjustments, README update.