### PR TITLE
feat(darwin): add sleepmode script with zsh completion

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -316,6 +316,7 @@
               inputs.nvf.homeManagerModules.default
               self.homeManagerModules.default
               self.homeManagerModules.xcodes
+              self.homeManagerModules.sleepmode
             ];
           }
           inputs.nix-homebrew.darwinModules.nix-homebrew
@@ -371,6 +372,7 @@
               inputs.mac-app-util.homeManagerModules.default
               inputs.nvf.homeManagerModules.default
               self.homeManagerModules.default
+              self.homeManagerModules.sleepmode
             ];
           }
           inputs.nix-homebrew.darwinModules.nix-homebrew
@@ -389,6 +391,7 @@
       };
       homeManagerModules = {
         xcodes = import ./modules/home-manager/darwin/xcodes.nix;
+        sleepmode = import ./modules/home-manager/darwin/sleepmode.nix;
       };
 
       formatter = {

--- a/hosts/NightSprings/users/matteo/default.nix
+++ b/hosts/NightSprings/users/matteo/default.nix
@@ -34,6 +34,7 @@
   custom.ghostty.enable = true;
   custom.claude-code.enable = true;
   custom.herdr.enable = true;
+  custom.sleepmode.enable = true;
   custom.mpv.enable = true;
   custom.mpv.jellyfinShim.enable = true;
 

--- a/hosts/WorkLaptop/users/matteo.pacini/default.nix
+++ b/hosts/WorkLaptop/users/matteo.pacini/default.nix
@@ -35,6 +35,7 @@
   custom.ghostty.enable = true;
   custom.claude-code.enable = true;
   custom.herdr.enable = true;
+  custom.sleepmode.enable = true;
   custom.mpv.enable = true;
   custom.mpv.jellyfinShim.enable = true;
 

--- a/modules/home-manager/darwin/sleepmode.nix
+++ b/modules/home-manager/darwin/sleepmode.nix
@@ -1,0 +1,74 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.custom.sleepmode;
+
+  # disablesleep is a system-wide pmset setting, hence sudo. The value is
+  # inverted with respect to the argument: "on" means the Mac may sleep.
+  sleepmode = pkgs.writeShellApplication {
+    name = "sleepmode";
+    runtimeInputs = [ pkgs.gawk ];
+    text = ''
+      usage() {
+        echo "usage: sleepmode on|off" >&2
+        exit 2
+      }
+
+      [ $# -eq 1 ] || usage
+
+      case "$1" in
+        on) want=0 ;;
+        off) want=1 ;;
+        *) usage ;;
+      esac
+
+      /usr/bin/sudo /usr/bin/pmset -a disablesleep "$want"
+
+      # Absent SleepDisabled line means sleep is allowed.
+      actual=$(/usr/bin/pmset -g \
+        | awk '/SleepDisabled/ { print $2; found = 1 } END { if (!found) print 0 }')
+
+      if [ "$actual" != "$want" ]; then
+        printf '\033[1;31mFAILED\033[0m sleep mode unchanged (disablesleep = %s)\n' "$actual" >&2
+        exit 1
+      fi
+
+      if [ "$actual" = 0 ]; then
+        printf '\033[1;32mSleep mode ACTIVATED\033[0m - this Mac can sleep\n'
+      else
+        printf '\033[1;33mSleep mode DEACTIVATED\033[0m - this Mac will stay awake\n'
+      fi
+    '';
+  };
+
+  sleepmode-completion = pkgs.writeTextFile {
+    name = "sleepmode-zsh-completion";
+    destination = "/share/zsh/site-functions/_sleepmode";
+    text = ''
+      #compdef sleepmode
+
+      _sleepmode() {
+        _arguments -C \
+          '1:mode:((on\:"allow this Mac to sleep" off\:"keep this Mac awake"))'
+      }
+
+      _sleepmode "$@"
+    '';
+  };
+in
+{
+  options.custom.sleepmode = {
+    enable = lib.mkEnableOption "sleepmode helper for pmset disablesleep";
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [
+      sleepmode
+      sleepmode-completion
+    ];
+  };
+}


### PR DESCRIPTION
`sleepmode on|off` wraps `sudo pmset -a disablesleep` (`on` → 0, `off` → 1), reads the state back from `pmset -g` and prints a coloured confirmation (red + exit 1 if the readback disagrees). Bad args print usage and exit 2.

New darwin-only HM module `custom.sleepmode`, enabled for `matteo` on NightSprings and `matteo.pacini` on WorkLaptop. Completion ships as `_sleepmode` in `share/zsh/site-functions`.

Verified: both darwin toplevels build; completion exercised in a real zsh via zpty; on/off/mismatch paths tested with stubbed `sudo`/`pmset` (real `pmset` not run).