### PR TITLE
chore: weekly flake update - 2026-07-16T13:21:14Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1781226006,
-        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
+        "lastModified": 1784068757,
+        "narHash": "sha256-7KnV7rTlMpys+2J+TFVxUDDyKPLXFs4wIMtckMC72VM=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
+        "rev": "6bd951d96e7ebc54787799dba77bfb26ec956c4c",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.1",
+        "ref": "6.0.11",
         "repo": "brew",
         "type": "github"
       }
@@ -345,11 +345,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783618078,
-        "narHash": "sha256-F43DGcBoIO8xOZFAfodg3jy0VghB9NGdb6xbTYAIx1A=",
+        "lastModified": 1784129366,
+        "narHash": "sha256-N5JiyICSeQF14x+OQebNyPpYowOT9Rs1iKyeCylSzOA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "144f4e36d0186195037da9fce80a727108978070",
+        "rev": "165228b0efefc3e635e5174020c40ea64271dc25",
         "type": "github"
       },
       "original": {
@@ -382,11 +382,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1783641298,
-        "narHash": "sha256-CCY+PJkEngUsDMdNEOPjahLjmqJHUBx5NjccB/grdmA=",
+        "lastModified": 1784246247,
+        "narHash": "sha256-PJYVmJbZjzugzSubM9vh4SnxaKutTy83UdlVJYhvgIs=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "df719fe87b66d91c5eff41e5357d444474fa40a2",
+        "rev": "2cd4c86fcbc78898df7c530b0c78917ca78246f5",
         "type": "github"
       },
       "original": {
@@ -398,11 +398,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1783643214,
-        "narHash": "sha256-HUNGwXt8DyEqw+4p3xLx4IvoUgk1ALv6o1tV/QJDUAY=",
+        "lastModified": 1784240475,
+        "narHash": "sha256-NzcICOeg9vmxOMDfxAEksthxZ+hgWjXFG+R+sUp2ZYI=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "1f26bae586a44d8600cfcb1bae8e5b8e457cc30f",
+        "rev": "b144deb833ff84b6025ae72efc1b0ca31fe84adf",
         "type": "github"
       },
       "original": {
@@ -456,11 +456,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783395956,
-        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
+        "lastModified": 1784123936,
+        "narHash": "sha256-IOWwQMJhUxcojm0MRvuKs1fKLH727u4+hHeEOPhdUyA=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
+        "rev": "a4cf1d10853b0d2be19b9eca35d749e201d70b55",
         "type": "github"
       },
       "original": {
@@ -475,11 +475,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1781389246,
-        "narHash": "sha256-ORqLAo/hoJdsZC7UPAuEHev6S0+XIqKEC7vjo5prz1k=",
+        "lastModified": 1784159664,
+        "narHash": "sha256-I/B6YoRLImHEqNWh8bs+tPjEDeteACeFhcLyoSMo1GE=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "de7953a08ed4bb9245be043e468561c17b89130d",
+        "rev": "842eeb863ecca0eeb463f7a814cdc51e1d925776",
         "type": "github"
       },
       "original": {
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783414108,
-        "narHash": "sha256-RY8e+gR2/DhXsYDxGDL6Hhe9+POD9u4+llwxMBqMQDs=",
+        "lastModified": 1783864904,
+        "narHash": "sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj+dNn/8Dsi3sPM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "96d6de10eb281b98f5cfcd1841394c03da5df77c",
+        "rev": "1111b9bc836afb7e31a7014e8d1272de9b1c917d",
         "type": "github"
       },
       "original": {
@@ -541,11 +541,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1783642937,
-        "narHash": "sha256-AiWTp54tXcVhX3vKV1qIbtbbXTZnAoJC6C5TxvE1ThQ=",
+        "lastModified": 1784246997,
+        "narHash": "sha256-FikUcFtT+9mDKmMnoMAmWgj5SbVk1OdRpFAweh9lWTI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54888f6a65298371ce04b2656f0ee0e6e27a1046",
+        "rev": "3caf6c92cef23e58998eadcd85c3e1d3154d0391",
         "type": "github"
       },
       "original": {
@@ -605,11 +605,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {
@@ -643,11 +643,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783642607,
-        "narHash": "sha256-zEnCXo5ZdANi93FqPYJDXQmn3ComoGu6ppC7l26s4Fc=",
+        "lastModified": 1784238397,
+        "narHash": "sha256-Reg7V0xbZMwdwtoJ/x1fKGwV025TaERfaZQXchfCNVw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2b241e544c415d4f0441f8c7fd4baee828f6426c",
+        "rev": "c2b1b330618d210442be4776a504cc08422d8483",
         "type": "github"
       },
       "original": {
@@ -665,11 +665,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783627742,
-        "narHash": "sha256-KbcmMnmKzKUvPoKzFOkFd425MEdvdA5zohFTMCIXyx4=",
+        "lastModified": 1784149460,
+        "narHash": "sha256-S1RhDpdnRmRlVhLnze3w51YStpMW7wn+QDtct3Z8UJs=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "9040a27829dab327d6cc30f88a0797db680b745f",
+        "rev": "ca782441ccbc930ce3959bea1321971d7aac3fb7",
         "type": "github"
       },
       "original": {
@@ -686,11 +686,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1783607685,
-        "narHash": "sha256-9/NjZHN25rg3MCG78iN3zj8Mb6nf51m8o3L4eWdgE2o=",
+        "lastModified": 1784215689,
+        "narHash": "sha256-uBDBk60BNpk7clti9+iXsTO/na+aI7HYHnd5KtULedg=",
         "owner": "nexu-io",
         "repo": "open-design",
-        "rev": "81b20dc6a214da2228bdd08f8850656b98f9bcea",
+        "rev": "3a6221a54b84bdc29d7f1bfe9b9da71c0935a229",
         "type": "github"
       },
       "original": {

--- a/hosts/Nexus/services/nextcloud.nix
+++ b/hosts/Nexus/services/nextcloud.nix
@@ -7,7 +7,7 @@
 
   services.nextcloud = {
     enable = true;
-    package = pkgs.nextcloud33;
+    package = pkgs.nextcloud34;
     hostName = "nextcloud.matteopacini.me";
     https = true;
     datadir = "/diskpool/nextcloud";

--- a/modules/home-manager/git.nix
+++ b/modules/home-manager/git.nix
@@ -105,7 +105,10 @@ in
         };
       })
       (lib.mkIf (cfg.signing.enable && cfg.signing.allowedSignersContent != "") {
-        home.file."${cfg.signing.allowedSignersFile}".text = cfg.signing.allowedSignersContent;
+        # home.file keys are $HOME-relative and don't expand "~", so strip the
+        # prefix here; git expands the "~" form in gpg.ssh.allowedSignersFile.
+        home.file."${lib.removePrefix "~/" cfg.signing.allowedSignersFile}".text =
+          cfg.signing.allowedSignersContent;
       })
       (lib.mkIf (cfg.includes != [ ]) {
         programs.git.includes = cfg.includes;

--- a/modules/nvf/default.nix
+++ b/modules/nvf/default.nix
@@ -148,6 +148,15 @@
       formatOnSave = true;
       lightbulb.enable = true;
       trouble.enable = true;
+      servers.rust-analyzer.settings."rust-analyzer" = {
+        cargo.allFeatures = true;
+        checkOnSave = true;
+        check = {
+          command = "clippy";
+          extraArgs = [ "--no-deps" ];
+        };
+        procMacro.enable = true;
+      };
     };
     autocomplete.nvim-cmp.enable = true;
     assistant.copilot = {
@@ -252,7 +261,7 @@
           enable = true;
           type = [
             "ruff"
-            "ruff-check"
+            "ruff-fix"
           ];
         };
         extraDiagnostics.enable = false;
@@ -265,17 +274,6 @@
       html.enable = true;
       rust = {
         enable = true;
-        lsp.opts = ''
-          ['rust-analyzer'] = {
-            cargo = { allFeatures = true },
-            checkOnSave = true,
-            check = {
-              command = "clippy",
-              extraArgs = { "--no-deps" },
-            },
-            procMacro = { enable = true },
-          },
-        '';
         extensions.crates-nvim.enable = true;
       };
     };

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -113,6 +113,24 @@
       doCheck = false;
     });
 
+    # patool-4.0.5: 12 tests fail because file's new landlock sandbox can't
+    # posix_spawn the bzip2/xz helpers, so `file --uncompress` misdetects
+    # t.tar.bz2 as application/x-bzip2 instead of application/x-tar. Cascades
+    # into bottles on the gaming hosts (BrightFalls, CauldronLake), killing
+    # their full system builds in CI.
+    #
+    # Upstream fix relaxes file's landlock sandbox, already merged:
+    #   Fix: https://github.com/NixOS/nixpkgs/pull/540742 (merged to staging
+    #        2026-07-11, in staging-next as of 2026-07-18)
+    # Drop this override once that PR reaches nixos-unstable.
+    pythonPackagesExtensions = (super.pythonPackagesExtensions or [ ]) ++ [
+      (_: pyprev: {
+        patool = pyprev.patool.overridePythonAttrs (_: {
+          doCheck = false;
+        });
+      })
+    ];
+
     # fwupd-2.1.1: two test cases fail in the Nix build sandbox because they
     # expect a running desktop session:
     #   - fu-engine-gtypes-test: FuPluginLogind aborts with


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:firelzrd/bore-scheduler/b3d32d475646ab95d7c1e59f210117d71ed5046d' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/5602ed62d638142c1ab31dccd01dfbfb28841225' into the Git cache...
unpacking 'github:nix-community/home-manager/165228b0efefc3e635e5174020c40ea64271dc25' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/2cd4c86fcbc78898df7c530b0c78917ca78246f5' into the Git cache...
unpacking 'github:homebrew/homebrew-core/b144deb833ff84b6025ae72efc1b0ca31fe84adf' into the Git cache...
unpacking 'github:hraban/mac-app-util/039f33deef21782d4db97087f426504951239887' into the Git cache...
unpacking 'github:lnl7/nix-darwin/a4cf1d10853b0d2be19b9eca35d749e201d70b55' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/842eeb863ecca0eeb463f7a814cdc51e1d925776' into the Git cache...
unpacking 'github:nix-community/nix-index-database/1111b9bc836afb7e31a7014e8d1272de9b1c917d' into the Git cache...
unpacking 'github:NixOS/nixpkgs/753cc8a3a87467296ddd1fa93f0cc3e81120ee46' into the Git cache...
unpacking 'github:NixOS/nixpkgs/3caf6c92cef23e58998eadcd85c3e1d3154d0391' into the Git cache...
unpacking 'github:nix-community/NUR/c2b1b330618d210442be4776a504cc08422d8483' into the Git cache...
unpacking 'github:NotAShelf/nvf/ca782441ccbc930ce3959bea1321971d7aac3fb7' into the Git cache...
unpacking 'github:nexu-io/open-design/3a6221a54b84bdc29d7f1bfe9b9da71c0935a229' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/144f4e36d0186195037da9fce80a727108978070?narHash=sha256-F43DGcBoIO8xOZFAfodg3jy0VghB9NGdb6xbTYAIx1A%3D' (2026-07-09)
  → 'github:nix-community/home-manager/165228b0efefc3e635e5174020c40ea64271dc25?narHash=sha256-N5JiyICSeQF14x%2BOQebNyPpYowOT9Rs1iKyeCylSzOA%3D' (2026-07-15)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/df719fe87b66d91c5eff41e5357d444474fa40a2?narHash=sha256-CCY%2BPJkEngUsDMdNEOPjahLjmqJHUBx5NjccB/grdmA%3D' (2026-07-09)
  → 'github:homebrew/homebrew-cask/2cd4c86fcbc78898df7c530b0c78917ca78246f5?narHash=sha256-PJYVmJbZjzugzSubM9vh4SnxaKutTy83UdlVJYhvgIs%3D' (2026-07-16)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/1f26bae586a44d8600cfcb1bae8e5b8e457cc30f?narHash=sha256-HUNGwXt8DyEqw%2B4p3xLx4IvoUgk1ALv6o1tV/QJDUAY%3D' (2026-07-10)
  → 'github:homebrew/homebrew-core/b144deb833ff84b6025ae72efc1b0ca31fe84adf?narHash=sha256-NzcICOeg9vmxOMDfxAEksthxZ%2BhgWjXFG%2BR%2BsUp2ZYI%3D' (2026-07-16)
• Updated input 'nix-darwin':
    'github:lnl7/nix-darwin/d5bd9cd77aea4c0a8f49e7fd85545671a208ed15?narHash=sha256-AAbexQvDoK%2B6GFJdhY6kqjA%2B6ECKRkidgWxkn4gMwAA%3D' (2026-07-07)
  → 'github:lnl7/nix-darwin/a4cf1d10853b0d2be19b9eca35d749e201d70b55?narHash=sha256-IOWwQMJhUxcojm0MRvuKs1fKLH727u4%2BhHeEOPhdUyA%3D' (2026-07-15)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/de7953a08ed4bb9245be043e468561c17b89130d?narHash=sha256-ORqLAo/hoJdsZC7UPAuEHev6S0%2BXIqKEC7vjo5prz1k%3D' (2026-06-13)
  → 'github:zhaofengli/nix-homebrew/842eeb863ecca0eeb463f7a814cdc51e1d925776?narHash=sha256-I/B6YoRLImHEqNWh8bs%2BtPjEDeteACeFhcLyoSMo1GE%3D' (2026-07-15)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/109191be4988470b51a60a5ef1998520aa24c01b?narHash=sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y%3D' (2026-06-12)
  → 'github:Homebrew/brew/6bd951d96e7ebc54787799dba77bfb26ec956c4c?narHash=sha256-7KnV7rTlMpys%2B2J%2BTFVxUDDyKPLXFs4wIMtckMC72VM%3D' (2026-07-14)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/96d6de10eb281b98f5cfcd1841394c03da5df77c?narHash=sha256-RY8e%2BgR2/DhXsYDxGDL6Hhe9%2BPOD9u4%2BllwxMBqMQDs%3D' (2026-07-07)
  → 'github:nix-community/nix-index-database/1111b9bc836afb7e31a7014e8d1272de9b1c917d?narHash=sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj%2BdNn/8Dsi3sPM%3D' (2026-07-12)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/d407951447dcd00442e97087bf374aad70c04cea?narHash=sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU%2BK27sk%3D' (2026-07-05)
  → 'github:NixOS/nixpkgs/753cc8a3a87467296ddd1fa93f0cc3e81120ee46?narHash=sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k%3D' (2026-07-15)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/54888f6a65298371ce04b2656f0ee0e6e27a1046?narHash=sha256-AiWTp54tXcVhX3vKV1qIbtbbXTZnAoJC6C5TxvE1ThQ%3D' (2026-07-10)
  → 'github:NixOS/nixpkgs/3caf6c92cef23e58998eadcd85c3e1d3154d0391?narHash=sha256-FikUcFtT%2B9mDKmMnoMAmWgj5SbVk1OdRpFAweh9lWTI%3D' (2026-07-17)
• Updated input 'nur':
    'github:nix-community/NUR/2b241e544c415d4f0441f8c7fd4baee828f6426c?narHash=sha256-zEnCXo5ZdANi93FqPYJDXQmn3ComoGu6ppC7l26s4Fc%3D' (2026-07-10)
  → 'github:nix-community/NUR/c2b1b330618d210442be4776a504cc08422d8483?narHash=sha256-Reg7V0xbZMwdwtoJ/x1fKGwV025TaERfaZQXchfCNVw%3D' (2026-07-16)
• Updated input 'nvf':
    'github:NotAShelf/nvf/9040a27829dab327d6cc30f88a0797db680b745f?narHash=sha256-KbcmMnmKzKUvPoKzFOkFd425MEdvdA5zohFTMCIXyx4%3D' (2026-07-09)
  → 'github:NotAShelf/nvf/ca782441ccbc930ce3959bea1321971d7aac3fb7?narHash=sha256-S1RhDpdnRmRlVhLnze3w51YStpMW7wn%2BQDtct3Z8UJs%3D' (2026-07-15)
• Updated input 'open-design':
    'github:nexu-io/open-design/81b20dc6a214da2228bdd08f8850656b98f9bcea?narHash=sha256-9/NjZHN25rg3MCG78iN3zj8Mb6nf51m8o3L4eWdgE2o%3D' (2026-07-09)
  → 'github:nexu-io/open-design/3a6221a54b84bdc29d7f1bfe9b9da71c0935a229?narHash=sha256-uBDBk60BNpk7clti9%2BiXsTO/na%2BaI7HYHnd5KtULedg%3D' (2026-07-16)
```
