### PR TITLE
feat(nexus): add Immich photo server, local-only via Caddy

### DIFF
--- a/hosts/Nexus/services/backup.nix
+++ b/hosts/Nexus/services/backup.nix
@@ -88,7 +88,7 @@ let
   restic-b2 = pkgs.writeShellScriptBin "restic-b2" ''
     set -euo pipefail
 
-    REPOS="matteo debora fabrizio config"
+    REPOS="matteo debora fabrizio config immich"
 
     if [[ $# -lt 2 ]]; then
       echo "Usage: restic-b2 <repo> <restic command...>"
@@ -104,6 +104,7 @@ let
       debora)    REPO_URL="${b2Endpoint}/debora-nexus-backup" ;;
       fabrizio)  REPO_URL="${b2Endpoint}/fabrizio-nexus-backup" ;;
       config)    REPO_URL="${b2Endpoint}/config-nexus-backup" ;;
+      immich)    REPO_URL="${b2Endpoint}/immich-nexus-backup" ;;
       *)
         echo "Unknown repo: $REPO_NAME"
         echo "Available repos: $REPOS"
@@ -259,6 +260,7 @@ in
     "restic-backups-matteo".after = [ "backup-job.service" ];
     "restic-backups-debora".after = [ "backup-job.service" ];
     "restic-backups-fabrizio".after = [ "backup-job.service" ];
+    "restic-backups-immich".after = [ "backup-job.service" ];
   };
 
   services.restic.backups = {
@@ -343,6 +345,36 @@ in
       extraBackupArgs = b2ExtraBackupArgs;
       timerConfig = {
         OnCalendar = "*-*-* 06:00:00";
+        Persistent = true;
+      };
+    };
+
+    # Immich photo library — backed up in place (not via the rsync →
+    # /diskpool/configuration path) to avoid duplicating the library onto
+    # the pool. Only original content is whitelisted; thumbs/ and
+    # encoded-video/ are regenerable and deliberately omitted. The DB
+    # itself rides the pg_dumpall → config repo pipeline separately.
+    # https://docs.immich.app/administration/backup-and-restore/
+    immich = {
+      initialize = true;
+      user = "root";
+      repository = "${b2Endpoint}/immich-nexus-backup";
+      environmentFile = resticEnvFile;
+      passwordFile = resticPasswordFile;
+      paths = [
+        "/diskpool/immich/library" # originals when storage template is on
+        "/diskpool/immich/upload" # originals in the default (template-off) layout
+        "/diskpool/immich/profile" # user avatars
+        "/diskpool/immich/backups" # immich's own metadata-only DB dumps
+      ];
+      exclude = personalExcludes;
+      pruneOpts = personalRetention;
+      runCheck = true;
+      checkOpts = [ "--read-data-subset=2%" ];
+      extraOptions = b2ExtraOptions;
+      extraBackupArgs = b2ExtraBackupArgs;
+      timerConfig = {
+        OnCalendar = "*-*-* 06:30:00";
         Persistent = true;
       };
     };

--- a/hosts/Nexus/services/caddy.nix
+++ b/hosts/Nexus/services/caddy.nix
@@ -172,6 +172,32 @@ in
           }
         '';
       };
+
+      "photos.matteopacini.me" = {
+        logFormat = ''
+          output file /var/log/caddy/access.log
+          format json
+        '';
+        extraConfig = ''
+          ${securityHeaders}
+
+          # LAN-only: no public A record exists, and this gates by source IP
+          # (LAN + tailnet) so the shared, WAN-forwarded :443 can't reach it.
+          @external not remote_ip 192.168.10.0/24 192.168.20.0/24 100.64.0.0/10 127.0.0.1/8
+          respond @external 403
+
+          # Immich uploads each asset in a single request (no client-side
+          # chunking), so the ceiling must clear the largest video/motion
+          # photo. Generous, matching the other large-upload hosts.
+          request_body {
+            max_size 20GB
+          }
+
+          # Reverse proxy to Immich (port tracks services.immich.port)
+          # WebSocket support (real-time events) is automatic
+          reverse_proxy 127.0.0.1:${toString config.services.immich.port}
+        '';
+      };
     };
   };
 }

--- a/hosts/Nexus/services/default.nix
+++ b/hosts/Nexus/services/default.nix
@@ -27,6 +27,7 @@
     ./atuin.nix
     ./mosh.nix
     ./attic.nix
+    ./immich.nix
   ];
 
   systemd.tmpfiles.rules = [

--- a/hosts/Nexus/services/immich.nix
+++ b/hosts/Nexus/services/immich.nix
@@ -1,0 +1,38 @@
+{ ... }:
+{
+  # Media library lives on the mergerfs pool. The module only adjusts
+  # perms on the default /var/lib/immich; a non-default mediaLocation
+  # must be created by us (module docs). Owned by the module's static
+  # immich user (isSystemUser, not DynamicUser) so the UID is stable
+  # for pool ownership.
+  systemd.tmpfiles.rules = [
+    "d /diskpool/immich 0700 immich immich -"
+  ];
+
+  services.immich = {
+    enable = true;
+
+    host = "127.0.0.1"; # Exposed via Caddy only
+    port = 2283;
+    openFirewall = false;
+
+    mediaLocation = "/diskpool/immich";
+
+    machine-learning.enable = true;
+
+    # Reuse the existing Postgres singleton over the unix socket
+    # (peer auth, no password). database.enable augments that instance
+    # in place — it adds the immich DB + role and the pgvector/vectorchord
+    # extensions, it does not spawn a second server.
+    database = {
+      enable = true;
+      createDB = true;
+      host = "/run/postgresql";
+      name = "immich";
+      user = "immich";
+    };
+
+    # Dedicated immich redis on its own unix socket (no collision).
+    redis.enable = true;
+  };
+}

--- a/hosts/Nexus/snapraid.nix
+++ b/hosts/Nexus/snapraid.nix
@@ -28,6 +28,11 @@ in
       "*.unrecoverable"
       "/tmp/"
       "/lost+found/"
+      # Immich regenerable caches: constantly rewritten (thumbnail/transcode
+      # jobs) so they churn parity under a live sync, and are rebuilt on demand
+      # anyway. Also omitted from the immich restic repo for the same reason.
+      "/immich/thumbs/"
+      "/immich/encoded-video/"
     ];
     touchBeforeSync = true;
     scrub = {

--- a/hosts/Nexus/users/matteo/default.nix
+++ b/hosts/Nexus/users/matteo/default.nix
@@ -23,6 +23,8 @@
   dracula.bat.enable = true;
 
   home.packages = with pkgs; [
+    # Development
+    gh
   ];
 
   home.stateVersion = "26.05";


### PR DESCRIPTION
## What

Integrates [Immich](https://immich.app) on Nexus, reachable locally at `photos.matteopacini.me`.

- **`services/immich.nix`** — Immich on loopback `:2283`, media library on `/diskpool/immich` (tmpfiles dir owned by the module's static `immich` user, safe for pool ownership), machine-learning enabled, dedicated redis. Reuses the **existing Postgres singleton** over the unix socket (peer auth, no secret). `database.enable = true` augments that instance in place with the `immich` DB/role and the `pgvector`/`vectorchord` extensions.
- **`caddy.nix`** — `photos.matteopacini.me` vhost using the same LAN + tailnet source-IP gate as `design.matteopacini.me` (no public A record + 403 for off-LAN). 20GB request-body ceiling (Immich uploads each asset in one request). Upstream port tracks `config.services.immich.port`.
- **`backup.nix`** — dedicated restic repo `immich-nexus-backup`, backing up **originals only** (`library`/`upload`/`profile`/`backups`); `thumbs` and `encoded-video` are regenerable and omitted per the [official backup guidance](https://docs.immich.app/administration/backup-and-restore/). Added to the `restic-b2` helper. The DB rides the existing `pg_dumpall` → `config` repo pipeline (no change needed).

## Deploy notes

- Adding `vchord.so` to `shared_preload_libraries` means the first `nixos-rebuild switch` **restarts Postgres once** (brief blip for hass/nextcloud/attic/radarr/sonarr).
- Media library lives on the mergerfs pool; verified against Immich v3.0.2 that its only file-mover (`StorageCore.moveFile`) falls back to copy+verify+unlink on `EXDEV`, and the pool's non-path-preserving `category.create=mfs` rarely triggers it — no config change required.

## Out-of-repo (manual)

- Add `photos.matteopacini.me A → 192.168.10.14` in LAN DNS only (keep it off public Route53).
- Create the B2 bucket `immich-nexus-backup` (done).
- Post-install: set External Domain = `https://photos.matteopacini.me` in the Immich web UI.

## Verification

`nix eval` of the Nexus toplevel is clean; wiring confirmed via eval (immich DB in `ensureDatabases`, `vchord.so` preloaded, socket peer-auth, dedicated redis socket, restic paths + repo + ordering).