### PR TITLE
chore: weekly flake update - 2026-08-20T23:04:35Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,16 +26,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1785710351,
-        "narHash": "sha256-DTL5T9+HlblsnXCEdxRpEo/2NBHD3t48BS7r+PTf090=",
+        "lastModified": 1786348930,
+        "narHash": "sha256-bCQJkbgsAMDp5HQystZLCq11UHiyEuoWbxKulAPYrh8=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "7b0f22a4ab77567edef114c8dfc423fb96e2fbaa",
+        "rev": "3ecc9eff23feebf1bc73846d74e14a122c93b66f",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.15",
+        "ref": "6.0.16",
         "repo": "brew",
         "type": "github"
       }
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786656209,
-        "narHash": "sha256-ybGtuwGKTUCefKYsplzvw4xcCqznto0c7BaiQhgILtA=",
+        "lastModified": 1787176219,
+        "narHash": "sha256-djoRr6jBpe35q/0JwAvXpFXg1Ktf+X54NU2RLR7wnHw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c554d3441f725537854e877519f01cbd60680174",
+        "rev": "c53d643b3737e2fcd04e6cb3b3580ef50b2087a0",
         "type": "github"
       },
       "original": {
@@ -287,11 +287,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1786670159,
-        "narHash": "sha256-GcDOPqSv3WmM70jyT8avu13oyS+w3Sy0771gcaIWM2s=",
+        "lastModified": 1787272282,
+        "narHash": "sha256-rQatOvEiITne72kh+2Msni6lw68eboi538U8bZXZ2dE=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "285d3f812d3fb2018083135a739b188c98a10f85",
+        "rev": "b08c45a1ffd504739da8199dcf803bc2b9b53160",
         "type": "github"
       },
       "original": {
@@ -303,11 +303,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1786668767,
-        "narHash": "sha256-0FBYGP3LURVFB4xMKM6za508e9pPchjv4BV6JHfuBuI=",
+        "lastModified": 1787273084,
+        "narHash": "sha256-kxGksbzS9UHflP9Xaccrtd0MaCFkwsBMrgNN13fAFlw=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "a660928c61c7a43678ea7a7e2bf478d1428a84a2",
+        "rev": "799d30710c11f1b3214f9486c9d54fe69b722415",
         "type": "github"
       },
       "original": {
@@ -361,11 +361,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785389976,
-        "narHash": "sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU=",
+        "lastModified": 1786845137,
+        "narHash": "sha256-oQFip+v0luP8NIxJzmiW4Wu8bILsbFWom5l0zonl8hQ=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "15abb8c98f336cd8bd840d71059adebabe60bf04",
+        "rev": "4cff07de74b50e64bdd68cd4e722ab5b6b35ee48",
         "type": "github"
       },
       "original": {
@@ -380,11 +380,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1786580329,
-        "narHash": "sha256-/8cBGYJ+Cj2bSdXv7+B+DFIU+s5u/iKouWUZUvFz32E=",
+        "lastModified": 1786686423,
+        "narHash": "sha256-8q3WdB8o3VUI7rOz1OXfioXIaaWbFTAxRJAkWLlfc0s=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "7be2ffcda4d9632edb7150b263ee081abba5e984",
+        "rev": "ccabf79a6b9845eb72b51ea1d9c7ce3446350df3",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786249295,
-        "narHash": "sha256-Y2mSr+HLKYoOsjiackgilxkHXe8gkJ3z4hFFekjQX3I=",
+        "lastModified": 1786852476,
+        "narHash": "sha256-IM5CYtf86W4w8eUPpKcY/LpdHElmVBtJhaKnoTKxZEA=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "14d55b8069119e3b88da7aa2f6c97f86a2cd3cd6",
+        "rev": "c7962dc97b45129df8d751bedaf37beb5a17706e",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1786670044,
-        "narHash": "sha256-WcRxwA3/k9E8E6VjKJgFXp1K/9OrH6h3Fv+z6fSu8OE=",
+        "lastModified": 1787272787,
+        "narHash": "sha256-C7uIwPnuj7lbKdkuVyxr3Txg9eNfh5VUpqQ8/JGSV0E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c21631155ea2bc6c2885c908f2a6e4a627301da",
+        "rev": "1f6f5c91fc13c152799740a47b461c566aa72f87",
         "type": "github"
       },
       "original": {
@@ -532,11 +532,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786667428,
-        "narHash": "sha256-rtBI5BwVpVP4Tbg6udtYiw4kD9C0COHEc/rzpzylfI4=",
+        "lastModified": 1787273267,
+        "narHash": "sha256-snfXYxE7rAUs547psUfpbQqdKrm4YXDi1o7lDdG68TA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "40ec339ee452baf23b2676e9c1fcdbe456c7f873",
+        "rev": "6e4a5ecda7e156a51b2d2e98a6991886538967c9",
         "type": "github"
       },
       "original": {
@@ -554,11 +554,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786433999,
-        "narHash": "sha256-rbOp2g0UCYt+evTnCGCKBQGqSMfwX4RTXneNbeHqOAk=",
+        "lastModified": 1787161243,
+        "narHash": "sha256-3voBPkuncAi4/6fn3EZG7UvG8TO9xkEt6FXUAzeWVdI=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "a213644cadd5f90bf18b0c409f08f282b30e55e3",
+        "rev": "c5cad7edcdcf683f4ba80c4d0cbf0e0eb7116c08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/5602ed62d638142c1ab31dccd01dfbfb28841225' into the Git cache...
unpacking 'github:nix-community/home-manager/c53d643b3737e2fcd04e6cb3b3580ef50b2087a0' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/b08c45a1ffd504739da8199dcf803bc2b9b53160' into the Git cache...
unpacking 'github:homebrew/homebrew-core/799d30710c11f1b3214f9486c9d54fe69b722415' into the Git cache...
unpacking 'github:hraban/mac-app-util/039f33deef21782d4db97087f426504951239887' into the Git cache...
unpacking 'github:lnl7/nix-darwin/4cff07de74b50e64bdd68cd4e722ab5b6b35ee48' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/ccabf79a6b9845eb72b51ea1d9c7ce3446350df3' into the Git cache...
unpacking 'github:nix-community/nix-index-database/c7962dc97b45129df8d751bedaf37beb5a17706e' into the Git cache...
unpacking 'github:NixOS/nixpkgs/ffb3c9b700e759be2ef13237c9d8f953b32a1e46' into the Git cache...
unpacking 'github:NixOS/nixpkgs/1f6f5c91fc13c152799740a47b461c566aa72f87' into the Git cache...
unpacking 'github:nix-community/NUR/6e4a5ecda7e156a51b2d2e98a6991886538967c9' into the Git cache...
unpacking 'github:NotAShelf/nvf/c5cad7edcdcf683f4ba80c4d0cbf0e0eb7116c08' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/c554d3441f725537854e877519f01cbd60680174?narHash=sha256-ybGtuwGKTUCefKYsplzvw4xcCqznto0c7BaiQhgILtA%3D' (2026-08-13)
  → 'github:nix-community/home-manager/c53d643b3737e2fcd04e6cb3b3580ef50b2087a0?narHash=sha256-djoRr6jBpe35q/0JwAvXpFXg1Ktf%2BX54NU2RLR7wnHw%3D' (2026-08-19)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/285d3f812d3fb2018083135a739b188c98a10f85?narHash=sha256-GcDOPqSv3WmM70jyT8avu13oyS%2Bw3Sy0771gcaIWM2s%3D' (2026-08-14)
  → 'github:homebrew/homebrew-cask/b08c45a1ffd504739da8199dcf803bc2b9b53160?narHash=sha256-rQatOvEiITne72kh%2B2Msni6lw68eboi538U8bZXZ2dE%3D' (2026-08-21)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/a660928c61c7a43678ea7a7e2bf478d1428a84a2?narHash=sha256-0FBYGP3LURVFB4xMKM6za508e9pPchjv4BV6JHfuBuI%3D' (2026-08-14)
  → 'github:homebrew/homebrew-core/799d30710c11f1b3214f9486c9d54fe69b722415?narHash=sha256-kxGksbzS9UHflP9Xaccrtd0MaCFkwsBMrgNN13fAFlw%3D' (2026-08-21)
• Updated input 'nix-darwin':
    'github:lnl7/nix-darwin/15abb8c98f336cd8bd840d71059adebabe60bf04?narHash=sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU%3D' (2026-07-30)
  → 'github:lnl7/nix-darwin/4cff07de74b50e64bdd68cd4e722ab5b6b35ee48?narHash=sha256-oQFip%2Bv0luP8NIxJzmiW4Wu8bILsbFWom5l0zonl8hQ%3D' (2026-08-16)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/7be2ffcda4d9632edb7150b263ee081abba5e984?narHash=sha256-/8cBGYJ%2BCj2bSdXv7%2BB%2BDFIU%2Bs5u/iKouWUZUvFz32E%3D' (2026-08-13)
  → 'github:zhaofengli/nix-homebrew/ccabf79a6b9845eb72b51ea1d9c7ce3446350df3?narHash=sha256-8q3WdB8o3VUI7rOz1OXfioXIaaWbFTAxRJAkWLlfc0s%3D' (2026-08-14)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/7b0f22a4ab77567edef114c8dfc423fb96e2fbaa?narHash=sha256-DTL5T9%2BHlblsnXCEdxRpEo/2NBHD3t48BS7r%2BPTf090%3D' (2026-08-02)
  → 'github:Homebrew/brew/3ecc9eff23feebf1bc73846d74e14a122c93b66f?narHash=sha256-bCQJkbgsAMDp5HQystZLCq11UHiyEuoWbxKulAPYrh8%3D' (2026-08-10)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/14d55b8069119e3b88da7aa2f6c97f86a2cd3cd6?narHash=sha256-Y2mSr%2BHLKYoOsjiackgilxkHXe8gkJ3z4hFFekjQX3I%3D' (2026-08-09)
  → 'github:nix-community/nix-index-database/c7962dc97b45129df8d751bedaf37beb5a17706e?narHash=sha256-IM5CYtf86W4w8eUPpKcY/LpdHElmVBtJhaKnoTKxZEA%3D' (2026-08-16)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/1c21631155ea2bc6c2885c908f2a6e4a627301da?narHash=sha256-WcRxwA3/k9E8E6VjKJgFXp1K/9OrH6h3Fv%2Bz6fSu8OE%3D' (2026-08-14)
  → 'github:NixOS/nixpkgs/1f6f5c91fc13c152799740a47b461c566aa72f87?narHash=sha256-C7uIwPnuj7lbKdkuVyxr3Txg9eNfh5VUpqQ8/JGSV0E%3D' (2026-08-21)
• Updated input 'nur':
    'github:nix-community/NUR/40ec339ee452baf23b2676e9c1fcdbe456c7f873?narHash=sha256-rtBI5BwVpVP4Tbg6udtYiw4kD9C0COHEc/rzpzylfI4%3D' (2026-08-14)
  → 'github:nix-community/NUR/6e4a5ecda7e156a51b2d2e98a6991886538967c9?narHash=sha256-snfXYxE7rAUs547psUfpbQqdKrm4YXDi1o7lDdG68TA%3D' (2026-08-21)
• Updated input 'nvf':
    'github:NotAShelf/nvf/a213644cadd5f90bf18b0c409f08f282b30e55e3?narHash=sha256-rbOp2g0UCYt%2BevTnCGCKBQGqSMfwX4RTXneNbeHqOAk%3D' (2026-08-11)
  → 'github:NotAShelf/nvf/c5cad7edcdcf683f4ba80c4d0cbf0e0eb7116c08?narHash=sha256-3voBPkuncAi4/6fn3EZG7UvG8TO9xkEt6FXUAzeWVdI%3D' (2026-08-19)
```
