### PR TITLE
chore: weekly flake update - 2026-08-13T20:38:55Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786031233,
-        "narHash": "sha256-TIDlLTLI1/pB7IqgjzcKQjpODQsZE2oII4XGG9B6KjI=",
+        "lastModified": 1786656209,
+        "narHash": "sha256-ybGtuwGKTUCefKYsplzvw4xcCqznto0c7BaiQhgILtA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7834e82588860aaf780cec1366524456a70898d7",
+        "rev": "c554d3441f725537854e877519f01cbd60680174",
         "type": "github"
       },
       "original": {
@@ -287,11 +287,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1786227398,
-        "narHash": "sha256-oXl292oUfS/U1aPDF37dECpvd1G7AvPNu4NP/BjnNwQ=",
+        "lastModified": 1786670159,
+        "narHash": "sha256-GcDOPqSv3WmM70jyT8avu13oyS+w3Sy0771gcaIWM2s=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "04ca29f2c62ceb273726472b8b8629cd33fc2b6b",
+        "rev": "285d3f812d3fb2018083135a739b188c98a10f85",
         "type": "github"
       },
       "original": {
@@ -303,11 +303,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1786225920,
-        "narHash": "sha256-xXEbdweYR3ngcl/Yu4ELe8kjmd7+OhtQl/JPykyz1j0=",
+        "lastModified": 1786668767,
+        "narHash": "sha256-0FBYGP3LURVFB4xMKM6za508e9pPchjv4BV6JHfuBuI=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "f37a316deaaf590ed3816d4c3a98b467a15ccd38",
+        "rev": "a660928c61c7a43678ea7a7e2bf478d1428a84a2",
         "type": "github"
       },
       "original": {
@@ -319,11 +319,11 @@
     "linuwux-runtime": {
       "flake": false,
       "locked": {
-        "lastModified": 1786640992,
-        "narHash": "sha256-pGcJuuJs9iSJuc6kRORJEXHh+tUva2900SF6ktp0RXs=",
+        "lastModified": 1786660385,
+        "narHash": "sha256-f2JyaNgHQdnvzTqcEDwuOsYt0MXQP/JP/UNkTKXBHIQ=",
         "owner": "brcly",
         "repo": "linuwux-runtime",
-        "rev": "dfaea18b4ff53c8d683c361d6b83ed8804e88c71",
+        "rev": "d93f0cbd168abbba502262a9b92917eaedd4b8a6",
         "type": "github"
       },
       "original": {
@@ -396,11 +396,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1786217209,
-        "narHash": "sha256-rusAj5QBnbSwXG6csns6dwxTeCOGRcj08VmlnhUQ6ZY=",
+        "lastModified": 1786580329,
+        "narHash": "sha256-/8cBGYJ+Cj2bSdXv7+B+DFIU+s5u/iKouWUZUvFz32E=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "486357ea434dc0061ea52121ff99b1d33096c811",
+        "rev": "7be2ffcda4d9632edb7150b263ee081abba5e984",
         "type": "github"
       },
       "original": {
@@ -416,11 +416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785650611,
-        "narHash": "sha256-q4kR7g+pCcz6NASvoVPYu+CWWUurX03wogtBqGmR4h0=",
+        "lastModified": 1786249295,
+        "narHash": "sha256-Y2mSr+HLKYoOsjiackgilxkHXe8gkJ3z4hFFekjQX3I=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "dbc756c9d7287de19b3e0e38c928c47510d42c3e",
+        "rev": "14d55b8069119e3b88da7aa2f6c97f86a2cd3cd6",
         "type": "github"
       },
       "original": {
@@ -462,11 +462,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1786227658,
-        "narHash": "sha256-JpbnOiygVlhUKmSW6qDu/3Ga1p1L2MZt6Ji6Pzlrlb8=",
+        "lastModified": 1786670044,
+        "narHash": "sha256-WcRxwA3/k9E8E6VjKJgFXp1K/9OrH6h3Fv+z6fSu8OE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e3bd7ff8acf5c2f98a1b4605876339446698448",
+        "rev": "1c21631155ea2bc6c2885c908f2a6e4a627301da",
         "type": "github"
       },
       "original": {
@@ -526,11 +526,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
         "type": "github"
       },
       "original": {
@@ -548,11 +548,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786227941,
-        "narHash": "sha256-dYJYY5vj1Htq1Z1HIBhIkoxkyIp10Z0oeInMhNvU3ic=",
+        "lastModified": 1786667428,
+        "narHash": "sha256-rtBI5BwVpVP4Tbg6udtYiw4kD9C0COHEc/rzpzylfI4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f7a00558b209aa646eedaaa7effccbdedb749dcc",
+        "rev": "40ec339ee452baf23b2676e9c1fcdbe456c7f873",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785857293,
-        "narHash": "sha256-E7WXL/pYNph1ChKv4BixI9Pev6osdJL43322uZqLw5w=",
+        "lastModified": 1786433999,
+        "narHash": "sha256-rbOp2g0UCYt+evTnCGCKBQGqSMfwX4RTXneNbeHqOAk=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "64cbd0ffea1a76dc0248528985e1c8ee711fae99",
+        "rev": "a213644cadd5f90bf18b0c409f08f282b30e55e3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -526,11 +526,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1786862985,
+        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
         "type": "github"
       },
       "original": {

--- a/overlays/brightfalls.nix
+++ b/overlays/brightfalls.nix
@@ -40,6 +40,33 @@
       ];
     });
 
+    # ananicy-cpp 1.2.0 reaches std::memset and the <cstdint> integer aliases
+    # through fmt rather than including those headers itself, and fmt 12.2.0
+    # swapped <cstring>/<cstdint> in fmt/format.h for <string.h> — which only
+    # declares memset in the global namespace. Breaks the build on any rev
+    # carrying fmt >= 12.2.0. Pulled in by services.ananicy on this host
+    # (hosts/BrightFalls/gaming.nix). See the patch header for the full
+    # write-up, including why the glibc 2.42 attribution in both PRs below is
+    # a red herring (glibc and clang are identical either side of the break).
+    #
+    # Upstream fix, both OPEN as of 2026-08-14 — the patch is the verbatim MR
+    # diff, so this override becomes redundant the moment the nixpkgs one lands:
+    #   nixpkgs: https://github.com/NixOS/nixpkgs/pull/552211 (OPEN)
+    #   upstream: https://gitlab.com/ananicy-cpp/ananicy-cpp/-/merge_requests/43 (OPEN)
+    #
+    # To drop this: once nixos-unstable carries #552211, delete this attribute
+    # and patches/ananicy-cpp/. Inspect the effective patch list with
+    #   nix eval .#nixosConfigurations.BrightFalls.pkgs.ananicy-cpp.patches
+    # which prints nixpkgs' own patches alongside ours. #552211 fetchpatches the
+    # very same MR diff, so once it lands ours is byte-identical to a patch
+    # already applied and the build fails with a reversed/already-applied hunk —
+    # that failure is the signal it is time to go, not a new bug.
+    ananicy-cpp = super.ananicy-cpp.overrideAttrs (old: {
+      patches = (old.patches or [ ]) ++ [
+        ../patches/ananicy-cpp/001-missing-cstring-cstdint-includes.patch
+      ];
+    });
+
     qemu = optimizedForBrightFalls (
       super.qemu.override ({
         hostCpuTargets = [

--- a/overlays/brightfalls.nix
+++ b/overlays/brightfalls.nix
@@ -49,10 +49,11 @@
     # write-up, including why the glibc 2.42 attribution in both PRs below is
     # a red herring (glibc and clang are identical either side of the break).
     #
-    # Upstream fix, both OPEN as of 2026-08-14 — the patch is the verbatim MR
-    # diff, so this override becomes redundant the moment the nixpkgs one lands:
-    #   nixpkgs: https://github.com/NixOS/nixpkgs/pull/552211 (OPEN)
-    #   upstream: https://gitlab.com/ananicy-cpp/ananicy-cpp/-/merge_requests/43 (OPEN)
+    # Upstream fix — the patch is the verbatim MR diff, so this override becomes
+    # redundant the moment the nixpkgs one reaches the nixos-unstable channel:
+    #   nixpkgs: https://github.com/NixOS/nixpkgs/pull/552211 (MERGED 2026-08-16
+    #     as 74c1eb32, still 4 commits ahead of the e5bdc4a pin as of 2026-08-17)
+    #   upstream: https://gitlab.com/ananicy-cpp/ananicy-cpp/-/merge_requests/43
     #
     # To drop this: once nixos-unstable carries #552211, delete this attribute
     # and patches/ananicy-cpp/. Inspect the effective patch list with

--- a/patches/ananicy-cpp/001-missing-cstring-cstdint-includes.patch
+++ b/patches/ananicy-cpp/001-missing-cstring-cstdint-includes.patch
@@ -1,0 +1,200 @@
+ananicy-cpp 1.2.0: include <cstring>/<cstdint> instead of relying on fmt
+========================================================================
+
+Problem
+-------
+The BrightFalls closure stopped building on the 2026-08-13 flake update
+(PR #364), failing to compile ananicy-cpp:
+
+    src/utility/argument_parsing/argument.cpp:24:3: error: no member named
+      'memset' in namespace 'std'; did you mean simply 'memset'?
+       24 |   std::memset(buffer.get(), 0, sz);
+          |   ^~~~~~~~~~~
+    .../glibc-2.42-67-dev/include/bits/string_fortified.h:57:8: note:
+      'memset' declared here
+
+Root cause
+----------
+ananicy-cpp reaches `std::memset` and the <cstdint> integer aliases
+(`std::int32_t`/`std::uint32_t`) through a transitive include rather than
+including those headers itself. Every affected translation unit includes some
+fmt header, and fmt was what supplied them. fmt 12.2.0 stopped:
+
+    fmt/format.h, 12.1.0            fmt/format.h, 12.2.0
+      #include <cstdint>  // uint32_t  -->  #include <string.h>  // memcpy
+      #include <cstring>  // std::memcpy
+
+<string.h> declares `memset` in the global namespace only, so `std::memset`
+no longer resolves, and the <cstdint> aliases disappear outright. Hence the
+two error classes this patch fixes.
+
+Note the glibc 2.42 attribution in both upstream PRs below is a red herring —
+it is the note line in the diagnostic, not the trigger. The nixpkgs revs
+either side of this update carry identical glibc (2.42-67) and clang
+(21.1.8); fmt 12.1.0 -> 12.2.0 is the only relevant change. The old
+derivation still builds and is substitutable from cache.nixos.org
+(a3r2blx88i85m9rnhb4xg5x0798zjbbm), which is why CI's "Build latest
+configuration" step passed while "Build new configuration" failed.
+
+ananicy-cpp also carried a comparable include fix once before (nixpkgs
+84a953fb0, "ananicy-cpp: fix build w/ glibc-2.42"); the 1.1.1 -> 1.2.0 bump
+(nixpkgs 6517c55b3) dropped it.
+
+Upstream status
+---------------
+Verbatim diff of upstream MR ananicy-cpp!43, "fix: add missing <cstring> and
+<cstdint> headers for glibc 2.42" (OPEN as of 2026-08-14):
+  https://gitlab.com/ananicy-cpp/ananicy-cpp/-/merge_requests/43
+
+nixpkgs carries the same fix in PR #552211 (OPEN, one approval, green
+nixpkgs-review on x86_64-linux):
+  https://github.com/NixOS/nixpkgs/pull/552211
+
+The <unistd.h> hunks come from the same MR; they fix getpid()/getuid() under
+GCC 16 on Fedora, found by upstream CI, and are unrelated to our failure.
+
+Drop this override once #552211 reaches nixos-unstable. Vendored rather than
+fetchpatch'd on purpose: the nixpkgs PR points fetchpatch at the live MR
+`.diff` URL, whose content (and therefore hash) changes if the MR branch gets
+new commits.
+
+Applies cleanly alongside the nixpkgs-side match-wrappers.patch, which only
+touches src/worker.cpp.
+
+diff --git a/src/config.cpp b/src/config.cpp
+index 4a53e2f6a0523cf95ec6adc24fecee6b3063ee74..ce9eb3fe36673407a889b836801f17f4e423cc4a 100644
+--- a/src/config.cpp
++++ b/src/config.cpp
+@@ -6,6 +6,7 @@
+ #include "core/priority.hpp"
+ 
+ #include <chrono> // for system_clock::now
++#include <cstdint>
+ #include <fstream>
+ 
+ #include <fmt/chrono.h>
+diff --git a/src/platform/linux/backtrace.cpp b/src/platform/linux/backtrace.cpp
+index fed73c58815fc0bd4e518ec4297c785ca9c5fa6e..93759784c5e8d36736536c27b830af114e77c428 100644
+--- a/src/platform/linux/backtrace.cpp
++++ b/src/platform/linux/backtrace.cpp
+@@ -1,5 +1,6 @@
+ #include "utility/backtrace.hpp"
+ 
++#include <cstdint>
+ #include <cstdlib>    // for free
+ #include <cxxabi.h>   // for abi::__cxa_demangle
+ #include <execinfo.h> // for backtrace, backtrace_symbols
+diff --git a/src/platform/linux/cgroups.cpp b/src/platform/linux/cgroups.cpp
+index 4f4d535b9a6d5d1cf68be618042315c9a2ec589a..c5766d28f1eb8b57bfde1f954fac407a1138d71c 100644
+--- a/src/platform/linux/cgroups.cpp
++++ b/src/platform/linux/cgroups.cpp
+@@ -1,6 +1,7 @@
+ #include "core/cgroups.hpp"
+ #include "utility/mounts.hpp"
+ 
++#include <cstdint>
+ #include <filesystem>  // for path
+ #include <fstream>     // for ifstream
+ #include <mutex>       // for mutex, lock_guard
+diff --git a/src/platform/linux/debug.cpp b/src/platform/linux/debug.cpp
+index 1cbfb482dcada4d96dcda13cfafdafd8606c90ce..b8bd8aeaffa717bf50f8e25eb53925f5265e99e6 100644
+--- a/src/platform/linux/debug.cpp
++++ b/src/platform/linux/debug.cpp
+@@ -1,4 +1,5 @@
+ #include "utility/debug.hpp"
++
+ #include "core/cgroups.hpp"
+ #include "service.hpp"
+ #include "utility/utils.hpp"
+@@ -7,6 +8,7 @@
+ #include <iostream>    // for cout
+ #include <string>      // for string
+ #include <string_view> // for string_view
++#include <unistd.h>
+ 
+ #include <fmt/format.h>
+ 
+diff --git a/src/platform/linux/process.cpp b/src/platform/linux/process.cpp
+index d84cecfec68ef6dc700a201041614401d0477286..ab6a9adb97974bf7133c0f1761d90eaa83b46232 100644
+--- a/src/platform/linux/process.cpp
++++ b/src/platform/linux/process.cpp
+@@ -14,6 +14,7 @@
+ #include <filesystem> // for path
+ #include <fstream>    // for ifstream
+ #include <thread>     // for jthread
++#include <unistd.h>
+ 
+ #include <fmt/format.h>
+ #include <fmt/ranges.h>
+diff --git a/src/platform/linux/singleton_process.cpp b/src/platform/linux/singleton_process.cpp
+index 92ab2ab40b0895c203594434d380d48f6637f499..9c7a6fd85d4670335d48562c9c6c227d68528a6d 100644
+--- a/src/platform/linux/singleton_process.cpp
++++ b/src/platform/linux/singleton_process.cpp
+@@ -2,6 +2,7 @@
+ 
+ #include <cerrno>
+ #include <chrono>
++#include <cstring>
+ #include <fcntl.h> /* For O_* constants */
+ #include <sys/ipc.h>
+ #include <sys/mman.h>
+diff --git a/src/platform/systemd/service.cpp b/src/platform/systemd/service.cpp
+index d716481eb8d2fd7533852e51cd3541e0549d7252..060232156f8265900849e1462df156f31061da65 100644
+--- a/src/platform/systemd/service.cpp
++++ b/src/platform/systemd/service.cpp
+@@ -2,6 +2,7 @@
+ 
+ #include <systemd/sd-daemon.h>
+ #include <systemd/sd-login.h>
++#include <unistd.h>
+ 
+ #include <spdlog/spdlog.h>
+ 
+diff --git a/src/tests/unit-core.cpp b/src/tests/unit-core.cpp
+index b71e03398d7c99b182f7330fe57333be8c007e70..b9db9a029ec462da9bb63e81502374e8f51fd842 100644
+--- a/src/tests/unit-core.cpp
++++ b/src/tests/unit-core.cpp
+@@ -9,6 +9,7 @@
+ 
+ #include <filesystem>
+ #include <fstream>
++#include <unistd.h>
+ 
+ #include <spdlog/spdlog.h>
+ 
+diff --git a/src/tests/unit-cpuset.cpp b/src/tests/unit-cpuset.cpp
+index 31ac770a6e64cb74f090285e97226dba89594dbc..daaa11c861df22e6c7dc9b8b9d7cfc41778366fe 100644
+--- a/src/tests/unit-cpuset.cpp
++++ b/src/tests/unit-cpuset.cpp
+@@ -5,6 +5,7 @@
+ #include "core/x3d.hpp"
+ 
+ #include <spdlog/spdlog.h>
++#include <unistd.h>
+ 
+ TEST_SUITE_BEGIN("CpuSet");
+ 
+diff --git a/src/utility/argument_parsing/argument.cpp b/src/utility/argument_parsing/argument.cpp
+index 954a58843b17b90715e5d27ee34bdfe94067d2ff..cf3a331558a89a1b732a18b52f47c63e422085ac 100644
+--- a/src/utility/argument_parsing/argument.cpp
++++ b/src/utility/argument_parsing/argument.cpp
+@@ -1,6 +1,7 @@
+ #include "utility/argument_parser.hpp"
+ 
+ #include <cstdlib>
++#include <cstring>
+ #include <cxxabi.h>
+ #include <iostream>
+ #include <memory>
+diff --git a/src/utility/argument_parsing/argument_parser.cpp b/src/utility/argument_parsing/argument_parser.cpp
+index c51f85149682757dd7def21e80f8cee8755c6e06..b91139a81a385f74bcb88c167bef6ff9082b3c11 100644
+--- a/src/utility/argument_parsing/argument_parser.cpp
++++ b/src/utility/argument_parsing/argument_parser.cpp
+@@ -1,6 +1,7 @@
+ #include "utility/argument_parser.hpp"
+ 
+ #include <algorithm>
++#include <cstdint>
+ #include <cxxabi.h>
+ #include <functional>
+ #include <iostream>


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/5602ed62d638142c1ab31dccd01dfbfb28841225' into the Git cache...
unpacking 'github:nix-community/home-manager/c554d3441f725537854e877519f01cbd60680174' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/285d3f812d3fb2018083135a739b188c98a10f85' into the Git cache...
unpacking 'github:homebrew/homebrew-core/a660928c61c7a43678ea7a7e2bf478d1428a84a2' into the Git cache...
unpacking 'github:brcly/linuwux-runtime/d93f0cbd168abbba502262a9b92917eaedd4b8a6' into the Git cache...
unpacking 'github:hraban/mac-app-util/039f33deef21782d4db97087f426504951239887' into the Git cache...
unpacking 'github:lnl7/nix-darwin/15abb8c98f336cd8bd840d71059adebabe60bf04' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/7be2ffcda4d9632edb7150b263ee081abba5e984' into the Git cache...
unpacking 'github:nix-community/nix-index-database/14d55b8069119e3b88da7aa2f6c97f86a2cd3cd6' into the Git cache...
unpacking 'github:NixOS/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4' into the Git cache...
unpacking 'github:NixOS/nixpkgs/1c21631155ea2bc6c2885c908f2a6e4a627301da' into the Git cache...
unpacking 'github:nix-community/NUR/40ec339ee452baf23b2676e9c1fcdbe456c7f873' into the Git cache...
unpacking 'github:NotAShelf/nvf/a213644cadd5f90bf18b0c409f08f282b30e55e3' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/7834e82588860aaf780cec1366524456a70898d7?narHash=sha256-TIDlLTLI1/pB7IqgjzcKQjpODQsZE2oII4XGG9B6KjI%3D' (2026-08-06)
  → 'github:nix-community/home-manager/c554d3441f725537854e877519f01cbd60680174?narHash=sha256-ybGtuwGKTUCefKYsplzvw4xcCqznto0c7BaiQhgILtA%3D' (2026-08-13)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/04ca29f2c62ceb273726472b8b8629cd33fc2b6b?narHash=sha256-oXl292oUfS/U1aPDF37dECpvd1G7AvPNu4NP/BjnNwQ%3D' (2026-08-08)
  → 'github:homebrew/homebrew-cask/285d3f812d3fb2018083135a739b188c98a10f85?narHash=sha256-GcDOPqSv3WmM70jyT8avu13oyS%2Bw3Sy0771gcaIWM2s%3D' (2026-08-14)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/f37a316deaaf590ed3816d4c3a98b467a15ccd38?narHash=sha256-xXEbdweYR3ngcl/Yu4ELe8kjmd7%2BOhtQl/JPykyz1j0%3D' (2026-08-08)
  → 'github:homebrew/homebrew-core/a660928c61c7a43678ea7a7e2bf478d1428a84a2?narHash=sha256-0FBYGP3LURVFB4xMKM6za508e9pPchjv4BV6JHfuBuI%3D' (2026-08-14)
• Updated input 'linuwux-runtime':
    'github:brcly/linuwux-runtime/dfaea18b4ff53c8d683c361d6b83ed8804e88c71?narHash=sha256-pGcJuuJs9iSJuc6kRORJEXHh%2BtUva2900SF6ktp0RXs%3D' (2026-08-13)
  → 'github:brcly/linuwux-runtime/d93f0cbd168abbba502262a9b92917eaedd4b8a6?narHash=sha256-f2JyaNgHQdnvzTqcEDwuOsYt0MXQP/JP/UNkTKXBHIQ%3D' (2026-08-13)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/486357ea434dc0061ea52121ff99b1d33096c811?narHash=sha256-rusAj5QBnbSwXG6csns6dwxTeCOGRcj08VmlnhUQ6ZY%3D' (2026-08-08)
  → 'github:zhaofengli/nix-homebrew/7be2ffcda4d9632edb7150b263ee081abba5e984?narHash=sha256-/8cBGYJ%2BCj2bSdXv7%2BB%2BDFIU%2Bs5u/iKouWUZUvFz32E%3D' (2026-08-13)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/dbc756c9d7287de19b3e0e38c928c47510d42c3e?narHash=sha256-q4kR7g%2BpCcz6NASvoVPYu%2BCWWUurX03wogtBqGmR4h0%3D' (2026-08-02)
  → 'github:nix-community/nix-index-database/14d55b8069119e3b88da7aa2f6c97f86a2cd3cd6?narHash=sha256-Y2mSr%2BHLKYoOsjiackgilxkHXe8gkJ3z4hFFekjQX3I%3D' (2026-08-09)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/f13ff45afd1bb73e640eaa08a7066dbed07e3238?narHash=sha256-zDSUbpoeo/9ZmD2%2BwXnzxoo1%2BuhL8vxc0b8yuYMKYq0%3D' (2026-08-07)
  → 'github:NixOS/nixpkgs/0e251e24a4f24e036a084b6b4b2d2491af4167f4?narHash=sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU%3D' (2026-08-13)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/5e3bd7ff8acf5c2f98a1b4605876339446698448?narHash=sha256-JpbnOiygVlhUKmSW6qDu/3Ga1p1L2MZt6Ji6Pzlrlb8%3D' (2026-08-08)
  → 'github:NixOS/nixpkgs/1c21631155ea2bc6c2885c908f2a6e4a627301da?narHash=sha256-WcRxwA3/k9E8E6VjKJgFXp1K/9OrH6h3Fv%2Bz6fSu8OE%3D' (2026-08-14)
• Updated input 'nur':
    'github:nix-community/NUR/f7a00558b209aa646eedaaa7effccbdedb749dcc?narHash=sha256-dYJYY5vj1Htq1Z1HIBhIkoxkyIp10Z0oeInMhNvU3ic%3D' (2026-08-08)
  → 'github:nix-community/NUR/40ec339ee452baf23b2676e9c1fcdbe456c7f873?narHash=sha256-rtBI5BwVpVP4Tbg6udtYiw4kD9C0COHEc/rzpzylfI4%3D' (2026-08-14)
• Updated input 'nvf':
    'github:NotAShelf/nvf/64cbd0ffea1a76dc0248528985e1c8ee711fae99?narHash=sha256-E7WXL/pYNph1ChKv4BixI9Pev6osdJL43322uZqLw5w%3D' (2026-08-04)
  → 'github:NotAShelf/nvf/a213644cadd5f90bf18b0c409f08f282b30e55e3?narHash=sha256-rbOp2g0UCYt%2BevTnCGCKBQGqSMfwX4RTXneNbeHqOAk%3D' (2026-08-11)
```
