### PR TITLE
fix(nexus): enable pam_unix for LAN password SSH auth

### DIFF
--- a/hosts/Nexus/services/openssh.nix
+++ b/hosts/Nexus/services/openssh.nix
@@ -1,10 +1,15 @@
-{ ... }:
+{ lib, ... }:
 {
   services.openssh = {
     enable = true;
     settings = {
       PermitRootLogin = "no";
       PasswordAuthentication = false;
+      # Keyboard-interactive defaults to on and is offered to every source,
+      # routing to the same PAM auth stack. With unixAuth forced on below it
+      # would become password login from WAN/tailnet/any VLAN. Off globally;
+      # the Match block re-enables only the `password` method for the LAN.
+      KbdInteractiveAuthentication = false;
     };
     ports = [ 1788 ];
     # Password login for matteo from the HOME VLAN only (installer ISO
@@ -16,4 +21,12 @@
         PasswordAuthentication yes
     '';
   };
+
+  # NixOS ties security.pam.services.sshd.unixAuth to the *global*
+  # PasswordAuthentication (false here), which strips pam_unix from the sshd
+  # PAM auth stack — leaving only pam_deny. That makes the Match-block
+  # password path above impossible: PAM denies before the password is ever
+  # checked. Force pam_unix back into the auth stack; the SSH-layer Match
+  # block is the gate for who may actually use password auth.
+  security.pam.services.sshd.unixAuth = lib.mkForce true;
 }


### PR DESCRIPTION
## Problem

#347 added a `Match User matteo Address 192.168.10.0/24 { PasswordAuthentication yes }` block for the installer-ISO restore path, but password login was rejected every time (`PAM: Authentication failure`), even with a correct, freshly-set password.

## Root cause

The NixOS sshd module wires PAM to the **global** setting:
```nix
unixAuth = if cfg.settings.PasswordAuthentication == true then true else false;
```
With global `PasswordAuthentication = false`, `unixAuth` is `false`, so NixOS omits `pam_unix` from the sshd auth stack — leaving only `pam_deny`. `Match` blocks are opaque text in `extraConfig`, invisible to Nix, so they can't restore `pam_unix`. PAM denied the password before it was ever checked.

## Fix

- `security.pam.services.sshd.unixAuth = lib.mkForce true` — put `pam_unix` back in the auth stack.
- `KbdInteractiveAuthentication = false` globally — it defaults to on and is offered to every source; with `unixAuth` on it would otherwise become password login from WAN/tailnet/any VLAN.

Default-deny posture is preserved: global `PasswordAuthentication` stays `false`, so only the `Match` block grants the `password` method, to matteo from the home VLAN. Everything else stays key-only.