### PR TITLE
feat(brightfalls): enable flatpak

### DIFF
--- a/hosts/BrightFalls/services.nix
+++ b/hosts/BrightFalls/services.nix
@@ -73,6 +73,23 @@ in
 
   services.fstrim.enable = true;
 
+  # GNOME already pulls in xdg-desktop-portal-gnome and sets XDG_DATA_DIRS,
+  # so enabling the service is all that is needed here.
+  services.flatpak.enable = true;
+
+  # flatpak ships no remotes out of the box. remote-add fetches the
+  # .flatpakrepo over the network, hence the ordering.
+  systemd.services.flatpak-repo = {
+    wantedBy = [ "multi-user.target" ];
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+    path = [ pkgs.flatpak ];
+    serviceConfig.Type = "oneshot";
+    script = ''
+      flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+    '';
+  };
+
   # https://discourse.nixos.org/t/connected-to-mullvadvpn-but-no-internet-connection/35803/8?u=lion
   services.resolved.enable = true;
   services.mullvad-vpn.enable = true;


### PR DESCRIPTION
Enables Flatpak on BrightFalls, following the [NixOS wiki](https://wiki.nixos.org/wiki/Flatpak).

`services.flatpak.enable = true` plus a oneshot unit registering the flathub remote, since flatpak ships no remotes out of the box.

Two deviations from the wiki snippet: it is ordered after `network-online.target` because `remote-add` fetches the `.flatpakrepo` over the network, and it sets `Type = "oneshot"` so the unit isn't mistaken for a long-running service.

Not needed here: the wiki's `XDG_DATA_DIRS` export is a Sway workaround — GNOME is already on this host and provides `xdg-desktop-portal-gnome` and `-gtk`.

Differs from CauldronLake, which registers flathub `--user` in a hand-run script alongside a fixed app list. This one is a system remote with no app list.

## Testing

BrightFalls evaluates clean. Not built or applied.