### PR TITLE
chore: weekly flake update - 2026-08-27T07:34:07Z

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -111,14 +111,20 @@ jobs:
         run: |
           nix build ".#${{ matrix.system_attr }}.${{ matrix.host }}.${{ matrix.build_attr }}" --out-link ./result --fallback
 
+      # Pinned to v1.4.2: dix HEAD fails to build because libsqlite3-sys
+      # 0.38.0 (pulled in 2026-05-27) uses the unstable cfg_select! macro.
+      - name: Build dix
+        continue-on-error: true
+        id: dix
+        run: nix build github:faukah/dix/v1.4.2 -o dix-result
+
       - name: Compare configurations
+        if: steps.dix.outcome == 'success'
         run: |
 
           echo "## Diff" >> "$GITHUB_STEP_SUMMARY"
           echo '```diff' >> "$GITHUB_STEP_SUMMARY"
-          # Pinned to v1.4.2: dix HEAD fails to build because libsqlite3-sys
-          # 0.38.0 (pulled in 2026-05-27) uses the unstable cfg_select! macro.
-          nix run github:faukah/dix/v1.4.2 -- ./old-result ./result >> "$GITHUB_STEP_SUMMARY" || true
+          ./dix-result/bin/dix ./old-result ./result >> "$GITHUB_STEP_SUMMARY" || true
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       # Cache the PR's candidate toplevel so the post-merge master build in

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -116,7 +116,9 @@ jobs:
 
           echo "## Diff" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          nix store diff-closures ./old-result ./result >> "$GITHUB_STEP_SUMMARY"
+          # diff-closures always emits ANSI color codes, even when piped
+          nix store diff-closures ./old-result ./result \
+            | sed -e 's/\x1b\[[0-9;]*m//g' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       # Cache the PR's candidate toplevel so the post-merge master build in

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -111,20 +111,12 @@ jobs:
         run: |
           nix build ".#${{ matrix.system_attr }}.${{ matrix.host }}.${{ matrix.build_attr }}" --out-link ./result --fallback
 
-      # Pinned to v1.4.2: dix HEAD fails to build because libsqlite3-sys
-      # 0.38.0 (pulled in 2026-05-27) uses the unstable cfg_select! macro.
-      - name: Build dix
-        continue-on-error: true
-        id: dix
-        run: nix build github:faukah/dix/v1.4.2 -o dix-result
-
       - name: Compare configurations
-        if: steps.dix.outcome == 'success'
         run: |
 
           echo "## Diff" >> "$GITHUB_STEP_SUMMARY"
-          echo '```diff' >> "$GITHUB_STEP_SUMMARY"
-          ./dix-result/bin/dix ./old-result ./result >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          nix store diff-closures ./old-result ./result >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       # Cache the PR's candidate toplevel so the post-merge master build in

--- a/flake.lock
+++ b/flake.lock
@@ -26,16 +26,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1786348930,
-        "narHash": "sha256-bCQJkbgsAMDp5HQystZLCq11UHiyEuoWbxKulAPYrh8=",
+        "lastModified": 1786945682,
+        "narHash": "sha256-VBESSoJccikdhxh3vp3SQeG7cZXTOulMvVkoSqNDEhs=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "3ecc9eff23feebf1bc73846d74e14a122c93b66f",
+        "rev": "5b90e281d4e0c8fbd6ca4d8358276fb305b8d0bd",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.16",
+        "ref": "6.0.18",
         "repo": "brew",
         "type": "github"
       }
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787176219,
-        "narHash": "sha256-djoRr6jBpe35q/0JwAvXpFXg1Ktf+X54NU2RLR7wnHw=",
+        "lastModified": 1787797243,
+        "narHash": "sha256-8+Q7NOB7RPajRjA4pbCDLzqH+MTjnG9x6LUPLfL2joA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c53d643b3737e2fcd04e6cb3b3580ef50b2087a0",
+        "rev": "99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11",
         "type": "github"
       },
       "original": {
@@ -287,11 +287,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1787272282,
-        "narHash": "sha256-rQatOvEiITne72kh+2Msni6lw68eboi538U8bZXZ2dE=",
+        "lastModified": 1787905543,
+        "narHash": "sha256-yAedwRW3PCq+u0QKLpOW13JLwJYtYpqCjcwm78eHlxo=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "b08c45a1ffd504739da8199dcf803bc2b9b53160",
+        "rev": "5c0cf5857a74536c15a7c718c21b847ff539fe24",
         "type": "github"
       },
       "original": {
@@ -303,11 +303,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1787273084,
-        "narHash": "sha256-kxGksbzS9UHflP9Xaccrtd0MaCFkwsBMrgNN13fAFlw=",
+        "lastModified": 1787905319,
+        "narHash": "sha256-i0m0whJDWNYmu28RLm1Iemh/yv3h49Mdv1dE0XN4/eE=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "799d30710c11f1b3214f9486c9d54fe69b722415",
+        "rev": "5d176ddf9d3455813320bddc04004f2b2953789e",
         "type": "github"
       },
       "original": {
@@ -380,11 +380,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1786686423,
-        "narHash": "sha256-8q3WdB8o3VUI7rOz1OXfioXIaaWbFTAxRJAkWLlfc0s=",
+        "lastModified": 1787330919,
+        "narHash": "sha256-LslMncqN7uOOH5S88WZtO/EVt2HwD8ltUnfyANk+mC0=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "ccabf79a6b9845eb72b51ea1d9c7ce3446350df3",
+        "rev": "b00218e4aec0e5bf07d61a0bb13f842faa582d7b",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786852476,
-        "narHash": "sha256-IM5CYtf86W4w8eUPpKcY/LpdHElmVBtJhaKnoTKxZEA=",
+        "lastModified": 1787457452,
+        "narHash": "sha256-FJh4esFS3zqNNuKwvN3t6wrJGewqp1AUF9DAEvoKPD8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "c7962dc97b45129df8d751bedaf37beb5a17706e",
+        "rev": "c51d5c2ba69c907a34e90c9b6b80cd2b93811745",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1787272787,
-        "narHash": "sha256-C7uIwPnuj7lbKdkuVyxr3Txg9eNfh5VUpqQ8/JGSV0E=",
+        "lastModified": 1787905602,
+        "narHash": "sha256-ONcljdHEuiQJZ3dD/evInz4tO1nzOkDPPHAtQOcXPo8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1f6f5c91fc13c152799740a47b461c566aa72f87",
+        "rev": "0e7911a191ea0fb9d6e8e771d24736d3618f8b1f",
         "type": "github"
       },
       "original": {
@@ -510,11 +510,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1787135253,
-        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
         "type": "github"
       },
       "original": {
@@ -532,11 +532,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787273267,
-        "narHash": "sha256-snfXYxE7rAUs547psUfpbQqdKrm4YXDi1o7lDdG68TA=",
+        "lastModified": 1787905624,
+        "narHash": "sha256-prj/zTitAlYPTvWIa+29GBwm7J03ZMtwdz9IJmCsDVM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e4a5ecda7e156a51b2d2e98a6991886538967c9",
+        "rev": "c55fec34d486c2f7f6f41620677fd69cb69806df",
         "type": "github"
       },
       "original": {
@@ -554,11 +554,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787161243,
-        "narHash": "sha256-3voBPkuncAi4/6fn3EZG7UvG8TO9xkEt6FXUAzeWVdI=",
+        "lastModified": 1787776375,
+        "narHash": "sha256-gxa6C1+Xfl0ys5h0X/ocusbwT3ABIdX38mrX3MRmPnM=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "c5cad7edcdcf683f4ba80c4d0cbf0e0eb7116c08",
+        "rev": "f019fe83c224eedb145982a9a26b764e7cb2fdd0",
         "type": "github"
       },
       "original": {

--- a/hosts/Nexus/services/caddy.nix
+++ b/hosts/Nexus/services/caddy.nix
@@ -19,7 +19,7 @@ in
     # DNS-01 challenge instead of HTTP-01 — no inbound port 80 needed.
     package = pkgs.caddy.withPlugins {
       plugins = [ "github.com/caddy-dns/route53@v1.6.2" ];
-      hash = "sha256-/9c9b+S98V+eDj6mzb6KfAWWSBCrZoUzA1JDrMxuKQ0=";
+      hash = "sha256-Vzp4Y9mARJrAHZ1C3x6+5zTSGiYY1l3FxIPkqK1RI30=";
     };
 
     # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for the Route53 plugin.

--- a/hosts/Nexus/services/home-assistant.nix
+++ b/hosts/Nexus/services/home-assistant.nix
@@ -93,6 +93,8 @@ in
       "smartthings"
       # Volvo (core integration, OAuth via Application Credentials)
       "volvo"
+      # MCP server (exposes Assist-exposed entities at /api/mcp)
+      "mcp_server"
     ];
     customComponents = with pkgs.home-assistant-custom-components; [
       waste_collection_schedule


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/5602ed62d638142c1ab31dccd01dfbfb28841225' into the Git cache...
unpacking 'github:nix-community/home-manager/99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/5c0cf5857a74536c15a7c718c21b847ff539fe24' into the Git cache...
unpacking 'github:homebrew/homebrew-core/5d176ddf9d3455813320bddc04004f2b2953789e' into the Git cache...
unpacking 'github:hraban/mac-app-util/039f33deef21782d4db97087f426504951239887' into the Git cache...
unpacking 'github:lnl7/nix-darwin/4cff07de74b50e64bdd68cd4e722ab5b6b35ee48' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/b00218e4aec0e5bf07d61a0bb13f842faa582d7b' into the Git cache...
unpacking 'github:nix-community/nix-index-database/c51d5c2ba69c907a34e90c9b6b80cd2b93811745' into the Git cache...
unpacking 'github:NixOS/nixpkgs/9fbb54b33e91ee4ca368e35a78e0613c720600b3' into the Git cache...
unpacking 'github:NixOS/nixpkgs/0e7911a191ea0fb9d6e8e771d24736d3618f8b1f' into the Git cache...
unpacking 'github:nix-community/NUR/c55fec34d486c2f7f6f41620677fd69cb69806df' into the Git cache...
unpacking 'github:NotAShelf/nvf/f019fe83c224eedb145982a9a26b764e7cb2fdd0' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/c53d643b3737e2fcd04e6cb3b3580ef50b2087a0?narHash=sha256-djoRr6jBpe35q/0JwAvXpFXg1Ktf%2BX54NU2RLR7wnHw%3D' (2026-08-19)
  → 'github:nix-community/home-manager/99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11?narHash=sha256-8%2BQ7NOB7RPajRjA4pbCDLzqH%2BMTjnG9x6LUPLfL2joA%3D' (2026-08-27)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/b08c45a1ffd504739da8199dcf803bc2b9b53160?narHash=sha256-rQatOvEiITne72kh%2B2Msni6lw68eboi538U8bZXZ2dE%3D' (2026-08-21)
  → 'github:homebrew/homebrew-cask/5c0cf5857a74536c15a7c718c21b847ff539fe24?narHash=sha256-yAedwRW3PCq%2Bu0QKLpOW13JLwJYtYpqCjcwm78eHlxo%3D' (2026-08-28)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/799d30710c11f1b3214f9486c9d54fe69b722415?narHash=sha256-kxGksbzS9UHflP9Xaccrtd0MaCFkwsBMrgNN13fAFlw%3D' (2026-08-21)
  → 'github:homebrew/homebrew-core/5d176ddf9d3455813320bddc04004f2b2953789e?narHash=sha256-i0m0whJDWNYmu28RLm1Iemh/yv3h49Mdv1dE0XN4/eE%3D' (2026-08-28)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/ccabf79a6b9845eb72b51ea1d9c7ce3446350df3?narHash=sha256-8q3WdB8o3VUI7rOz1OXfioXIaaWbFTAxRJAkWLlfc0s%3D' (2026-08-14)
  → 'github:zhaofengli/nix-homebrew/b00218e4aec0e5bf07d61a0bb13f842faa582d7b?narHash=sha256-LslMncqN7uOOH5S88WZtO/EVt2HwD8ltUnfyANk%2BmC0%3D' (2026-08-21)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/3ecc9eff23feebf1bc73846d74e14a122c93b66f?narHash=sha256-bCQJkbgsAMDp5HQystZLCq11UHiyEuoWbxKulAPYrh8%3D' (2026-08-10)
  → 'github:Homebrew/brew/5b90e281d4e0c8fbd6ca4d8358276fb305b8d0bd?narHash=sha256-VBESSoJccikdhxh3vp3SQeG7cZXTOulMvVkoSqNDEhs%3D' (2026-08-17)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/c7962dc97b45129df8d751bedaf37beb5a17706e?narHash=sha256-IM5CYtf86W4w8eUPpKcY/LpdHElmVBtJhaKnoTKxZEA%3D' (2026-08-16)
  → 'github:nix-community/nix-index-database/c51d5c2ba69c907a34e90c9b6b80cd2b93811745?narHash=sha256-FJh4esFS3zqNNuKwvN3t6wrJGewqp1AUF9DAEvoKPD8%3D' (2026-08-23)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/ffb3c9b700e759be2ef13237c9d8f953b32a1e46?narHash=sha256-RD2kNWCG%2BBjo6h%2BJVjWVNntZs2GtRoeY2xHjts/FNkA%3D' (2026-08-19)
  → 'github:NixOS/nixpkgs/9fbb54b33e91ee4ca368e35a78e0613c720600b3?narHash=sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA%3D' (2026-08-26)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/1f6f5c91fc13c152799740a47b461c566aa72f87?narHash=sha256-C7uIwPnuj7lbKdkuVyxr3Txg9eNfh5VUpqQ8/JGSV0E%3D' (2026-08-21)
  → 'github:NixOS/nixpkgs/0e7911a191ea0fb9d6e8e771d24736d3618f8b1f?narHash=sha256-ONcljdHEuiQJZ3dD/evInz4tO1nzOkDPPHAtQOcXPo8%3D' (2026-08-28)
• Updated input 'nur':
    'github:nix-community/NUR/6e4a5ecda7e156a51b2d2e98a6991886538967c9?narHash=sha256-snfXYxE7rAUs547psUfpbQqdKrm4YXDi1o7lDdG68TA%3D' (2026-08-21)
  → 'github:nix-community/NUR/c55fec34d486c2f7f6f41620677fd69cb69806df?narHash=sha256-prj/zTitAlYPTvWIa%2B29GBwm7J03ZMtwdz9IJmCsDVM%3D' (2026-08-28)
• Updated input 'nvf':
    'github:NotAShelf/nvf/c5cad7edcdcf683f4ba80c4d0cbf0e0eb7116c08?narHash=sha256-3voBPkuncAi4/6fn3EZG7UvG8TO9xkEt6FXUAzeWVdI%3D' (2026-08-19)
  → 'github:NotAShelf/nvf/f019fe83c224eedb145982a9a26b764e7cb2fdd0?narHash=sha256-gxa6C1%2BXfl0ys5h0X/ocusbwT3ABIdX38mrX3MRmPnM%3D' (2026-08-26)
```
