### PR TITLE
feat(nexus): add bazarr subtitle manager

### DIFF
--- a/hosts/Nexus/networking.nix
+++ b/hosts/Nexus/networking.nix
@@ -37,7 +37,7 @@
       ++ lib.optionals config.services.nzbget.enable [ 6789 ]
       ++ lib.unique (map (l: l.port) config.services.mosquitto.listeners);
 
-      # Admin web UIs (paperless, zigbee2mqtt, radarr, sonarr): trusted-device
+      # Admin web UIs (paperless, zigbee2mqtt, radarr, sonarr, bazarr): trusted-device
       # VLAN + WorkLaptop only. Guest and IoT VLANs and WAN are blocked.
       # Tailnet bypasses via trustedInterfaces.
       extraInputRules =
@@ -47,6 +47,7 @@
             config.services.zigbee2mqtt.settings.frontend.port
             config.services.radarr.settings.server.port
             config.services.sonarr.settings.server.port
+            config.services.bazarr.listenPort
           ];
         in
         ''

--- a/hosts/Nexus/services/backup.nix
+++ b/hosts/Nexus/services/backup.nix
@@ -21,6 +21,7 @@ let
     "nzbhydra2"
     "radarr"
     "sonarr"
+    "bazarr"
     "paperless-web"
     "paperless-scheduler"
     "paperless-consumer"
@@ -202,6 +203,8 @@ let
     ''${RSYNC_CMD} ${config.services.radarr.dataDir} ${backupDestination}/
     # sonarr
     ''${RSYNC_CMD} ${config.services.sonarr.dataDir} ${backupDestination}/
+    # bazarr (provider credentials live in its UI-managed config)
+    ''${RSYNC_CMD} ${config.services.bazarr.dataDir} ${backupDestination}/
     # paperless - data directory
     ''${RSYNC_CMD} ${config.services.paperless.dataDir} ${backupDestination}/
     # paperless - media directory

--- a/hosts/Nexus/services/bazarr.nix
+++ b/hosts/Nexus/services/bazarr.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  services.bazarr = {
+    enable = true;
+    group = "media";
+    openFirewall = false; # tailnet + trusted-device rule in ../networking.nix
+  };
+}

--- a/hosts/Nexus/services/default.nix
+++ b/hosts/Nexus/services/default.nix
@@ -9,6 +9,7 @@
     ./nzbhydra.nix
     ./radarr.nix
     ./sonarr.nix
+    ./bazarr.nix
     ./n8n
     ./ddns.nix
     ./caddy.nix


### PR DESCRIPTION
Adds Bazarr (automated subtitle fetching) to Nexus, syncing from the existing Sonarr/Radarr instances and writing sidecar subs into the media library for Jellyfin.

- `services.bazarr` with `group = media`, firewall closed (tailnet + trusted-device rule)
- Web UI port added to the admin-UI nftables allowlist
- `/var/lib/bazarr` added to the backup pipeline (stop list + rsync)

Eval verified: `nix eval .#nixosConfigurations.Nexus.config.system.build.toplevel` passes.