### PR TITLE
feat(brightfalls): add without-umip specialisation

### DIFF
--- a/hosts/Brightfalls/disko.nix
+++ b/hosts/Brightfalls/disko.nix
@@ -38,7 +38,7 @@
           partitions = {
 
             # Part 1: EFI Boot partition - 2GB - vfat
-            # 2G: 5 generations x 2 entries (wifi specialisation) x BORE initrds + memtest
+            # 2G: 5 generations x 3 entries (wifi + without-umip specialisations) x BORE initrds + memtest
             boot = {
               size = "2G";
               type = "EF00";

--- a/hosts/Brightfalls/specialisations.nix
+++ b/hosts/Brightfalls/specialisations.nix
@@ -7,4 +7,13 @@
     # Remove the WiFi driver from the blacklist
     boot.blacklistedKernelModules = lib.mkForce [ ];
   };
+
+  # UMIP-disabled specialisation - some older games/drivers (e.g. under
+  # Wine/VMware) fault on UMIP. Name form (not clearcpuid=514) is stable
+  # across kernel versions; numeric IDs track internal feature-word layout.
+  specialisation."without-umip".configuration = {
+    system.nixos.tags = [ "without-umip" ];
+
+    boot.kernelParams = [ "clearcpuid=umip" ];
+  };
 }


### PR DESCRIPTION
Adds a `without-umip` specialisation that inherits the main config and appends `clearcpuid=umip`, for software that faults on UMIP (Zen 4 8845HS has it).

Name form over `clearcpuid=514`: numeric IDs encode the kernel's internal feature-word position (word 16, bit 2) and can shift between kernel releases; the name form is stable on >= 5.17.

Also bumps the disko `/boot` sizing comment from 2 to 3 entries per generation (negligible space: the specialisation shares the parent kernel/initrd, only the cmdline differs).

Verified: full `nix build` of the BrightFalls toplevel; the specialisation's `kernel-params` contains all parent params plus `clearcpuid=umip`.