### PR TITLE
chore: weekly flake update - 2026-07-23T12:13:31Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -345,11 +345,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784129366,
-        "narHash": "sha256-N5JiyICSeQF14x+OQebNyPpYowOT9Rs1iKyeCylSzOA=",
+        "lastModified": 1784789275,
+        "narHash": "sha256-cgRTWuG+u1tBPhm01JrId2k0Bni09phVJ1Q0BZlRd7M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "165228b0efefc3e635e5174020c40ea64271dc25",
+        "rev": "3b0e6bbd65869af1beadf5963a99befc179d209f",
         "type": "github"
       },
       "original": {
@@ -382,11 +382,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1784246247,
-        "narHash": "sha256-PJYVmJbZjzugzSubM9vh4SnxaKutTy83UdlVJYhvgIs=",
+        "lastModified": 1784826580,
+        "narHash": "sha256-qYowgG7ZACmzqkfMNsR5PtopvZClAL/UP36v+MICKv8=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "2cd4c86fcbc78898df7c530b0c78917ca78246f5",
+        "rev": "8fb335eedcd66a7f87814ae667f09a18090a8a90",
         "type": "github"
       },
       "original": {
@@ -398,11 +398,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1784240475,
-        "narHash": "sha256-NzcICOeg9vmxOMDfxAEksthxZ+hgWjXFG+R+sUp2ZYI=",
+        "lastModified": 1784826592,
+        "narHash": "sha256-z5FRY/tEgfv07de5h4KY8z7zp5BbhI1Fv0ZAQLiGdlc=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "b144deb833ff84b6025ae72efc1b0ca31fe84adf",
+        "rev": "a409730aa93611bffcf29bf45444834f0d8e52d8",
         "type": "github"
       },
       "original": {
@@ -456,11 +456,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784123936,
-        "narHash": "sha256-IOWwQMJhUxcojm0MRvuKs1fKLH727u4+hHeEOPhdUyA=",
+        "lastModified": 1784500460,
+        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "a4cf1d10853b0d2be19b9eca35d749e201d70b55",
+        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
         "type": "github"
       },
       "original": {
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783864904,
-        "narHash": "sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj+dNn/8Dsi3sPM=",
+        "lastModified": 1784440659,
+        "narHash": "sha256-Q5kNLlWngt7TaIIZoxDKWMHjiSaNRVqr70FqWCRRfr4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "1111b9bc836afb7e31a7014e8d1272de9b1c917d",
+        "rev": "4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb",
         "type": "github"
       },
       "original": {
@@ -541,11 +541,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1784246997,
-        "narHash": "sha256-FikUcFtT+9mDKmMnoMAmWgj5SbVk1OdRpFAweh9lWTI=",
+        "lastModified": 1784826766,
+        "narHash": "sha256-sF6mAOv1Sn+k3VQl/uL/3EbUdFeeAcfM5cES/V0Jnl4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3caf6c92cef23e58998eadcd85c3e1d3154d0391",
+        "rev": "782802ec1877e64bd39a32d01596985ac6598d07",
         "type": "github"
       },
       "original": {
@@ -605,11 +605,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1784120854,
-        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -643,11 +643,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784238397,
-        "narHash": "sha256-Reg7V0xbZMwdwtoJ/x1fKGwV025TaERfaZQXchfCNVw=",
+        "lastModified": 1784824634,
+        "narHash": "sha256-qgiv+WbMLdPjK1roLyTMFB5GYAobVkyesoMU4muh4Ak=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2b1b330618d210442be4776a504cc08422d8483",
+        "rev": "b220af8673ae0bdf37e68468bdf01c47551bc3ac",
         "type": "github"
       },
       "original": {
@@ -665,11 +665,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784149460,
-        "narHash": "sha256-S1RhDpdnRmRlVhLnze3w51YStpMW7wn+QDtct3Z8UJs=",
+        "lastModified": 1784811718,
+        "narHash": "sha256-1N6WzM69sARVl2Fo4C7LBhdXRIhJh4KOR+FKBn1w/UU=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "ca782441ccbc930ce3959bea1321971d7aac3fb7",
+        "rev": "78474b4b88024e14c9e1d0de6d90f125e04cb1b2",
         "type": "github"
       },
       "original": {
@@ -686,11 +686,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1784215689,
-        "narHash": "sha256-uBDBk60BNpk7clti9+iXsTO/na+aI7HYHnd5KtULedg=",
+        "lastModified": 1784817240,
+        "narHash": "sha256-1HK90QECTYxzEECPzqmK8xkx9HsvCx6eRkvXHL2Cu+U=",
         "owner": "nexu-io",
         "repo": "open-design",
-        "rev": "3a6221a54b84bdc29d7f1bfe9b9da71c0935a229",
+        "rev": "f2760fdf335775bc35cc19521e6fad2f114c3571",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:firelzrd/bore-scheduler/b3d32d475646ab95d7c1e59f210117d71ed5046d' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/5602ed62d638142c1ab31dccd01dfbfb28841225' into the Git cache...
unpacking 'github:nix-community/home-manager/3b0e6bbd65869af1beadf5963a99befc179d209f' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/8fb335eedcd66a7f87814ae667f09a18090a8a90' into the Git cache...
unpacking 'github:homebrew/homebrew-core/a409730aa93611bffcf29bf45444834f0d8e52d8' into the Git cache...
unpacking 'github:hraban/mac-app-util/039f33deef21782d4db97087f426504951239887' into the Git cache...
unpacking 'github:lnl7/nix-darwin/57a3171f94705599a2499248ca5758d5eb47c0e0' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/842eeb863ecca0eeb463f7a814cdc51e1d925776' into the Git cache...
unpacking 'github:nix-community/nix-index-database/4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb' into the Git cache...
unpacking 'github:NixOS/nixpkgs/241313f4e8e508cb9b13278c2b0fa25b9ca27163' into the Git cache...
unpacking 'github:NixOS/nixpkgs/782802ec1877e64bd39a32d01596985ac6598d07' into the Git cache...
unpacking 'github:nix-community/NUR/b220af8673ae0bdf37e68468bdf01c47551bc3ac' into the Git cache...
unpacking 'github:NotAShelf/nvf/78474b4b88024e14c9e1d0de6d90f125e04cb1b2' into the Git cache...
unpacking 'github:nexu-io/open-design/f2760fdf335775bc35cc19521e6fad2f114c3571' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/165228b0efefc3e635e5174020c40ea64271dc25?narHash=sha256-N5JiyICSeQF14x%2BOQebNyPpYowOT9Rs1iKyeCylSzOA%3D' (2026-07-15)
  → 'github:nix-community/home-manager/3b0e6bbd65869af1beadf5963a99befc179d209f?narHash=sha256-cgRTWuG%2Bu1tBPhm01JrId2k0Bni09phVJ1Q0BZlRd7M%3D' (2026-07-23)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/2cd4c86fcbc78898df7c530b0c78917ca78246f5?narHash=sha256-PJYVmJbZjzugzSubM9vh4SnxaKutTy83UdlVJYhvgIs%3D' (2026-07-16)
  → 'github:homebrew/homebrew-cask/8fb335eedcd66a7f87814ae667f09a18090a8a90?narHash=sha256-qYowgG7ZACmzqkfMNsR5PtopvZClAL/UP36v%2BMICKv8%3D' (2026-07-23)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/b144deb833ff84b6025ae72efc1b0ca31fe84adf?narHash=sha256-NzcICOeg9vmxOMDfxAEksthxZ%2BhgWjXFG%2BR%2BsUp2ZYI%3D' (2026-07-16)
  → 'github:homebrew/homebrew-core/a409730aa93611bffcf29bf45444834f0d8e52d8?narHash=sha256-z5FRY/tEgfv07de5h4KY8z7zp5BbhI1Fv0ZAQLiGdlc%3D' (2026-07-23)
• Updated input 'nix-darwin':
    'github:lnl7/nix-darwin/a4cf1d10853b0d2be19b9eca35d749e201d70b55?narHash=sha256-IOWwQMJhUxcojm0MRvuKs1fKLH727u4%2BhHeEOPhdUyA%3D' (2026-07-15)
  → 'github:lnl7/nix-darwin/57a3171f94705599a2499248ca5758d5eb47c0e0?narHash=sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo%3D' (2026-07-19)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/1111b9bc836afb7e31a7014e8d1272de9b1c917d?narHash=sha256-BQxN5UMg9FOevAsgBRwPxfxlh51Puj%2BdNn/8Dsi3sPM%3D' (2026-07-12)
  → 'github:nix-community/nix-index-database/4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb?narHash=sha256-Q5kNLlWngt7TaIIZoxDKWMHjiSaNRVqr70FqWCRRfr4%3D' (2026-07-19)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/753cc8a3a87467296ddd1fa93f0cc3e81120ee46?narHash=sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k%3D' (2026-07-15)
  → 'github:NixOS/nixpkgs/241313f4e8e508cb9b13278c2b0fa25b9ca27163?narHash=sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU%3D' (2026-07-19)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/3caf6c92cef23e58998eadcd85c3e1d3154d0391?narHash=sha256-FikUcFtT%2B9mDKmMnoMAmWgj5SbVk1OdRpFAweh9lWTI%3D' (2026-07-17)
  → 'github:NixOS/nixpkgs/782802ec1877e64bd39a32d01596985ac6598d07?narHash=sha256-sF6mAOv1Sn%2Bk3VQl/uL/3EbUdFeeAcfM5cES/V0Jnl4%3D' (2026-07-23)
• Updated input 'nur':
    'github:nix-community/NUR/c2b1b330618d210442be4776a504cc08422d8483?narHash=sha256-Reg7V0xbZMwdwtoJ/x1fKGwV025TaERfaZQXchfCNVw%3D' (2026-07-16)
  → 'github:nix-community/NUR/b220af8673ae0bdf37e68468bdf01c47551bc3ac?narHash=sha256-qgiv%2BWbMLdPjK1roLyTMFB5GYAobVkyesoMU4muh4Ak%3D' (2026-07-23)
• Updated input 'nvf':
    'github:NotAShelf/nvf/ca782441ccbc930ce3959bea1321971d7aac3fb7?narHash=sha256-S1RhDpdnRmRlVhLnze3w51YStpMW7wn%2BQDtct3Z8UJs%3D' (2026-07-15)
  → 'github:NotAShelf/nvf/78474b4b88024e14c9e1d0de6d90f125e04cb1b2?narHash=sha256-1N6WzM69sARVl2Fo4C7LBhdXRIhJh4KOR%2BFKBn1w/UU%3D' (2026-07-23)
• Updated input 'open-design':
    'github:nexu-io/open-design/3a6221a54b84bdc29d7f1bfe9b9da71c0935a229?narHash=sha256-uBDBk60BNpk7clti9%2BiXsTO/na%2BaI7HYHnd5KtULedg%3D' (2026-07-16)
  → 'github:nexu-io/open-design/f2760fdf335775bc35cc19521e6fad2f114c3571?narHash=sha256-1HK90QECTYxzEECPzqmK8xkx9HsvCx6eRkvXHL2Cu%2BU%3D' (2026-07-23)
```
