### PR TITLE
fix(brightfalls): gate jellyfin-mpv-shim on network readiness

### DIFF
--- a/modules/home-manager/mpv/jellyfin-shim.nix
+++ b/modules/home-manager/mpv/jellyfin-shim.nix
@@ -30,16 +30,19 @@ let
     "script-opts/smart-native-screenshot.conf"
   ];
 
-  baseConf =
-    {
-      shader_pack_enable = false;
-      transcode_hdr = false;
-      transcode_dolby_vision = false;
-      mpv_ext = isDarwin;
-    }
-    // lib.optionalAttrs isDarwin {
-      mpv_ext_path = "${pkgs.mpv}/bin/mpv";
-    };
+  baseConf = {
+    shader_pack_enable = false;
+    transcode_hdr = false;
+    transcode_dolby_vision = false;
+    mpv_ext = isDarwin;
+    # Retry the server connection every 30s for this many minutes before
+    # giving up and blocking on the login window (upstream default is 0,
+    # i.e. a single attempt).
+    connect_retry_mins = 5;
+  }
+  // lib.optionalAttrs isDarwin {
+    mpv_ext_path = "${pkgs.mpv}/bin/mpv";
+  };
 
   baseConfFile = pkgs.writeText "jellyfin-mpv-shim-conf.json" (builtins.toJSON baseConf);
 in
@@ -91,6 +94,13 @@ in
       };
       Service = {
         Type = "simple";
+        # network-online.target is a no-op in the user manager (nothing
+        # activates it there), so gate on NetworkManager connectivity
+        # instead. On timeout the unit fails and Restart=on-failure turns
+        # this into an indefinite retry. Without the gate the shim starts
+        # before the network is up, fails its single connection attempt,
+        # and blocks forever on the login window without exiting.
+        ExecStartPre = "${pkgs.networkmanager}/bin/nm-online -q --timeout=60";
         ExecStart = "${pkgs.jellyfin-mpv-shim}/bin/jellyfin-mpv-shim";
         Restart = "on-failure";
         RestartSec = 5;


### PR DESCRIPTION
## Problem
jellyfin-mpv-shim starts with the graphical session, before the network is up. It makes a single connection attempt, then blocks on the login window **without exiting** — so `Restart=on-failure` never fires and the shim sits dead until manually restarted.

## Why the obvious fix doesn't work
`After=network-online.target` is a no-op in the systemd **user** manager: the user instance has its own passive copy of the target and nothing ever activates it (systemd/systemd#12853). Upstream's proposed unit (jellyfin/jellyfin-mpv-shim#330) was closed unmerged.

## Fix
- `ExecStartPre = nm-online -q --timeout=60` — BrightFalls runs NetworkManager, and `nm-online` works from the user session over the system D-Bus. On timeout the unit fails and `Restart=on-failure` turns the gate into an indefinite retry.
- `connect_retry_mins = 5` in the seeded `conf.json` — upstream's sanctioned knob: the shim retries the server every 30s for 5 minutes before giving up, covering the network-up-but-server-not-yet case.

Live `conf.json` on BrightFalls patched separately (seed only runs when the file is missing).

Verified: `nix build .#nixosConfigurations.BrightFalls.config.system.build.toplevel` green.