### PR TITLE
Restore opencode (OpenRouter ZDR), add codex, shared AGENTS.md

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,8 @@
           ./modules/home-manager/starship.nix
           ./modules/home-manager/ghostty.nix
           ./modules/home-manager/claude-code.nix
+          ./modules/home-manager/codex.nix
+          ./modules/home-manager/opencode.nix
           ./modules/home-manager/phone-scrcpy.nix
           ./modules/home-manager/herdr.nix
           ./modules/home-manager/mpv
@@ -174,6 +176,10 @@
           {
             age.identityPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
             age.secrets."brightfalls/attic-netrc".file = ./secrets/brightfalls/attic-netrc.age;
+            age.secrets."openrouter.env" = {
+              file = ./secrets/shared/openrouter.env.age;
+              owner = "matteo"; # opencode launcher runs as the user; default root:root 0400 would block it
+            };
           }
         ];
       };
@@ -238,6 +244,10 @@
             };
             age.secrets."nexus/geoip-license-key".file = ./secrets/nexus/geoip-license-key.age;
             age.secrets."nexus/n8n-env".file = ./secrets/nexus/n8n-env.age;
+            age.secrets."openrouter.env" = {
+              file = ./secrets/shared/openrouter.env.age;
+              owner = "matteo"; # opencode launcher runs as the user; default root:root 0400 would block it
+            };
           }
         ];
       };
@@ -335,6 +345,10 @@
           {
             age.identityPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
             age.secrets."nightsprings/attic-netrc".file = ./secrets/nightsprings/attic-netrc.age;
+            age.secrets."openrouter.env" = {
+              file = ./secrets/shared/openrouter.env.age;
+              owner = "matteo"; # opencode launcher runs as the user; default root:root 0400 would block it
+            };
           }
         ];
       };
@@ -357,6 +371,10 @@
           {
             age.identityPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
             age.secrets."worklaptop/attic-netrc".file = ./secrets/worklaptop/attic-netrc.age;
+            age.secrets."openrouter.env" = {
+              file = ./secrets/shared/openrouter.env.age;
+              owner = "matteo.pacini"; # opencode launcher runs as the user; default root:root 0400 would block it
+            };
           }
           inputs.mac-app-util.darwinModules.default
           inputs.home-manager.darwinModules.home-manager

--- a/hosts/BrightFalls/users/matteo/default.nix
+++ b/hosts/BrightFalls/users/matteo/default.nix
@@ -71,6 +71,7 @@
   custom.zellij.enable = true;
   custom.starship.enable = true;
   custom.claude-code.enable = true;
+  custom.opencode.enable = true;
   custom.herdr.enable = true;
   custom.phone.scrcpy.enable = true;
   custom.mpv.enable = true;

--- a/hosts/Nexus/default.nix
+++ b/hosts/Nexus/default.nix
@@ -37,6 +37,10 @@
     configurationLimit = 5;
   };
 
+  # Headless host that only ever sees remote terminals: install every
+  # terminal's terminfo so ssh sessions (xterm-ghostty et al.) resolve TERM.
+  environment.enableAllTerminfo = true;
+
   environment.systemPackages = with pkgs; [
     terminus_font
     mergerfs

--- a/hosts/Nexus/users/matteo/default.nix
+++ b/hosts/Nexus/users/matteo/default.nix
@@ -12,6 +12,8 @@
   custom.zellij.enable = true;
   custom.starship.enable = true;
   custom.claude-code.enable = true;
+  custom.codex.enable = true;
+  custom.opencode.enable = true;
   custom.herdr.enable = true;
   custom.herdr.server = true;
 

--- a/hosts/NightSprings/users/matteo/default.nix
+++ b/hosts/NightSprings/users/matteo/default.nix
@@ -33,6 +33,8 @@
   custom.starship.enable = true;
   custom.ghostty.enable = true;
   custom.claude-code.enable = true;
+  custom.codex.enable = true;
+  custom.opencode.enable = true;
   custom.herdr.enable = true;
   custom.sleepmode.enable = true;
   custom.mpv.enable = true;

--- a/hosts/WorkLaptop/users/matteo.pacini/default.nix
+++ b/hosts/WorkLaptop/users/matteo.pacini/default.nix
@@ -34,6 +34,8 @@
   custom.starship.enable = true;
   custom.ghostty.enable = true;
   custom.claude-code.enable = true;
+  custom.codex.enable = true;
+  custom.opencode.enable = true;
   custom.herdr.enable = true;
   custom.sleepmode.enable = true;
   custom.mpv.enable = true;

--- a/modules/home-manager/claude-code/CLAUDE.md
+++ b/modules/home-manager/claude-code/CLAUDE.md
@@ -22,8 +22,6 @@ question — one-line questions get one-line answers.
   declaring done after one pass.
 - Prefer minimal diffs over rewrites unless asked.
 - Match the surrounding code's style; don't impose a different one.
-- Don't narrate the diff in comments. Comment only what isn't
-  obvious from the code itself.
 
 ## Output format
 - Default to diffs or focused snippets, not full file dumps.
@@ -49,33 +47,17 @@ judgment.
   unused — but don't delete pre-existing dead code; mention it instead.
 - Every changed line should trace directly to the request.
 
-## Model delegation
-
-Guidance last updated 13/06/2026. If this is clearly out of date or
-you know a better current option, prefer that over this section.
-
-When spawning subagents or choosing a model for a task:
-
-| Task | Model |
-|------|-------|
-| Orchestration, multi-agent coordination | opus (xhigh) |
-| Hardest bugs, architecture, security review, deep planning | opus |
-| Normal coding, tests, refactors, intermediate reasoning | sonnet |
-| Search, file discovery, mechanical edits, summaries | haiku |
-
-- Use aliases, never pinned model IDs — pinned IDs fail when models
-  retire.
-- Effort: default is high; sonnet's balanced default is medium (bump
-  to high only when needed); use xhigh for hard agentic coding (opus
-  only — sonnet has no xhigh); avoid max (diminishing returns,
-  overthinking); low for simple subagents.
-- Haiku has no effort parameter and a 200K context window.
-- Plan with opus, execute with sonnet when cost matters (`opusplan`
-  automates this). Switching model mid-session costs one full
-  uncached context re-read — don't switch frivolously.
-- Before acting on web-research or multi-source claims, spawn one
-  opus skeptic prompted to refute them; drop anything refuted or
-  unverifiable. Skip for trivial lookups or primary-doc reads.
+## Code comments
+- Comment only what isn't apparent from the code itself; prefer a
+  better name or clearer structure in the code you're writing over a
+  comment — but don't refactor existing code just to avoid one.
+- Comments explain why, not what: a non-obvious trade-off, an
+  invariant a maintainer could break, a workaround, a performance or
+  security constraint.
+- Never reference the conversation, the request, or the change
+  process in comments.
+- Before finishing, delete any comment whose absence wouldn't make
+  the code harder to understand or safely modify.
 
 ## Git
 

--- a/modules/home-manager/codex.nix
+++ b/modules/home-manager/codex.nix
@@ -1,0 +1,17 @@
+{ config, lib, ... }:
+let
+  cfg = config.custom.codex;
+in
+{
+  options.custom.codex.enable = lib.mkEnableOption "Codex CLI with the shared instruction doc as global AGENTS.md";
+
+  config = lib.mkIf cfg.enable {
+    programs.codex = {
+      enable = true;
+      # Same tool-neutral doc claude-code ships as CLAUDE.md and opencode as
+      # AGENTS.md; lands in ~/.codex/AGENTS.md. Auth state (auth.json/Keychain)
+      # is runtime-managed by `codex login`, deliberately not managed here.
+      context = ./claude-code/CLAUDE.md;
+    };
+  };
+}

--- a/modules/home-manager/opencode.nix
+++ b/modules/home-manager/opencode.nix
@@ -1,0 +1,72 @@
+{
+  config,
+  lib,
+  pkgs,
+  osConfig,
+  ...
+}:
+let
+  cfg = config.custom.opencode;
+
+  opencodeConfig = builtins.toJSON {
+    "$schema" = "https://opencode.ai/config.json";
+    autoupdate = false;
+    # Cheap utility model for title generation and other lightweight tasks;
+    # main model is picked at runtime via /model (full models.dev catalog).
+    small_model = "openrouter/z-ai/glm-4.7-flash";
+    # Privacy: route every OpenRouter request only to Zero-Data-Retention,
+    # no-training providers. Provider-level `options` is spread into the shared
+    # OpenRouter SDK client, whose `extraBody` is merged into every request —
+    # so this covers all models without enumerating them (model-level
+    # `options.provider` would only apply to models listed in this file).
+    provider.openrouter.options.extraBody.provider = {
+      zdr = true;
+      data_collection = "deny";
+    };
+  };
+
+  # AGENTS.md mirrors the claude-code CLAUDE.md — the doc is tool-neutral.
+  agentsMd = builtins.readFile ./claude-code/CLAUDE.md;
+
+  launcher = pkgs.writeShellApplication {
+    name = "opencode";
+    runtimeInputs = [ pkgs.opencode ];
+    text =
+      lib.optionalString (cfg.openrouterKeyFile != null) ''
+        if [ -r "${cfg.openrouterKeyFile}" ]; then
+          set -a
+          # shellcheck disable=SC1090,SC1091
+          . "${cfg.openrouterKeyFile}"
+          set +a
+        else
+          echo "opencode: ${cfg.openrouterKeyFile} unreadable; run 'opencode auth login' or deploy the agenix secret" >&2
+        fi
+      ''
+      + ''
+        exec opencode "$@"
+      '';
+  };
+in
+{
+  options.custom.opencode = {
+    enable = lib.mkEnableOption "opencode with OpenRouter ZDR provider config";
+
+    openrouterKeyFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = lib.attrByPath [
+        "age"
+        "secrets"
+        "openrouter.env"
+        "path"
+      ] null osConfig;
+      defaultText = lib.literalExpression ''osConfig.age.secrets."openrouter.env".path or null'';
+      description = "Env file defining OPENROUTER_API_KEY, sourced by the launcher. Defaults to the agenix path of the shared openrouter.env secret.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ launcher ];
+    xdg.configFile."opencode/opencode.json".text = opencodeConfig;
+    xdg.configFile."opencode/AGENTS.md".text = agentsMd;
+  };
+}

--- a/modules/home-manager/opencode/patches/openrouter-real-cost.patch
+++ b/modules/home-manager/opencode/patches/openrouter-real-cost.patch
@@ -1,0 +1,41 @@
+Prefer OpenRouter's authoritative billed cost over opencode's per-token estimate.
+
+opencode's getUsage prices a turn as (single outer-model rate x token counts) and
+ignores OpenRouter's returned usage.cost. For OpenRouter server-side tools like
+Fusion (a panel + judge + the final answer = several completions across different
+models) that is a large undercount and the displayed number bears no relation to
+what was billed. OpenRouter already returns the real per-request cost in
+providerMetadata.openrouter.usage.cost (opencode enables usage accounting for
+@openrouter/ai-sdk-provider in provider/transform.ts). Prefer it when it is a
+valid finite number; otherwise fall back to the existing per-token calculation,
+so this is a no-op for providers/turns that do not surface a real cost.
+
+Applies cleanly across opencode 1.16.2–1.17.7 (anomalyco/opencode) — the
+getUsage hunk context is unchanged over that range (verified with
+`git apply --check` against v1.17.7).
+
+--- a/packages/opencode/src/session/session.ts
++++ b/packages/opencode/src/session/session.ts
+@@ -433,11 +433,21 @@
+       ? input.model.cost.experimentalOver200K
+       : input.model.cost)
+   const totalNanoAiu = input.metadata?.["copilot"]?.["totalNanoAiu"]
++  // OpenRouter returns the authoritative billed cost for the whole request —
++  // including server-side tools like Fusion (panel + judge + final answer) —
++  // under providerMetadata.openrouter.usage.cost (usage accounting is enabled
++  // for @openrouter/ai-sdk-provider in provider/transform.ts). Prefer it over
++  // the per-token table calc below, which only prices the single outer model
++  // and undercounts multi-completion server tools.
++  const openrouterUsage = input.metadata?.["openrouter"]?.["usage"] as { cost?: number } | undefined
++  const openrouterCost = openrouterUsage?.cost
+   return {
+     cost:
+       typeof totalNanoAiu === "number" && Number.isFinite(totalNanoAiu) && totalNanoAiu >= 0
+         ? new Decimal(totalNanoAiu).div(100_000_000_000).toNumber()
+-        : safe(
++        : typeof openrouterCost === "number" && Number.isFinite(openrouterCost) && openrouterCost >= 0
++          ? openrouterCost
++          : safe(
+             new Decimal(0)
+               .add(new Decimal(tokens.input).mul(costInfo?.input ?? 0).div(1_000_000))
+               .add(new Decimal(tokens.output).mul(costInfo?.output ?? 0).div(1_000_000))

--- a/modules/home-manager/opencode/patches/subagent-total-cost.patch
+++ b/modules/home-manager/opencode/patches/subagent-total-cost.patch
@@ -1,0 +1,84 @@
+Show the whole-agent-tree cost total in the sidebar, next to the session title.
+
+opencode tracks cost per session. Subagents spawned by the Task tool are
+separate child sessions linked to the parent by parentID, and a parent's cost
+column is never rolled up with its descendants' (the projector's applyUsage in
+packages/core only increments the session whose part is being projected). So the
+sidebar "spent" line and the subagent footer both show per-agent cost only, and
+there is no single number for "what this whole run cost". Upstream is aware but
+has not fixed it: issue #11027 (bot-closed stale), RFC #12377 (maintainer-closed
+"completed" over objection), TUI feature #22103 (open), foundation PR #7763
+(open, unmerged).
+
+This adds a derived total — the current session walked up to its tree root, then
+summed over the root and every transitive descendant — rendered under the title
+in the sidebar (the right column where the session id lives). The existing
+per-agent cost in the Context section and the subagent footer is left untouched.
+This is purely client-side: the TUI's sync store already holds every session in
+the project (session.list runs without the `roots` filter), so no server, schema
+or SDK change is needed. It does inherit session.list's 100-row / 30-day window,
+so very deep/old trees can undercount — noted in the code comment.
+
+Targets the opencode TUI (anomalyco/opencode). Verified to apply cleanly against
+v1.17.7 with `git apply --check`.
+
+diff --git a/packages/tui/src/routes/session/sidebar.tsx b/packages/tui/src/routes/session/sidebar.tsx
+index 0c5d2b3..bfbcb16 100644
+--- a/packages/tui/src/routes/session/sidebar.tsx
++++ b/packages/tui/src/routes/session/sidebar.tsx
+@@ -9,6 +9,8 @@ import { usePluginRuntime } from "../../plugin/runtime"
+ import { getScrollAcceleration } from "../../util/scroll"
+ import { WorkspaceLabel } from "../../component/workspace-label"
+
++const money = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" })
++
+ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
+   const pluginRuntime = usePluginRuntime()
+   const project = useProject()
+@@ -16,6 +18,36 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
+   const { theme } = useTheme()
+   const tuiConfig = useTuiConfig()
+   const session = createMemo(() => sync.session.get(props.sessionID))
++  // Total cost across the whole agent tree (main session + every subagent).
++  // Subagents are separate sessions linked by parentID; the per-agent cost still
++  // shows in the Context / subagent footer. Walk up to the tree root so the
++  // number is stable whichever node is in view. Bounded by session.list's
++  // 100-row / 30-day window (context/sync.tsx), so very deep trees may undercount.
++  const totalCost = createMemo(() => {
++    const all = sync.data.session
++    let root = session()
++    const guard = new Set<string>()
++    while (root?.parentID && !guard.has(root.id)) {
++      guard.add(root.id)
++      const parent = all.find((s) => s.id === root!.parentID)
++      if (!parent) break
++      root = parent
++    }
++    if (!root) return 0
++    let total = 0
++    const seen = new Set<string>()
++    const stack = [root.id]
++    while (stack.length) {
++      const id = stack.pop()!
++      if (seen.has(id)) continue
++      seen.add(id)
++      const node = all.find((s) => s.id === id)
++      if (!node) continue
++      total += node.cost ?? 0
++      for (const child of all) if (child.parentID === id) stack.push(child.id)
++    }
++    return total
++  })
+   const workspace = () => {
+     const workspaceID = session()?.workspaceID
+     if (!workspaceID) return
+@@ -57,6 +89,9 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
+                 <text fg={theme.text}>
+                   <b>{session()!.title}</b>
+                 </text>
++                <Show when={totalCost() > 0}>
++                  <text fg={theme.textMuted}>{money.format(totalCost())} total</text>
++                </Show>
+                 <Show when={InstallationChannel !== "latest"}>
+                   <text fg={theme.textMuted}>{props.sessionID}</text>
+                 </Show>

--- a/overlays/shared.nix
+++ b/overlays/shared.nix
@@ -61,6 +61,27 @@
       '';
     });
 
+    # opencode sourced from the master pin (currently 1.18.18) so it matches the
+    # patches below, which apply cleanly across opencode 1.16.2–1.18.18
+    # (re-verified with `git apply --check` against 1.18.18 on 2026-08-20).
+    # Upstream still hasn't fixed OpenRouter cost reporting (PR #37525 closed
+    # unmerged; issues #18440/#454 closed stale, bug still live).
+    opencode = masterPkgs.opencode.overrideAttrs (old: {
+      patches = (old.patches or [ ]) ++ [
+        # opencode's getUsage prices a turn as (model rate × tokens) and ignores
+        # the authoritative response usage.cost. Prefer
+        # providerMetadata.openrouter.usage.cost (usage accounting is force-enabled
+        # for the openrouter provider) so per-turn cost reflects OpenRouter's real
+        # billing.
+        ../modules/home-manager/opencode/patches/openrouter-real-cost.patch
+        # Subagent (child-session) cost isn't rolled up into the parent, so no
+        # single number shows what a whole run cost. Render a derived whole-tree
+        # total in the sidebar next to the session title; per-agent cost stays as
+        # is. Client-side only (the TUI already holds every session). See header.
+        ../modules/home-manager/opencode/patches/subagent-total-cost.patch
+      ];
+    });
+
     # xdg-desktop-portal-1.20.4: two integration tests fail in the Nix build
     # sandbox because the validator helpers (xdg-desktop-portal-validate-sound
     # and -validate-icon) shell out to bwrap, which tries to create a nested

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -47,4 +47,12 @@ in
 
   # NightSprings service secrets
   "nightsprings/attic-netrc.age".publicKeys = [ nightsprings ];
+
+  # Shared service secrets (decryptable by multiple hosts)
+  "shared/openrouter.env.age".publicKeys = [
+    brightfalls
+    nexus
+    nightsprings
+    worklaptop
+  ];
 }

--- a/secrets/shared/openrouter.env.age
+++ b/secrets/shared/openrouter.env.age
@@ -1,0 +1,12 @@
+age-encryption.org/v1
+-> ssh-ed25519 kFfEUg 7HofOCfvfNHxZno5ewK/VjPCjywAxsm4QChtHbypynM
+LMssDH/gX7LMsefV+hMeDCNBV2x437OskNvZuNr8DqI
+-> ssh-ed25519 IsuDgA fszDeaS/ZZtBSxl3jUHjiw8mqNU6AtN/BynO4OoRv2o
+67qpiCCEqbyMI/KTgliCmazif6C8Dt2qib1b2s5Cbek
+-> ssh-ed25519 R0kkNQ R4xyzzv27pD+snErPsAMz8n3Jr3W2nuwnDHnFn76LEg
+hJgxCVc4nXh3TndaEhm9rklCIIeOWzP0PpQwOFrxcA4
+-> ssh-ed25519 JGlJwQ iDA4G10lWUE5+EyXMzB6UZVsz+2mv/dV+oU+x5ZF8H8
+pP7lNV3WXXJZWFtFRWIm1XTy4jjuvahBqBGkA9ivPOU
+--- qDledqvlmZWeVf60pgYtgcrf/wqRy3wlZjWCYkWKD5I
+z"/«T#/)Æg
+˜‚—¡tññqƒ®ße7`Í¹¶Ó>é6áÌ.ºN%ídlµ´±È¤%4_Jþ]¾Sþï$5þíp"k½[ñÓ}RöíD?‰ZèêÝÃzZßµ>FâÒ€kŽXæé›ñZ—F¨”ø˜ÓÝ>Ì¥ì4;¢WÏ


### PR DESCRIPTION
- Restore opencode (removed in df0d822) as a lean module: OpenRouter-only, ZDR/no-training routing provider-wide, models chosen at runtime, cost-reporting patches re-verified against 1.18.18.
- Add codex via home-manager's `programs.codex`.
- Both reuse the claude-code instruction doc as global AGENTS.md; doc itself swaps the stale model-delegation section for code-comments rules.
- Nexus: `environment.enableAllTerminfo` for ghostty ssh sessions.
- `openrouter.env` secret rekeyed to all four host keys.

All 5 configs eval; patched opencode builds and runs on x86_64-linux.