### PR TITLE
fix(brightfalls): cap LUKS2 argon2id pbkdf-parallel at 4

### DIFF
--- a/hosts/Brightfalls/disko.nix
+++ b/hosts/Brightfalls/disko.nix
@@ -75,7 +75,7 @@
                   "--pbkdf-memory"
                   "4194304"
                   "--pbkdf-parallel"
-                  "8"
+                  "4"
                   "--iter-time"
                   "3000"
                   "--sector-size"


### PR DESCRIPTION
## What

Drops `--pbkdf-parallel` from `8` to `4` in `hosts/BrightFalls/disko.nix`.

## Why

cryptsetup hard-caps parallel PBKDF threads at `MAX_PBKDF_THREADS = 4`. The value of `8` introduced in #347 causes `cryptsetup luksFormat` to reject the request, so `disko --mode destroy,format,mount` fails during install.

## Security impact

None. Post-Grover quantum resistance is a property of the cipher (`aes-xts-plain64`, `--key-size 512` → AES-256, ~128-bit effective post-Grover), which is unchanged. `--pbkdf-parallel` only tunes Argon2id passphrase derivation; with `--iter-time 3000` fixed and memory pinned at 4 GiB, cryptsetup compensates by adjusting the iteration count, so KDF hardness stays comparable.