### PR TITLE
chore: weekly flake update - 2026-07-30T22:28:43Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1784068757,
-        "narHash": "sha256-7KnV7rTlMpys+2J+TFVxUDDyKPLXFs4wIMtckMC72VM=",
+        "lastModified": 1784558651,
+        "narHash": "sha256-woXJ1ATKpSYRWCy46TQJjmm9XzAeZVEZw9xDfVG9NYI=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6bd951d96e7ebc54787799dba77bfb26ec956c4c",
+        "rev": "b48c7994b5f0eed7bef532efa63cb4e4f763887a",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.11",
+        "ref": "6.0.12",
         "repo": "brew",
         "type": "github"
       }
@@ -288,11 +288,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784789275,
-        "narHash": "sha256-cgRTWuG+u1tBPhm01JrId2k0Bni09phVJ1Q0BZlRd7M=",
+        "lastModified": 1785306346,
+        "narHash": "sha256-DScBkW0fOgpGPK2trNoX3ryLTlaC14+gglFo/BhGJ4g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3b0e6bbd65869af1beadf5963a99befc179d209f",
+        "rev": "e705714e918c3b11affcdd15db2cbe3a070420a0",
         "type": "github"
       },
       "original": {
@@ -304,11 +304,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1784848964,
-        "narHash": "sha256-8/1R7wnKNb6GuLLiJBhOYpw5TfvmdiIoUb4xKuqUKsY=",
+        "lastModified": 1785454642,
+        "narHash": "sha256-Ua4VpFYQnOQhCUJLcxyyYMc61UoWSEmZjO8WlXQHDAg=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "071c93d63c9679b490b8f1525c33a79e05915736",
+        "rev": "db96d081bcd8411507c098fd34877836747fc1c2",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1784852315,
-        "narHash": "sha256-/GlJ1fSlT0czBvsoX4twCpuUjTw6Y4CsJ+tU+VRZJJk=",
+        "lastModified": 1785457401,
+        "narHash": "sha256-B+M7JouP+AORo9XGo9+0a5Dn+OQru5KGfxyoELg6xhs=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "b9b1b4e51b4955b31e6e8ae2eb0a846d302e4b59",
+        "rev": "9e7a77fbede1a46828db11232c76ad70d48b5a5b",
         "type": "github"
       },
       "original": {
@@ -378,11 +378,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784500460,
-        "narHash": "sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo=",
+        "lastModified": 1785389976,
+        "narHash": "sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "57a3171f94705599a2499248ca5758d5eb47c0e0",
+        "rev": "15abb8c98f336cd8bd840d71059adebabe60bf04",
         "type": "github"
       },
       "original": {
@@ -397,11 +397,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1784159664,
-        "narHash": "sha256-I/B6YoRLImHEqNWh8bs+tPjEDeteACeFhcLyoSMo1GE=",
+        "lastModified": 1784906761,
+        "narHash": "sha256-2v0H8+Ert+xbm0oliHblXTPPczuKiibBUBvRax59kxg=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "842eeb863ecca0eeb463f7a814cdc51e1d925776",
+        "rev": "60623ec512406261f553d24033c8a0c53fd0b7f2",
         "type": "github"
       },
       "original": {
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784440659,
-        "narHash": "sha256-Q5kNLlWngt7TaIIZoxDKWMHjiSaNRVqr70FqWCRRfr4=",
+        "lastModified": 1785046085,
+        "narHash": "sha256-UiK+mmZJuLWQVhJ5b2wDzogIYWAesyRm6LA3h3Ulh3Y=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb",
+        "rev": "11665045df8b9938ef811a3bfdc65cffb02b4b70",
         "type": "github"
       },
       "original": {
@@ -463,11 +463,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1784850793,
-        "narHash": "sha256-H+cO9iA3RUYr4ckglcrn4hgvj1TWwEun8Mh2mkoCYhg=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e220185ff6e66544862579018f33012372bb708f",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {
@@ -527,11 +527,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
         "type": "github"
       },
       "original": {
@@ -549,11 +549,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784850751,
-        "narHash": "sha256-hgzAOYjCqpzL/kacdYwahNDZuiAfzq5mLE8K3GKOfKY=",
+        "lastModified": 1785455566,
+        "narHash": "sha256-AHZtcLHU3jG9bqCI87SQu8EwpVpDQh2aDjX0pmj3Pkw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2e38ec6a064e372aedbba7238a8ba8512885b89f",
+        "rev": "0f0d4c6a877585091aa05aa12f570477460014fc",
         "type": "github"
       },
       "original": {
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784811718,
-        "narHash": "sha256-1N6WzM69sARVl2Fo4C7LBhdXRIhJh4KOR+FKBn1w/UU=",
+        "lastModified": 1785340309,
+        "narHash": "sha256-6oYV6KtN1ZotFTRNrSqIeDl69Kvf/B2LLmVz4MB99Gw=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "78474b4b88024e14c9e1d0de6d90f125e04cb1b2",
+        "rev": "712598d41ad0ca87de84ad37a2fec745d7580700",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -26,17 +26,17 @@
     "bore-scheduler-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1777633487,
-        "narHash": "sha256-KdeMUJ0Sp0PgS/ZA2q3VK2Nf0mTtcncEwZr4meepOwI=",
+        "lastModified": 1785248677,
+        "narHash": "sha256-SzzbWPBOuwAgrL7JgesF3L2aCJgBOVGuvy5ynS24Adk=",
         "owner": "firelzrd",
         "repo": "bore-scheduler",
-        "rev": "b3d32d475646ab95d7c1e59f210117d71ed5046d",
+        "rev": "6a52aac2deab3faebcae97a34bb3eec4b3c2967e",
         "type": "github"
       },
       "original": {
         "owner": "firelzrd",
         "repo": "bore-scheduler",
-        "rev": "b3d32d475646ab95d7c1e59f210117d71ed5046d",
+        "rev": "6a52aac2deab3faebcae97a34bb3eec4b3c2967e",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
     # Bore Scheduler #
     ##################
     bore-scheduler-src = {
-      url = "github:firelzrd/bore-scheduler?rev=b3d32d475646ab95d7c1e59f210117d71ed5046d";
+      url = "github:firelzrd/bore-scheduler?rev=6a52aac2deab3faebcae97a34bb3eec4b3c2967e";
       flake = false;
     };
     ################

--- a/hosts/BrightFalls/services.nix
+++ b/hosts/BrightFalls/services.nix
@@ -76,7 +76,7 @@ in
   # https://discourse.nixos.org/t/connected-to-mullvadvpn-but-no-internet-connection/35803/8?u=lion
   services.resolved.enable = true;
   services.mullvad-vpn.enable = true;
-  services.mullvad-vpn.package = pkgs.mullvad-vpn;
+  services.mullvad-vpn.gui.enable = true;
 
   services.fwupd.enable = true;
 

--- a/hosts/CauldronLake/services.nix
+++ b/hosts/CauldronLake/services.nix
@@ -6,7 +6,7 @@
   # https://discourse.nixos.org/t/connected-to-mullvadvpn-but-no-internet-connection/35803/8?u=lion
   services.resolved.enable = true;
   services.mullvad-vpn.enable = true;
-  services.mullvad-vpn.package = pkgs.mullvad-vpn;
+  services.mullvad-vpn.gui.enable = true;
 
   services.thermald.enable = true;
 }

--- a/modules/nixos/kernel.nix
+++ b/modules/nixos/kernel.nix
@@ -28,15 +28,17 @@
       let
         # Use pkgs.linuxPackages_7_1.kernel.version instead of config.boot.kernelPackages.kernel.version
         # to avoid infinite recursion (boot.kernelPatches affects boot.kernelPackages)
-        kernelVersion = lib.versions.majorMinor pkgs.linuxPackages_7_1.kernel.version;
-        patchesDir = "${inputs.bore-scheduler-src}/patches/stable/linux-${kernelVersion}-bore";
+        kernelVersion = pkgs.linuxPackages_7_1.kernel.version;
+        # Stable BORE series still targets 7.1-rc1 and rots on 7.1.5; use the
+        # exact-version testing patch until upstream promotes a stable series.
+        testingPatch = "${inputs.bore-scheduler-src}/patches/testing/0001-linux${kernelVersion}-bore-6.8.0.patch";
 
-        borePatches = lib.optionals config.custom.kernel.useBorePatches (
-          lib.mapAttrsToList (name: _: {
-            name = "bore-${name}";
-            patch = "${patchesDir}/${name}";
-          }) (builtins.readDir patchesDir)
-        );
+        borePatches = lib.optionals config.custom.kernel.useBorePatches [
+          {
+            name = "bore-testing-${kernelVersion}";
+            patch = testingPatch;
+          }
+        ];
       in
       borePatches;
   };


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:firelzrd/bore-scheduler/b3d32d475646ab95d7c1e59f210117d71ed5046d' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/5602ed62d638142c1ab31dccd01dfbfb28841225' into the Git cache...
unpacking 'github:nix-community/home-manager/e705714e918c3b11affcdd15db2cbe3a070420a0' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/db96d081bcd8411507c098fd34877836747fc1c2' into the Git cache...
unpacking 'github:homebrew/homebrew-core/9e7a77fbede1a46828db11232c76ad70d48b5a5b' into the Git cache...
unpacking 'github:hraban/mac-app-util/039f33deef21782d4db97087f426504951239887' into the Git cache...
unpacking 'github:lnl7/nix-darwin/15abb8c98f336cd8bd840d71059adebabe60bf04' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/60623ec512406261f553d24033c8a0c53fd0b7f2' into the Git cache...
unpacking 'github:nix-community/nix-index-database/11665045df8b9938ef811a3bfdc65cffb02b4b70' into the Git cache...
unpacking 'github:NixOS/nixpkgs/0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5' into the Git cache...
unpacking 'github:NixOS/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746' into the Git cache...
unpacking 'github:nix-community/NUR/0f0d4c6a877585091aa05aa12f570477460014fc' into the Git cache...
unpacking 'github:NotAShelf/nvf/712598d41ad0ca87de84ad37a2fec745d7580700' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/3b0e6bbd65869af1beadf5963a99befc179d209f?narHash=sha256-cgRTWuG%2Bu1tBPhm01JrId2k0Bni09phVJ1Q0BZlRd7M%3D' (2026-07-23)
  → 'github:nix-community/home-manager/e705714e918c3b11affcdd15db2cbe3a070420a0?narHash=sha256-DScBkW0fOgpGPK2trNoX3ryLTlaC14%2BgglFo/BhGJ4g%3D' (2026-07-29)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/071c93d63c9679b490b8f1525c33a79e05915736?narHash=sha256-8/1R7wnKNb6GuLLiJBhOYpw5TfvmdiIoUb4xKuqUKsY%3D' (2026-07-23)
  → 'github:homebrew/homebrew-cask/db96d081bcd8411507c098fd34877836747fc1c2?narHash=sha256-Ua4VpFYQnOQhCUJLcxyyYMc61UoWSEmZjO8WlXQHDAg%3D' (2026-07-30)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/b9b1b4e51b4955b31e6e8ae2eb0a846d302e4b59?narHash=sha256-/GlJ1fSlT0czBvsoX4twCpuUjTw6Y4CsJ%2BtU%2BVRZJJk%3D' (2026-07-24)
  → 'github:homebrew/homebrew-core/9e7a77fbede1a46828db11232c76ad70d48b5a5b?narHash=sha256-B%2BM7JouP%2BAORo9XGo9%2B0a5Dn%2BOQru5KGfxyoELg6xhs%3D' (2026-07-31)
• Updated input 'nix-darwin':
    'github:lnl7/nix-darwin/57a3171f94705599a2499248ca5758d5eb47c0e0?narHash=sha256-UvORnAxTRHax7RG74W8Z2t4GvIkX6AjJ5kk0QlwZomo%3D' (2026-07-19)
  → 'github:lnl7/nix-darwin/15abb8c98f336cd8bd840d71059adebabe60bf04?narHash=sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU%3D' (2026-07-30)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/842eeb863ecca0eeb463f7a814cdc51e1d925776?narHash=sha256-I/B6YoRLImHEqNWh8bs%2BtPjEDeteACeFhcLyoSMo1GE%3D' (2026-07-15)
  → 'github:zhaofengli/nix-homebrew/60623ec512406261f553d24033c8a0c53fd0b7f2?narHash=sha256-2v0H8%2BErt%2Bxbm0oliHblXTPPczuKiibBUBvRax59kxg%3D' (2026-07-24)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/6bd951d96e7ebc54787799dba77bfb26ec956c4c?narHash=sha256-7KnV7rTlMpys%2B2J%2BTFVxUDDyKPLXFs4wIMtckMC72VM%3D' (2026-07-14)
  → 'github:Homebrew/brew/b48c7994b5f0eed7bef532efa63cb4e4f763887a?narHash=sha256-woXJ1ATKpSYRWCy46TQJjmm9XzAeZVEZw9xDfVG9NYI%3D' (2026-07-20)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/4f8d52a3598b0dc7db7a5e7b419e3edd9d1ecfdb?narHash=sha256-Q5kNLlWngt7TaIIZoxDKWMHjiSaNRVqr70FqWCRRfr4%3D' (2026-07-19)
  → 'github:nix-community/nix-index-database/11665045df8b9938ef811a3bfdc65cffb02b4b70?narHash=sha256-UiK%2BmmZJuLWQVhJ5b2wDzogIYWAesyRm6LA3h3Ulh3Y%3D' (2026-07-26)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/e2587caef70cea85dd97d7daab492899902dbf5d?narHash=sha256-wWFrV5/Qbm%2Blyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI%3D' (2026-07-23)
  → 'github:NixOS/nixpkgs/0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5?narHash=sha256-dN6Ou5x/%2B23FZLEpYP3IffO%2BNyJFzUlGumt1uu3MMaY%3D' (2026-07-29)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/e220185ff6e66544862579018f33012372bb708f?narHash=sha256-H%2BcO9iA3RUYr4ckglcrn4hgvj1TWwEun8Mh2mkoCYhg%3D' (2026-07-23)
  → 'github:NixOS/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746?narHash=sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH%2BzRHqg8%3D' (2026-07-30)
• Updated input 'nur':
    'github:nix-community/NUR/2e38ec6a064e372aedbba7238a8ba8512885b89f?narHash=sha256-hgzAOYjCqpzL/kacdYwahNDZuiAfzq5mLE8K3GKOfKY%3D' (2026-07-23)
  → 'github:nix-community/NUR/0f0d4c6a877585091aa05aa12f570477460014fc?narHash=sha256-AHZtcLHU3jG9bqCI87SQu8EwpVpDQh2aDjX0pmj3Pkw%3D' (2026-07-30)
• Updated input 'nvf':
    'github:NotAShelf/nvf/78474b4b88024e14c9e1d0de6d90f125e04cb1b2?narHash=sha256-1N6WzM69sARVl2Fo4C7LBhdXRIhJh4KOR%2BFKBn1w/UU%3D' (2026-07-23)
  → 'github:NotAShelf/nvf/712598d41ad0ca87de84ad37a2fec745d7580700?narHash=sha256-6oYV6KtN1ZotFTRNrSqIeDl69Kvf/B2LLmVz4MB99Gw%3D' (2026-07-29)
```
