### PR TITLE
feat(brightfalls): mount win11 partition rw via ntfs3

### DIFF
--- a/hosts/Brightfalls/win11-snapshots.nix
+++ b/hosts/Brightfalls/win11-snapshots.nix
@@ -4,8 +4,23 @@
 let
   # Windows partition (p6) on the 4TB Crucial — see disko.nix
   device = "/dev/disk/by-id/nvme-CT4000P310SSD8_25184FF48CDC-part6";
+  mountPoint = "/mnt/windows";
+  automountUnit = "mnt-windows.automount"; # systemd-escape -p ${mountPoint}
   remote = "nexus";
   remoteDir = "/diskpool/win11-snapshots";
+
+  # dd against a mounted partition reads/writes an inconsistent filesystem.
+  # Stop the automount first or any access during dd remounts it.
+  ensureUnmounted = ''
+    if systemctl is-active --quiet ${automountUnit}; then
+      echo "stopping ${automountUnit} (restart with: systemctl start ${automountUnit})" >&2
+      sudo systemctl stop ${automountUnit}
+    fi
+    if findmnt -rn -S ${device} >/dev/null; then
+      echo "unmounting ${device}" >&2
+      sudo umount ${device}
+    fi
+  '';
 
   win11-snapshot-create = pkgs.writeShellScriptBin "win11-snapshot-create" ''
     set -euo pipefail
@@ -27,6 +42,7 @@ let
     fi
 
     sudo -v
+    ${ensureUnmounted}
     SIZE=$(sudo blockdev --getsize64 ${device})
 
     # .partial then rename: an interrupted transfer never looks like a valid snapshot
@@ -79,6 +95,7 @@ let
     fi
 
     sudo -v
+    ${ensureUnmounted}
     SIZE=$(ssh ${remote} "stat -c %s \"$FILE\"")
 
     ssh -o Compression=no ${remote} "cat \"$FILE\"" \
@@ -88,11 +105,69 @@ let
 
     echo "snapshot '$NAME' restored"
   '';
+
+  win11-snapshot-delete = pkgs.writeShellScriptBin "win11-snapshot-delete" ''
+    set -euo pipefail
+
+    list_snapshots() {
+      echo "available snapshots:" >&2
+      ssh ${remote} "ls -1 ${remoteDir}" 2>/dev/null | sed -n 's/\.img\.zst$//p' >&2 || true
+    }
+
+    NAME=''${1:-}
+    if [[ -z "$NAME" ]]; then
+      echo "usage: win11-snapshot-delete NAME" >&2
+      list_snapshots
+      exit 1
+    fi
+    if [[ ! "$NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
+      echo "error: NAME must match [A-Za-z0-9._-]+" >&2
+      exit 1
+    fi
+    FILE="${remoteDir}/$NAME.img.zst"
+
+    if ! ssh ${remote} "test -e \"$FILE\""; then
+      echo "error: snapshot '$NAME' not found on ${remote}" >&2
+      list_snapshots
+      exit 1
+    fi
+
+    echo "WARNING: this permanently deletes snapshot '$NAME' from ${remote}."
+    read -r -p "Type the snapshot name to confirm: " REPLY
+    if [[ "$REPLY" != "$NAME" ]]; then
+      echo "aborted" >&2
+      exit 1
+    fi
+
+    ssh ${remote} "rm \"$FILE\""
+    echo "snapshot '$NAME' deleted"
+  '';
 in
 {
+  # In-kernel ntfs3 driver. Fast Startup is disabled on the Windows side, so
+  # the volume is normally clean; lazy mount + nofail still keep a dirty
+  # volume (e.g. Windows crash) from failing the boot.
+  fileSystems.${mountPoint} = {
+    inherit device;
+    fsType = "ntfs3";
+    noCheck = true; # no fsck.ntfs3 exists; real repair is chkdsk from Windows
+    options = [
+      "uid=1000"
+      "gid=100"
+      "windows_names" # forbid filenames Windows can't handle
+      "iocharset=utf8"
+      "nofail"
+      "noauto"
+      "x-systemd.automount"
+      "x-systemd.idle-timeout=600"
+    ];
+  };
+
   environment.systemPackages = [
+    pkgs.ntfs3g # ntfsfix, for clearing the dirty flag after a Windows crash
     win11-snapshot-create
     win11-snapshot-list
     win11-snapshot-restore
+    win11-snapshot-delete
   ];
 }


### PR DESCRIPTION
## Summary
- Mount Windows 11 partition (nvme p6) read/write at `/mnt/windows` via in-kernel `ntfs3` driver — lazy `x-systemd.automount` (10 min idle timeout), `nofail`, `windows_names`, `noCheck` (no `fsck.ntfs3` exists)
- Snapshot scripts gain a mount guard: stop `mnt-windows.automount` and unmount before `dd` (create + restore) — dd against a mounted partition reads/writes an inconsistent filesystem
- Add `win11-snapshot-delete` following existing conventions (NAME validation, existence check + listing, retype-name confirmation)
- Add `pkgs.ntfs3g` for `ntfsfix` (dirty-flag recovery after a Windows crash; Fast Startup already disabled on the Windows side)

## Verification
- `nix build .#nixosConfigurations.BrightFalls.config.system.build.toplevel` green
- `bash -n` clean on all four generated scripts
- fstab entry renders with by-id device and passno 0
- `windows_names`/`iocharset`/`prealloc` confirmed present in this kernel's `ntfs3.ko` (7.1.3)
- `findmnt -S` symlink canonicalization verified against mounted p8