### PR TITLE
feat(darwin): enable jellyfin-mpv-shim on macOS hosts

### DIFF
--- a/hosts/NightSprings/users/matteo/default.nix
+++ b/hosts/NightSprings/users/matteo/default.nix
@@ -36,6 +36,7 @@
   custom.wezterm.enable = true;
   custom.claude-code.enable = true;
   custom.mpv.enable = true;
+  custom.mpv.jellyfinShim.enable = true;
 
   home.stateVersion = "26.05";
 

--- a/hosts/WorkLaptop/users/matteo.pacini/default.nix
+++ b/hosts/WorkLaptop/users/matteo.pacini/default.nix
@@ -35,6 +35,7 @@
   custom.wezterm.enable = true;
   custom.claude-code.enable = true;
   custom.mpv.enable = true;
+  custom.mpv.jellyfinShim.enable = true;
 
   home.stateVersion = "26.05";
 

--- a/modules/home-manager/mpv/jellyfin-shim.nix
+++ b/modules/home-manager/mpv/jellyfin-shim.nix
@@ -52,20 +52,20 @@ in
 
     autoStart = lib.mkOption {
       type = lib.types.bool;
-      default = !isDarwin;
+      default = true;
       description = ''
-        Launch shim on login via systemd user service (Linux only).
-        Darwin has no equivalent — launch manually or add a launchd agent
-        at the system level.
+        Launch shim on login: systemd user service on Linux, launchd
+        agent (gui domain / Aqua session) on Darwin.
       '';
     };
   };
 
-  # Skip entirely on Darwin: the shim's embedded libmpv backend is broken
-  # upstream on macOS, jellyfin-mpv-shim's python-mpv dep fails to build
-  # because its test suite requires Xvfb, and home-manager cannot manage
-  # launchd agents for auto-start anyway.
-  config = lib.mkIf (cfg.enable && shimCfg.enable && !isDarwin) {
+  # Darwin notes: nixpkgs marks the package Linux-only and its python-mpv
+  # dep can't pass tests there — overlays/shared.nix lifts both. The shim's
+  # embedded libmpv backend is broken upstream on macOS, so we run the
+  # external-mpv backend (mpv_ext, upstream default on darwin since 2.10.0;
+  # kept explicit below alongside the store path).
+  config = lib.mkIf (cfg.enable && shimCfg.enable) {
     home.packages = [ pkgs.jellyfin-mpv-shim ];
 
     # Reuse the mpv config tree — single source of truth.
@@ -111,6 +111,21 @@ in
         Environment = [ "MESA_VK_DEVICE_SELECT=!llvmpipe" ];
       };
       Install.WantedBy = [ "graphical-session.target" ];
+    };
+
+    # No network gate on Darwin: launchd's KeepAlive.NetworkState is
+    # documented as no longer implemented, and connect_retry_mins above
+    # already covers a slow network at login.
+    launchd.agents.jellyfin-mpv-shim = lib.mkIf (isDarwin && shimCfg.autoStart) {
+      enable = true;
+      config = {
+        ProgramArguments = [ "${pkgs.jellyfin-mpv-shim}/bin/jellyfin-mpv-shim" ];
+        RunAtLoad = true;
+        # Restart on crash/nonzero exit, stay dead on clean quit from the tray.
+        KeepAlive.SuccessfulExit = false;
+        ProcessType = "Interactive";
+        LimitLoadToSessionType = "Aqua";
+      };
     };
   };
 }

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -102,6 +102,49 @@
       ];
     });
 
+    # jellyfin-mpv-shim: nixpkgs marks it Linux-only, and its python-mpv dep
+    # backs most tests with pyvirtualdisplay-spawned Xvfb while only
+    # providing the xvfb binary on Linux, so those tests can never pass on
+    # Darwin. Disable exactly the display-backed tests (40 of 44 in v1.0.8;
+    # the four display-free TestLifecycle ones still run) and lift the shim's
+    # platform gate: builds and runs fine on aarch64-darwin (verified
+    # 2026-07-30 against v2.10.0: builds, registers as a cast target, plays).
+    # Linux hosts pass through untouched. Drop once nixpkgs supports darwin
+    # in pkgs/by-name/je/jellyfin-mpv-shim/package.nix.
+    jellyfin-mpv-shim =
+      if super.stdenv.hostPlatform.isDarwin then
+        (super.jellyfin-mpv-shim.override {
+          python3Packages = super.python3Packages.overrideScope (
+            _: pysuper: {
+              mpv = pysuper.mpv.overridePythonAttrs (old: {
+                disabledTestPaths = (old.disabledTestPaths or [ ]) ++ [
+                  "tests/test_mpv.py::TestProperties"
+                  "tests/test_mpv.py::ObservePropertyTest"
+                  "tests/test_mpv.py::KeyBindingTest"
+                  "tests/test_mpv.py::TestStreams"
+                  "tests/test_mpv.py::CommandTests"
+                  "tests/test_mpv.py::RegressionTests"
+                  "tests/test_mpv.py::TestLifecycle::test_log_handler"
+                  "tests/test_mpv.py::TestLifecycle::test_wait_for_event"
+                  "tests/test_mpv.py::TestLifecycle::test_wait_for_event_shutdown"
+                  "tests/test_mpv.py::TestLifecycle::test_wait_for_property_event_overflow"
+                  "tests/test_mpv.py::TestLifecycle::test_wait_for_property_negative"
+                  "tests/test_mpv.py::TestLifecycle::test_wait_for_property_positive"
+                  "tests/test_mpv.py::TestLifecycle::test_wait_for_property_shutdown"
+                  "tests/test_mpv.py::TestLifecycle::test_wait_for_shutdown"
+                ];
+              });
+            }
+          );
+        }).overridePythonAttrs
+          (old: {
+            meta = old.meta // {
+              platforms = old.meta.platforms ++ super.lib.platforms.darwin;
+            };
+          })
+      else
+        super.jellyfin-mpv-shim;
+
     # jellyfin-tui: cover art flickers on every redraw when launched inside a
     # zellij pane because zellij's Kitty/Sixel passthrough is unreliable
     # (zellij-org/zellij#2814, #2576). The patch forces Picker::halfblocks() when


### PR DESCRIPTION
Brings the Jellyfin cast receiver to the Macs. Until now the shim only ran on BrightFalls because the package was Linux-only in nixpkgs.

- Small overlay makes the package build on macOS (skips tests that need a Linux-only display server)
- Shim now auto-starts on login on macOS, same as it already did on Linux
- Enabled on NightSprings and WorkLaptop

Tested on WorkLaptop: shows up as a cast target in Jellyfin and plays fine. Linux hosts are untouched (BrightFalls rebuilds identically).

Note: each Mac needs a one-time server login on first start.