### PR TITLE
chore: weekly flake update - 2026-08-05T19:45:50Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,16 +26,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1784558651,
-        "narHash": "sha256-woXJ1ATKpSYRWCy46TQJjmm9XzAeZVEZw9xDfVG9NYI=",
+        "lastModified": 1785146564,
+        "narHash": "sha256-Sa7/HrfB04H32OJ7/ofxXjiZEbkWtCNOriONYYTL1OA=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "b48c7994b5f0eed7bef532efa63cb4e4f763887a",
+        "rev": "b2cfc03346d482f79886de108fee5dc49a6efc10",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.12",
+        "ref": "6.0.13",
         "repo": "brew",
         "type": "github"
       }
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785306346,
-        "narHash": "sha256-DScBkW0fOgpGPK2trNoX3ryLTlaC14+gglFo/BhGJ4g=",
+        "lastModified": 1786031233,
+        "narHash": "sha256-TIDlLTLI1/pB7IqgjzcKQjpODQsZE2oII4XGG9B6KjI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e705714e918c3b11affcdd15db2cbe3a070420a0",
+        "rev": "7834e82588860aaf780cec1366524456a70898d7",
         "type": "github"
       },
       "original": {
@@ -287,11 +287,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1785454642,
-        "narHash": "sha256-Ua4VpFYQnOQhCUJLcxyyYMc61UoWSEmZjO8WlXQHDAg=",
+        "lastModified": 1786064568,
+        "narHash": "sha256-FMpXo8GAsae4QD6ar182k7lAmJDT9ovL/J3HYPHv5Mc=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "db96d081bcd8411507c098fd34877836747fc1c2",
+        "rev": "a8e1b8beee2059c140923a8f9dc8d58ee03d6d37",
         "type": "github"
       },
       "original": {
@@ -303,11 +303,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1785457401,
-        "narHash": "sha256-B+M7JouP+AORo9XGo9+0a5Dn+OQru5KGfxyoELg6xhs=",
+        "lastModified": 1786063095,
+        "narHash": "sha256-vV41gFmzwBO0kEREpeTQFRJqHnkNp6huEypYLMjRcAA=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "9e7a77fbede1a46828db11232c76ad70d48b5a5b",
+        "rev": "5781d13ddc6942bcc7fbe9846d75d183923e9d2c",
         "type": "github"
       },
       "original": {
@@ -380,11 +380,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1784906761,
-        "narHash": "sha256-2v0H8+Ert+xbm0oliHblXTPPczuKiibBUBvRax59kxg=",
+        "lastModified": 1785544760,
+        "narHash": "sha256-qV6OoNuly4ntqpCg7esIeJjUboxSnQNlLPxz+y5h9/o=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "60623ec512406261f553d24033c8a0c53fd0b7f2",
+        "rev": "937ce52c7d046310571f3a070713804ead496843",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785046085,
-        "narHash": "sha256-UiK+mmZJuLWQVhJ5b2wDzogIYWAesyRm6LA3h3Ulh3Y=",
+        "lastModified": 1785650611,
+        "narHash": "sha256-q4kR7g+pCcz6NASvoVPYu+CWWUurX03wogtBqGmR4h0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "11665045df8b9938ef811a3bfdc65cffb02b4b70",
+        "rev": "dbc756c9d7287de19b3e0e38c928c47510d42c3e",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1785454630,
-        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "lastModified": 1786064586,
+        "narHash": "sha256-YgoNpspLDziKCn0k6dqnkm+sOgBlNdO1dY3VOZLdqiU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "rev": "def6d5c786d2362add8a814b9ddc9dd6ce189fc6",
         "type": "github"
       },
       "original": {
@@ -510,11 +510,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1785318670,
-        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
         "type": "github"
       },
       "original": {
@@ -532,11 +532,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785455566,
-        "narHash": "sha256-AHZtcLHU3jG9bqCI87SQu8EwpVpDQh2aDjX0pmj3Pkw=",
+        "lastModified": 1786065102,
+        "narHash": "sha256-12s1k7UzGBnc6vUa8XLfdcPi/yTNM+io9DAxUvEnA9o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0f0d4c6a877585091aa05aa12f570477460014fc",
+        "rev": "3f36117b8883446d03dc03bfa933f6fab6ab889e",
         "type": "github"
       },
       "original": {
@@ -554,11 +554,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785340309,
-        "narHash": "sha256-6oYV6KtN1ZotFTRNrSqIeDl69Kvf/B2LLmVz4MB99Gw=",
+        "lastModified": 1785857293,
+        "narHash": "sha256-E7WXL/pYNph1ChKv4BixI9Pev6osdJL43322uZqLw5w=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "712598d41ad0ca87de84ad37a2fec745d7580700",
+        "rev": "64cbd0ffea1a76dc0248528985e1c8ee711fae99",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/5602ed62d638142c1ab31dccd01dfbfb28841225' into the Git cache...
unpacking 'github:nix-community/home-manager/7834e82588860aaf780cec1366524456a70898d7' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/a8e1b8beee2059c140923a8f9dc8d58ee03d6d37' into the Git cache...
unpacking 'github:homebrew/homebrew-core/5781d13ddc6942bcc7fbe9846d75d183923e9d2c' into the Git cache...
unpacking 'github:hraban/mac-app-util/039f33deef21782d4db97087f426504951239887' into the Git cache...
unpacking 'github:lnl7/nix-darwin/15abb8c98f336cd8bd840d71059adebabe60bf04' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/937ce52c7d046310571f3a070713804ead496843' into the Git cache...
unpacking 'github:nix-community/nix-index-database/dbc756c9d7287de19b3e0e38c928c47510d42c3e' into the Git cache...
unpacking 'github:NixOS/nixpkgs/b7c2ada94fe99c15b0dbcf4d11fd7850b957a436' into the Git cache...
unpacking 'github:NixOS/nixpkgs/def6d5c786d2362add8a814b9ddc9dd6ce189fc6' into the Git cache...
unpacking 'github:nix-community/NUR/3f36117b8883446d03dc03bfa933f6fab6ab889e' into the Git cache...
unpacking 'github:NotAShelf/nvf/64cbd0ffea1a76dc0248528985e1c8ee711fae99' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/e705714e918c3b11affcdd15db2cbe3a070420a0?narHash=sha256-DScBkW0fOgpGPK2trNoX3ryLTlaC14%2BgglFo/BhGJ4g%3D' (2026-07-29)
  → 'github:nix-community/home-manager/7834e82588860aaf780cec1366524456a70898d7?narHash=sha256-TIDlLTLI1/pB7IqgjzcKQjpODQsZE2oII4XGG9B6KjI%3D' (2026-08-06)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/db96d081bcd8411507c098fd34877836747fc1c2?narHash=sha256-Ua4VpFYQnOQhCUJLcxyyYMc61UoWSEmZjO8WlXQHDAg%3D' (2026-07-30)
  → 'github:homebrew/homebrew-cask/a8e1b8beee2059c140923a8f9dc8d58ee03d6d37?narHash=sha256-FMpXo8GAsae4QD6ar182k7lAmJDT9ovL/J3HYPHv5Mc%3D' (2026-08-07)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/9e7a77fbede1a46828db11232c76ad70d48b5a5b?narHash=sha256-B%2BM7JouP%2BAORo9XGo9%2B0a5Dn%2BOQru5KGfxyoELg6xhs%3D' (2026-07-31)
  → 'github:homebrew/homebrew-core/5781d13ddc6942bcc7fbe9846d75d183923e9d2c?narHash=sha256-vV41gFmzwBO0kEREpeTQFRJqHnkNp6huEypYLMjRcAA%3D' (2026-08-07)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/60623ec512406261f553d24033c8a0c53fd0b7f2?narHash=sha256-2v0H8%2BErt%2Bxbm0oliHblXTPPczuKiibBUBvRax59kxg%3D' (2026-07-24)
  → 'github:zhaofengli/nix-homebrew/937ce52c7d046310571f3a070713804ead496843?narHash=sha256-qV6OoNuly4ntqpCg7esIeJjUboxSnQNlLPxz%2By5h9/o%3D' (2026-08-01)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/b48c7994b5f0eed7bef532efa63cb4e4f763887a?narHash=sha256-woXJ1ATKpSYRWCy46TQJjmm9XzAeZVEZw9xDfVG9NYI%3D' (2026-07-20)
  → 'github:Homebrew/brew/b2cfc03346d482f79886de108fee5dc49a6efc10?narHash=sha256-Sa7/HrfB04H32OJ7/ofxXjiZEbkWtCNOriONYYTL1OA%3D' (2026-07-27)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/11665045df8b9938ef811a3bfdc65cffb02b4b70?narHash=sha256-UiK%2BmmZJuLWQVhJ5b2wDzogIYWAesyRm6LA3h3Ulh3Y%3D' (2026-07-26)
  → 'github:nix-community/nix-index-database/dbc756c9d7287de19b3e0e38c928c47510d42c3e?narHash=sha256-q4kR7g%2BpCcz6NASvoVPYu%2BCWWUurX03wogtBqGmR4h0%3D' (2026-08-02)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5?narHash=sha256-dN6Ou5x/%2B23FZLEpYP3IffO%2BNyJFzUlGumt1uu3MMaY%3D' (2026-07-29)
  → 'github:NixOS/nixpkgs/b7c2ada94fe99c15b0dbcf4d11fd7850b957a436?narHash=sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM%3D' (2026-08-05)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746?narHash=sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH%2BzRHqg8%3D' (2026-07-30)
  → 'github:NixOS/nixpkgs/def6d5c786d2362add8a814b9ddc9dd6ce189fc6?narHash=sha256-YgoNpspLDziKCn0k6dqnkm%2BsOgBlNdO1dY3VOZLdqiU%3D' (2026-08-07)
• Updated input 'nur':
    'github:nix-community/NUR/0f0d4c6a877585091aa05aa12f570477460014fc?narHash=sha256-AHZtcLHU3jG9bqCI87SQu8EwpVpDQh2aDjX0pmj3Pkw%3D' (2026-07-30)
  → 'github:nix-community/NUR/3f36117b8883446d03dc03bfa933f6fab6ab889e?narHash=sha256-12s1k7UzGBnc6vUa8XLfdcPi/yTNM%2Bio9DAxUvEnA9o%3D' (2026-08-07)
• Updated input 'nvf':
    'github:NotAShelf/nvf/712598d41ad0ca87de84ad37a2fec745d7580700?narHash=sha256-6oYV6KtN1ZotFTRNrSqIeDl69Kvf/B2LLmVz4MB99Gw%3D' (2026-07-29)
  → 'github:NotAShelf/nvf/64cbd0ffea1a76dc0248528985e1c8ee711fae99?narHash=sha256-E7WXL/pYNph1ChKv4BixI9Pev6osdJL43322uZqLw5w%3D' (2026-08-04)
```
