### PR TITLE
fix: recover jellyfin-mpv-shim from a dead WebSocket

### DIFF
--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -102,48 +102,69 @@
       ];
     });
 
-    # jellyfin-mpv-shim: nixpkgs marks it Linux-only, and its python-mpv dep
-    # backs most tests with pyvirtualdisplay-spawned Xvfb while only
-    # providing the xvfb binary on Linux, so those tests can never pass on
-    # Darwin. Disable exactly the display-backed tests (40 of 44 in v1.0.8;
-    # the four display-free TestLifecycle ones still run) and lift the shim's
+    # jellyfin-mpv-shim, all platforms: the shim's health check only checks
+    # that its DeviceId is listed in GET /Sessions, but the server keeps a
+    # session listed after the WebSocket dies while dropping remote control
+    # with it. The half-dead session then reads as healthy forever — the
+    # device stays in the server's device list but vanishes from the cast
+    # menu, and the shim never reconnects. The patch also requires
+    # SupportsRemoteControl so the existing reconnect path runs. See the
+    # patch header and jellyfin/jellyfin-mpv-shim#461 (OPEN).
+    #
+    # Darwin only, on top of that: nixpkgs marks the package Linux-only, and
+    # its python-mpv dep backs most tests with pyvirtualdisplay-spawned Xvfb
+    # while only providing the xvfb binary on Linux, so those tests can never
+    # pass there. Disable exactly the display-backed tests (40 of 44 in
+    # v1.0.8; the four display-free TestLifecycle ones still run) and lift the
     # platform gate: builds and runs fine on aarch64-darwin (verified
     # 2026-07-30 against v2.10.0: builds, registers as a cast target, plays).
-    # Linux hosts pass through untouched. Drop once nixpkgs supports darwin
-    # in pkgs/by-name/je/jellyfin-mpv-shim/package.nix.
+    # Drop that half once nixpkgs supports darwin in
+    # pkgs/by-name/je/jellyfin-mpv-shim/package.nix.
     jellyfin-mpv-shim =
-      if super.stdenv.hostPlatform.isDarwin then
-        (super.jellyfin-mpv-shim.override {
-          python3Packages = super.python3Packages.overrideScope (
-            _: pysuper: {
-              mpv = pysuper.mpv.overridePythonAttrs (old: {
-                disabledTestPaths = (old.disabledTestPaths or [ ]) ++ [
-                  "tests/test_mpv.py::TestProperties"
-                  "tests/test_mpv.py::ObservePropertyTest"
-                  "tests/test_mpv.py::KeyBindingTest"
-                  "tests/test_mpv.py::TestStreams"
-                  "tests/test_mpv.py::CommandTests"
-                  "tests/test_mpv.py::RegressionTests"
-                  "tests/test_mpv.py::TestLifecycle::test_log_handler"
-                  "tests/test_mpv.py::TestLifecycle::test_wait_for_event"
-                  "tests/test_mpv.py::TestLifecycle::test_wait_for_event_shutdown"
-                  "tests/test_mpv.py::TestLifecycle::test_wait_for_property_event_overflow"
-                  "tests/test_mpv.py::TestLifecycle::test_wait_for_property_negative"
-                  "tests/test_mpv.py::TestLifecycle::test_wait_for_property_positive"
-                  "tests/test_mpv.py::TestLifecycle::test_wait_for_property_shutdown"
-                  "tests/test_mpv.py::TestLifecycle::test_wait_for_shutdown"
-                ];
-              });
+      let
+        isDarwin = super.stdenv.hostPlatform.isDarwin;
+
+        # .override re-runs the package function and would discard anything
+        # added by overridePythonAttrs, so it has to come first.
+        base =
+          if isDarwin then
+            super.jellyfin-mpv-shim.override {
+              python3Packages = super.python3Packages.overrideScope (
+                _: pysuper: {
+                  mpv = pysuper.mpv.overridePythonAttrs (old: {
+                    disabledTestPaths = (old.disabledTestPaths or [ ]) ++ [
+                      "tests/test_mpv.py::TestProperties"
+                      "tests/test_mpv.py::ObservePropertyTest"
+                      "tests/test_mpv.py::KeyBindingTest"
+                      "tests/test_mpv.py::TestStreams"
+                      "tests/test_mpv.py::CommandTests"
+                      "tests/test_mpv.py::RegressionTests"
+                      "tests/test_mpv.py::TestLifecycle::test_log_handler"
+                      "tests/test_mpv.py::TestLifecycle::test_wait_for_event"
+                      "tests/test_mpv.py::TestLifecycle::test_wait_for_event_shutdown"
+                      "tests/test_mpv.py::TestLifecycle::test_wait_for_property_event_overflow"
+                      "tests/test_mpv.py::TestLifecycle::test_wait_for_property_negative"
+                      "tests/test_mpv.py::TestLifecycle::test_wait_for_property_positive"
+                      "tests/test_mpv.py::TestLifecycle::test_wait_for_property_shutdown"
+                      "tests/test_mpv.py::TestLifecycle::test_wait_for_shutdown"
+                    ];
+                  });
+                }
+              );
             }
-          );
-        }).overridePythonAttrs
-          (old: {
-            meta = old.meta // {
-              platforms = old.meta.platforms ++ super.lib.platforms.darwin;
-            };
-          })
-      else
-        super.jellyfin-mpv-shim;
+          else
+            super.jellyfin-mpv-shim;
+      in
+      base.overridePythonAttrs (old: {
+        patches = (old.patches or [ ]) ++ [
+          ../patches/jellyfin-mpv-shim/001-health-check-remote-control.patch
+        ];
+        meta =
+          old.meta
+          // super.lib.optionalAttrs isDarwin {
+            platforms = old.meta.platforms ++ super.lib.platforms.darwin;
+          };
+      });
 
     # jellyfin-tui: cover art flickers on every redraw when launched inside a
     # zellij pane because zellij's Kitty/Sixel passthrough is unreliable

--- a/patches/jellyfin-mpv-shim/001-health-check-remote-control.patch
+++ b/patches/jellyfin-mpv-shim/001-health-check-remote-control.patch
@@ -1,0 +1,84 @@
+jellyfin-mpv-shim: treat a session without remote control as disconnected
+=========================================================================
+
+Problem
+-------
+The shim silently disappears from Jellyfin's cast menu while still looking
+healthy. The device keeps showing up in the server's Dashboard → Devices
+list, playback cannot be started against it any more, and the shim never
+recovers on its own. Only a full restart of the process brings it back.
+
+Observed on a Darwin host (launchd agent) after ~24h uptime across
+sleep/wake and network changes: the process held one CLOSE_WAIT socket to
+the server, the server reported the session with `SupportsRemoteControl:
+false`, and `LastActivityDate` had gone stale by over an hour while a
+browser session on the same server kept ticking.
+
+Root cause
+----------
+The shim's own health check (`ClientManager.validate_client`, called every
+`health_check_interval` seconds — 300 by default) decides whether it is
+still connected by looking for its own `DeviceId` in `GET /Sessions`:
+
+    for f_client in client_list:
+        if f_client.get("DeviceId") == settings.client_uuid:
+            break
+    else:
+        ... force a reconnect ...
+
+Presence in that list is not the same thing as being controllable. Jellyfin
+keeps a session listed for as long as the HTTP session is alive, but only
+reports `SupportsRemoteControl: true` while a session controller with media
+control — in practice, the shim's WebSocket — is attached.
+
+When the WebSocket dies without a clean close (sleep/wake, roaming between
+networks, a NAT or VPN dropping the connection), `WebSocketDisconnect` is
+never delivered, so the reconnect path in `setup_client` never fires. The
+health check then finds the `DeviceId` still listed, concludes everything is
+fine, and returns True forever. The session stays half-dead: visible in the
+dashboard, invisible in the cast menu.
+
+This is the failure class described upstream in
+https://github.com/jellyfin/jellyfin-mpv-shim/issues/461 (OPEN). The 2.10.0
+health check was added for the related #344 / #410 reports but still only
+checks presence, so it does not cover this case.
+
+Fix
+---
+Require `SupportsRemoteControl` in addition to the `DeviceId` match. A
+listed-but-uncontrollable session now takes the existing not-in-list branch,
+which tears the client down and emits `WebSocketDisconnect` — driving the
+reconnect logic that already exists in `setup_client`. Recovery therefore
+happens within one health-check interval instead of never.
+
+The log message is widened to cover both cases so the reason stays clear in
+the logs.
+
+Applies to all platforms: this is the same wedge on Linux, it has simply
+only been observed on a Darwin host so far.
+
+Drop this patch once upstream's health check checks controllability.
+
+--- a/jellyfin_mpv_shim/clients.py
++++ b/jellyfin_mpv_shim/clients.py
+@@ -364,12 +364,18 @@ class ClientManager(object):
+             return True
+ 
+         for f_client in client_list:
+-            if f_client.get("DeviceId") == settings.client_uuid:
++            # Presence alone is not enough: the server keeps the session
++            # listed after the WebSocket dies, but drops remote control with
++            # it. Without this check a half-dead session reads as healthy and
++            # the reconnect below never runs.
++            if f_client.get("DeviceId") == settings.client_uuid and f_client.get(
++                "SupportsRemoteControl"
++            ):
+                 break
+         else:
+             if not dry_run:
+                 log.warning(
+-                    "Client is not actually connected. (It does not show in the client list.)"
++                    "Client is not actually connected. (It does not show in the client list, or cannot be remote controlled.)"
+                 )
+                 # WebSocketDisconnect doesn't always happen here.
+                 client.callback = lambda *_: None


### PR DESCRIPTION
The shim quietly disappears from Jellyfin's cast menu after a while — sleep/wake or a network change kills its connection, but it keeps looking fine to itself and never reconnects. Only a restart brings it back.

Small patch makes its own health check notice the dead connection, so it reconnects on its own within five minutes.

Applies to all hosts, not just the Macs — same failure is possible on BrightFalls, it just hasn't been seen there yet.

Verified: builds on macOS with the patch applied; BrightFalls evaluates clean. Nothing to see until it wedges again, at which point it should recover by itself.