### PR TITLE
feat(nexus): restore VictoriaMetrics + Grafana, shorten recorder retention

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -237,6 +237,19 @@
             age.secrets."nexus/restic-password".file = ./secrets/nexus/restic-password.age;
             age.secrets."nexus/route53-env".file = ./secrets/nexus/route53-env.age;
 
+            age.secrets."nexus/grafana-admin-password" = {
+              file = ./secrets/nexus/grafana-admin-password.age;
+              owner = "grafana";
+              group = "grafana";
+              mode = "770";
+            };
+            age.secrets."nexus/grafana-secret-key" = {
+              file = ./secrets/nexus/grafana-secret-key.age;
+              owner = "grafana";
+              group = "grafana";
+              mode = "770";
+            };
+
             age.secrets."nexus/zigbee2mqtt.env" = {
               file = ./secrets/nexus/zigbee2mqtt.env.age;
               owner = "zigbee2mqtt";

--- a/hosts/Nexus/services/backup.nix
+++ b/hosts/Nexus/services/backup.nix
@@ -14,6 +14,7 @@ let
     "zigbee2mqtt"
     "mosquitto"
     "home-assistant"
+    "victoriametrics"
   ];
   affectedServices = [
     "jellyfin"
@@ -144,6 +145,8 @@ let
     ''${RSYNC_CMD} ${config.services.mosquitto.dataDir} ${backupDestination}/
     # home-assistant
     ''${RSYNC_CMD} ${config.services.home-assistant.configDir} ${backupDestination}/
+    # victoriametrics (long-term metrics archive; DynamicUser StateDirectory)
+    ''${RSYNC_CMD} /var/lib/victoriametrics ${backupDestination}/
 
     # Special case: PostgreSQL
     # Does not need to be stopped, just backed up

--- a/hosts/Nexus/services/caddy.nix
+++ b/hosts/Nexus/services/caddy.nix
@@ -140,6 +140,25 @@ in
         '';
       };
 
+      "grafana.matteopacini.me" = {
+        logFormat = ''
+          output file /var/log/caddy/access.log
+          format json
+        '';
+        extraConfig = ''
+          ${securityHeaders}
+
+          # LAN-only: no public A record exists, and this gates by source IP
+          # (LAN + tailnet) so the shared, WAN-forwarded :443 can't reach it.
+          @external not remote_ip 192.168.10.0/24 192.168.20.0/24 100.64.0.0/10 127.0.0.1/8
+          respond @external 403
+
+          # Reverse proxy to Grafana (loopback; see services.grafana settings).
+          # WebSocket support (live panels) is automatic.
+          reverse_proxy 127.0.0.1:${toString config.services.grafana.settings.server.http_port}
+        '';
+      };
+
       "photos.matteopacini.me" = {
         logFormat = ''
           output file /var/log/caddy/access.log

--- a/hosts/Nexus/services/default.nix
+++ b/hosts/Nexus/services/default.nix
@@ -29,6 +29,8 @@
     ./attic.nix
     ./immich.nix
     ./tailscale-r53.nix
+    ./victoriametrics.nix
+    ./grafana.nix
   ];
 
   systemd.tmpfiles.rules = [

--- a/hosts/Nexus/services/default.nix
+++ b/hosts/Nexus/services/default.nix
@@ -17,7 +17,7 @@
     ./tailscale.nix
     ./zigbee2mqtt.nix
     ./mosquitto.nix
-    ./home-assistant.nix
+    ./home-assistant
     ./ups.nix
     ./postgresql.nix
     ./geoipupdate.nix

--- a/hosts/Nexus/services/fail2ban.nix
+++ b/hosts/Nexus/services/fail2ban.nix
@@ -11,6 +11,13 @@
       # LAN networks
       "192.168.10.0/24" # HOME VLAN
       "192.168.20.0/24" # GUEST VLAN
+      # Tailnet. Devices here are already authenticated by Tailscale before
+      # they reach Caddy, so banning them buys nothing — and the caddy-http-auth
+      # failregex matches 403 as well as 401, which the LAN-only vhosts
+      # (grafana, photos) return by design to anyone outside the allowlist.
+      # With bantime-increment overalljails, a few mistyped passwords would
+      # otherwise lock this machine out of every service at once.
+      "100.64.0.0/10"
     ];
     bantime = "1h";
     bantime-increment = {

--- a/hosts/Nexus/services/fail2ban.nix
+++ b/hosts/Nexus/services/fail2ban.nix
@@ -134,12 +134,16 @@
   # Matches 404 (Not Found) and 400 (Bad Request) responses
   # Ignores services with dedicated auth jails, and the binary cache:
   # 404s on narinfo lookups are normal operation (cache misses), not
-  # bot probing
+  # bot probing.
+  # grafana and photos are single-page apps: they probe for optional plugin
+  # assets and API endpoints on every load, so a handful of 404s is normal
+  # operation. With maxretry = 2 that was enough to ban a legitimate user
+  # mid-session.
   environment.etc."fail2ban/filter.d/caddy-botsearch.conf".text = ''
     [Definition]
     failregex = "client_ip":"<HOST>"(?:.*)"status":(?:404|400)
     datepattern = "ts":{Epoch}
-    ignoreregex = "host":"(?:home|jellyfin|nextcloud|n8n|cache)\.matteopacini\.me"
+    ignoreregex = "host":"(?:home|jellyfin|nextcloud|n8n|cache|grafana|photos)\.matteopacini\.me"
   '';
 
   # Custom filter for n8n authentication failures (JSON format)

--- a/hosts/Nexus/services/grafana.nix
+++ b/hosts/Nexus/services/grafana.nix
@@ -1,0 +1,52 @@
+{ pkgs, config, ... }:
+{
+  services.grafana = {
+    enable = true;
+
+    declarativePlugins = with pkgs.grafanaPlugins; [
+      victoriametrics-metrics-datasource
+    ];
+
+    settings = {
+      users.allow_sign_up = false;
+
+      server = {
+        # Loopback only: Caddy terminates TLS and gates by source IP, so Grafana
+        # must not be reachable directly on the LAN.
+        http_addr = "127.0.0.1";
+        http_port = 3000;
+        # Must match the Caddy vhost or OAuth redirects, share links and the
+        # rendered image URLs all point at the wrong host.
+        root_url = "https://grafana.matteopacini.me";
+      };
+
+      database = {
+        type = "postgres";
+        host = "/run/postgresql";
+        name = "grafana";
+        user = "grafana";
+      };
+
+      security = {
+        admin_user = "matteo";
+        admin_password = "$__file{${config.age.secrets."nexus/grafana-admin-password".path}}";
+        admin_email = "m+grafana@matteopacini.me";
+        allow_embedding = true;
+        secret_key = "$__file{${config.age.secrets."nexus/grafana-secret-key".path}}";
+      };
+    };
+
+    provision.datasources.settings = {
+      apiVersion = 1;
+      datasources = [
+        {
+          name = "VictoriaMetrics";
+          type = "victoriametrics-metrics-datasource";
+          access = "proxy";
+          url = "http://127.0.0.1:8428";
+          isDefault = true;
+        }
+      ];
+    };
+  };
+}

--- a/hosts/Nexus/services/home-assistant.nix
+++ b/hosts/Nexus/services/home-assistant.nix
@@ -82,6 +82,8 @@ in
       "shell_command"
       # UPS
       "apcupsd"
+      # Long-term metrics export to VictoriaMetrics (Influx v1 line protocol)
+      "influxdb"
       # Voice
       "whisper"
       "piper"
@@ -210,6 +212,92 @@ in
           };
         }
       ];
+
+      # Parallel export to VictoriaMetrics, which speaks the InfluxDB v1 line
+      # protocol on its main port. This is the long-term archive; the recorder
+      # below keeps only a short window (see purge_keep_days).
+      #
+      # Filters mirror recorder.exclude — no point paying to store the entities
+      # Postgres already refuses.
+      influxdb = {
+        api_version = 1;
+        host = "127.0.0.1";
+        port = 8428;
+        max_retries = 3;
+        measurement_attr = "entity_id";
+        tags_attributes = [
+          "friendly_name"
+          "unit_of_measurement"
+          "state_class"
+          "device_class"
+        ];
+        # Attributes that are constant, huge, or non-numeric. hvac_action is
+        # deliberately NOT ignored: it is what binary_sensor.needs_heating keys
+        # off, so without it no heating analysis is possible after the fact.
+        ignore_attributes = [
+          "icon"
+          "source"
+          "options"
+          "editable"
+          "min"
+          "max"
+          "step"
+          "mode"
+          "marker_type"
+          "preset_modes"
+          "supported_features"
+          "supported_color_modes"
+          "effect_list"
+          "attribution"
+          "assumed_state"
+          "state_open"
+          "state_closed"
+          "writable"
+          "stateExtra"
+          "event"
+          "ip_address"
+          "device_file"
+          "unitOfMeasure"
+          "color_mode"
+          "hs_color"
+          "rgb_color"
+          "xy_color"
+          "value"
+          "writeable"
+          "dataCorrect"
+          "dayname"
+        ];
+        include = {
+          domains = [
+            "sensor"
+            "binary_sensor"
+            "light"
+            "switch"
+            "cover"
+            "climate"
+            "input_boolean"
+            "input_select"
+            "number"
+            "lock"
+            "weather"
+          ];
+        };
+        exclude = {
+          entity_globs = [
+            "sensor.clock*"
+            "sensor.date*"
+            "sensor.glances*"
+            "sensor.time*"
+            "sensor.uptime*"
+            "sensor.dwd_weather_warnings_*"
+            "weather.weatherstation"
+            "binary_sensor.*_smartphone_*"
+            "sensor.*_smartphone_*"
+            "sensor.adguard_home_*"
+            "binary_sensor.*_internet_access"
+          ];
+        };
+      };
 
       homeassistant = {
         name = "Frenches Farm Drive 49 HASS";
@@ -381,7 +469,12 @@ in
 
       recorder = {
         db_url = "postgresql://@/hass";
-        purge_keep_days = 365;
+        # Raw states cost ~60 MB/day in Postgres; a year of them is ~22 GB and
+        # nothing in the UI reaches past a few weeks. Long-term statistics live
+        # in separate tables and are NEVER purged, so year-scale trends survive
+        # regardless of this value. Full-resolution history is kept in
+        # VictoriaMetrics instead (see the influxdb block above).
+        purge_keep_days = 30;
         auto_purge = true;
         auto_repack = true;
         exclude = {

--- a/hosts/Nexus/services/home-assistant/blueprints/automation/door_warning_blueprint.yaml
+++ b/hosts/Nexus/services/home-assistant/blueprints/automation/door_warning_blueprint.yaml
@@ -1,0 +1,91 @@
+blueprint:
+  name: Door Left Open – Repeating Notification (Matteo & Debora)
+  description: >
+    Sends repeating notifications to Matteo's and Debora's phones while
+    the selected door sensor is open. Message uses the sensor's friendly name.
+  domain: automation
+
+  input:
+    door_sensor:
+      name: Door sensor
+      description: Binary sensor for the door contact.
+      selector:
+        entity:
+          domain: binary_sensor
+          device_class:
+            - door
+            - opening
+
+    open_delay:
+      name: Time the door must stay open before notifying
+      description: Duration the door must be open before notifications start.
+      default:
+        minutes: 2
+      selector:
+        duration: {}
+
+    repeat_delay:
+      name: Time between repeats
+      description: How long to wait before sending the reminder again.
+      default: 30
+      selector:
+        number:
+          min: 5
+          max: 3600
+          unit_of_measurement: seconds
+          mode: box
+
+    max_notifications:
+      name: Maximum notifications
+      description: >-
+        Stop after this many reminders for a single opening. 0 repeats for as
+        long as the door stays open.
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 100
+          mode: box
+
+mode: single
+
+trigger:
+  - platform: state
+    entity_id: !input door_sensor
+    to: "on"
+    for: !input open_delay
+
+variables:
+  door_sensor: !input door_sensor
+  door_name: "{{ state_attr(door_sensor, 'friendly_name') or door_sensor }}"
+  max_notifications: !input max_notifications
+
+condition: []
+
+action:
+  - repeat:
+      sequence:
+        # Matteo's Pixel 9 Pro Fold
+        - service: notify.mobile_app_pixel_9_pro_fold
+          data:
+            title: "Warning"
+            message: "{{ door_name }} is open"
+
+        # Debora's iPhone
+        - service: notify.mobile_app_iphone_15_di_debora
+          data:
+            title: "Warning"
+            message: "{{ door_name }} is open"
+
+        - delay:
+            seconds: !input repeat_delay
+
+      # Must exit on anything that is not "on", not just on "off". These sensors
+      # come from SmartThings, which goes unavailable from time to time; testing
+      # for "off" alone never matches "unavailable", so a door open when the
+      # integration dropped would notify every repeat_delay for ever.
+      until:
+        - condition: template
+          value_template: >-
+            {{ not is_state(door_sensor, 'on')
+               or (max_notifications > 0 and repeat.index >= max_notifications) }}

--- a/hosts/Nexus/services/home-assistant/blueprints/automation/socket-auto-recover.yaml
+++ b/hosts/Nexus/services/home-assistant/blueprints/automation/socket-auto-recover.yaml
@@ -1,0 +1,209 @@
+blueprint:
+  name: Socket auto-recover
+  description: >-
+    Turns a smart socket back on when it switches itself off unattended.
+
+    Written for the Tuya TS011F plugs, which occasionally drop their relay on
+    their own, but works for any switch.
+
+    Only add sockets that are meant to stay energised. Do NOT add a socket that
+    something else legitimately switches — in particular the two driven by
+    generic_hygrostat (garage dehumidifier, first floor corridor). The
+    "unattended only" check below cannot tell a hygrostat apart from a firmware
+    glitch, because neither carries a user context, so this automation would
+    fight the hygrostat every cycle.
+
+    This treats a symptom on purpose. The plug's own power_outage_memory setting
+    would be the better fix, but on these units it does not survive the power
+    cut it is meant to protect against, so recovery has to happen from outside
+    the device.
+  domain: automation
+  input:
+    sockets:
+      name: Sockets to watch
+      description: Sockets that should always stay on.
+      selector:
+        entity:
+          filter:
+            domain: switch
+          multiple: true
+
+    unattended_only:
+      name: Only recover unattended switch-offs
+      description: >-
+        Ignore switch-offs that carry a user context (someone used the UI or a
+        physical control) or a parent context (another automation did it). Leave
+        this on unless you want the socket forced on no matter who turned it off.
+      default: true
+      selector:
+        boolean:
+
+    min_on_seconds:
+      name: Minimum on-time before recovering
+      description: >-
+        If the socket was on for less than this before dropping, treat it as
+        flapping and stop rather than fighting it. A plug that flaps needs
+        replacing, not retrying.
+      default: 60
+      selector:
+        number:
+          min: 0
+          max: 3600
+          unit_of_measurement: seconds
+          mode: box
+
+    recover_after_unavailable:
+      name: Recover a socket that comes back from unavailable already off
+      description: >-
+        A mains cut looks like on -> unavailable -> off, because these plugs lose
+        their power_outage_memory setting across the outage. But a Zigbee mesh or
+        zigbee2mqtt hiccup looks identical from Home Assistant's side, and when
+        the socket was already off before the dropout it simply re-reports off.
+        The trigger cannot tell those apart, so this is off by default.
+
+        Turn it on only for sockets that must never be off — a router, an ONT, a
+        server. For those, off is always wrong, so recovering is right whatever
+        caused it. Leave it off for sockets that are legitimately switched off
+        (a dishwasher, desk sockets), or every mesh hiccup turns them back on.
+      default: false
+      selector:
+        boolean:
+
+    startup_grace:
+      name: Ignore switch-offs just after Home Assistant starts
+      description: >-
+        Entities settle into their real states for a while after a restart.
+        Recovery is skipped until Home Assistant has been up this long.
+      default: 300
+      selector:
+        number:
+          min: 0
+          max: 1800
+          unit_of_measurement: seconds
+          mode: box
+
+    retries:
+      name: Recovery attempts
+      default: 3
+      selector:
+        number:
+          min: 1
+          max: 10
+          mode: slider
+
+    retry_delay:
+      name: Delay between attempts
+      default: 10
+      selector:
+        number:
+          min: 1
+          max: 120
+          unit_of_measurement: seconds
+          mode: box
+
+    recovered_action:
+      name: When recovered
+      description: >-
+        Runs once the socket is back on. Available variables are socket and
+        socket_name.
+      default: []
+      selector:
+        action:
+
+    failed_action:
+      name: When recovery failed
+      description: Runs when the socket is still off after every attempt.
+      default: []
+      selector:
+        action:
+
+    flapping_action:
+      name: When ignored as flapping
+      description: Runs instead of recovery when the socket dropped too soon after coming on.
+      default: []
+      selector:
+        action:
+
+# Per-socket runs must not block each other: one flapping socket should never
+# stop another from being recovered.
+# max must exceed the number of sockets watched: a mesh-wide event drops them
+# all at once, and max_exceeded silent means the surplus is discarded without a
+# log line. 25 covers every socket in the house with room to spare.
+mode: parallel
+max: 25
+max_exceeded: silent
+
+triggers:
+  - trigger: state
+    entity_id: !input sockets
+    to: "off"
+
+variables:
+  unattended_only: !input unattended_only
+  recover_after_unavailable: !input recover_after_unavailable
+  min_on_seconds: !input min_on_seconds
+  startup_grace: !input startup_grace
+  retries: !input retries
+  socket: "{{ trigger.entity_id }}"
+  socket_name: "{{ state_attr(trigger.entity_id, 'friendly_name') or trigger.entity_id }}"
+
+conditions:
+  # unknown -> off is always a restart artefact: Home Assistant re-reads the
+  # retained state and republishes it, which is not a measurement of anything.
+  # unavailable -> off is gated behind its own option, because a genuine outage
+  # and a mesh hiccup are indistinguishable here. See recover_after_unavailable.
+  - condition: template
+    value_template: >-
+      {{ trigger.from_state is not none
+         and trigger.from_state.state != 'unknown'
+         and (trigger.from_state.state != 'unavailable'
+              or recover_after_unavailable) }}
+
+  # After a restart, entities take a while to settle into real states.
+  - condition: template
+    value_template: >-
+      {{ states('sensor.uptime') in ['unknown', 'unavailable']
+         or (now() - (states('sensor.uptime') | as_datetime)).total_seconds()
+            > startup_grace }}
+
+  # user_id set means a person acted; parent_id set means another automation
+  # did. Neither set means the device reported the change by itself, which is
+  # the only case worth recovering.
+  - condition: template
+    value_template: >-
+      {{ not unattended_only
+         or (trigger.to_state.context.user_id is none
+             and trigger.to_state.context.parent_id is none) }}
+
+actions:
+  # Only meaningful when the socket was actually on beforehand. Coming back from
+  # unavailable says nothing about how long it ran.
+  - if:
+      - condition: template
+        value_template: >-
+          {{ trigger.from_state.state == 'on'
+             and (trigger.to_state.last_changed
+                  - trigger.from_state.last_changed).total_seconds() < min_on_seconds }}
+    then:
+      - sequence: !input flapping_action
+      - stop: Socket dropped too soon after coming on; treating as flapping.
+
+  - repeat:
+      sequence:
+        - action: switch.turn_on
+          target:
+            entity_id: "{{ socket }}"
+        - delay:
+            seconds: !input retry_delay
+      # Bounded on purpose. An unbounded retry loop keeps commanding a socket
+      # that is unplugged or has tripped for a reason.
+      until:
+        - condition: template
+          value_template: >-
+            {{ is_state(socket, 'on') or repeat.index >= retries }}
+
+  - if:
+      - condition: template
+        value_template: "{{ is_state(socket, 'on') }}"
+    then: !input recovered_action
+    else: !input failed_action

--- a/hosts/Nexus/services/home-assistant/blueprints/automation/sonoff_trvzb_external_temp_sync.yaml
+++ b/hosts/Nexus/services/home-assistant/blueprints/automation/sonoff_trvzb_external_temp_sync.yaml
@@ -1,0 +1,100 @@
+blueprint:
+  name: Sonoff TRVZB External Temperature Sensor Sync
+  description: >
+    Forwards a temperature sensor's value to a Sonoff TRZVB via Zigbee2MQTT.
+    On each sensor update, publishes:
+      {"external_temperature_input": <number>}
+    to zigbee2mqtt/<TRV friendly name>/set (derived from the selected device).
+  domain: automation
+  input:
+    temp_sensor:
+      name: Temperature sensor
+      description: The room temperature sensor to forward to the TRV.
+      selector:
+        entity:
+          domain: sensor
+          device_class: temperature
+
+    trv_device:
+      name: TRV device (from Zigbee2MQTT)
+      description: Pick the TRV device; its device name (Z2M friendly name) builds the topic.
+      selector:
+        device:
+          integration: mqtt
+
+    base_topic:
+      name: Zigbee2MQTT base topic
+      description: Root topic used by Zigbee2MQTT.
+      default: zigbee2mqtt
+      selector:
+        text:
+
+    qos:
+      name: MQTT QoS
+      default: 1
+      selector:
+        number:
+          min: 0
+          max: 2
+          step: 1
+          mode: slider
+
+    retain:
+      name: Retain message
+      default: false
+      selector:
+        boolean:
+
+mode: single
+
+# Make inputs available to templates
+variables:
+  _temp_sensor: !input temp_sensor
+  _trv_device: !input trv_device
+  _base_topic: !input base_topic
+
+  # Use the device's original name (Zigbee2MQTT friendly name)
+  _friendly_name: >-
+    {{ device_attr(_trv_device, 'name') | default('', true) }}
+
+  # Final MQTT topic: base/friendly_name/set
+  _mqtt_topic: >-
+    {{ _base_topic ~ '/' ~ _friendly_name ~ '/set' }}
+
+trigger:
+  - platform: state
+    entity_id: !input temp_sensor
+    to:
+    not_from:
+      - "unknown"
+      - "unavailable"
+
+# Only publish when we have a number and a non-empty friendly name
+condition:
+  - condition: template
+    value_template: >-
+      {{ states(_temp_sensor) | float(default=None) is not none }}
+  - condition: template
+    value_template: >-
+      {{ _friendly_name | length > 0 }}
+
+action:
+  # Set temperature source to external (if not already set)
+  - service: mqtt.publish
+    data:
+      topic: "{{ _mqtt_topic }}"
+      qos: !input qos
+      retain: !input retain
+      payload: >-
+        {{ {'temperature_sensor_select': 'external'} | tojson }}
+
+  # Publish the external temperature value
+  - service: mqtt.publish
+    data:
+      topic: "{{ _mqtt_topic }}"
+      qos: !input qos
+      retain: !input retain
+      payload: >-
+        {{ {'external_temperature_input':
+              (states(_temp_sensor) | float(0))}
+           | tojson }}

--- a/hosts/Nexus/services/home-assistant/default.nix
+++ b/hosts/Nexus/services/home-assistant/default.nix
@@ -159,6 +159,7 @@ in
       mushroom
       mini-graph-card
       button-card
+      clock-weather-card
       # In nixpkgs master but not yet in our pin; drop this inline copy
       # once the pin advances past NixOS/nixpkgs#525127.
       (pkgs.buildNpmPackage rec {

--- a/hosts/Nexus/services/home-assistant/default.nix
+++ b/hosts/Nexus/services/home-assistant/default.nix
@@ -52,6 +52,20 @@ in
 
   services.home-assistant = {
     enable = true;
+
+    # Symlinked into ${configDir}/blueprints/automation. Blueprints only supply
+    # the template; each automation built from one is still created in the UI
+    # and lives in .storage.
+    # NOTE: these land flat in blueprints/automation/, whereas the copies HA
+    # already has sit under blueprints/automation/matteo-pacini/. Automations
+    # built from the old path keep working until they are repointed; nothing
+    # here deletes those files (the module only reaps store symlinks at depth 2).
+    blueprints.automation = [
+      ./blueprints/automation/socket-auto-recover.yaml
+      ./blueprints/automation/door_warning_blueprint.yaml
+      ./blueprints/automation/sonoff_trvzb_external_temp_sync.yaml
+    ];
+
     extraComponents = [
       # Components required to complete the onboarding
       "analytics"

--- a/hosts/Nexus/services/home-assistant/default.nix
+++ b/hosts/Nexus/services/home-assistant/default.nix
@@ -114,7 +114,12 @@ in
     ];
     customComponents = with pkgs.home-assistant-custom-components; [
       waste_collection_schedule
-      smartthinq-sensors
+      # Patched so a failed setup raises ConfigEntryNotReady instead of
+      # reporting success. See the patch header for why upstream stopped doing
+      # that and why the reason does not apply here.
+      (smartthinq-sensors.overrideAttrs (old: {
+        patches = (old.patches or [ ]) ++ [ ./patches/smartthinq-sensors-retry-setup.patch ];
+      }))
       octopus_energy
       localtuya
       (pkgs.buildHomeAssistantComponent rec {

--- a/hosts/Nexus/services/home-assistant/default.nix
+++ b/hosts/Nexus/services/home-assistant/default.nix
@@ -163,6 +163,31 @@ in
       mini-graph-card
       button-card
       clock-weather-card
+      # Not in nixpkgs at all. Ships two chunks: the card lazily imports
+      # ./editor.js, so both must land in the merged lovelace module dir.
+      # No other module here ships an editor.js, so the buildEnv merge is safe.
+      (pkgs.buildNpmPackage rec {
+        pname = "calendar-card-pro";
+        version = "4.0.0";
+
+        src = pkgs.fetchFromGitHub {
+          owner = "alexpfau";
+          repo = "calendar-card-pro";
+          tag = "v${version}";
+          hash = "sha256-ZwCJZHRoyie/WkwsNATD5iDlDqJOIPg35C/gwCOap0I=";
+        };
+
+        npmDepsHash = "sha256-+HILd9NxNmMoW6VkDdUW4CGQ4xAUjQ0+V5qMHyafmow=";
+
+        installPhase = ''
+          runHook preInstall
+
+          mkdir $out
+          cp dist/calendar-card-pro.js dist/editor.js $out/
+
+          runHook postInstall
+        '';
+      })
       # In nixpkgs master but not yet in our pin; drop this inline copy
       # once the pin advances past NixOS/nixpkgs#525127.
       (pkgs.buildNpmPackage rec {

--- a/hosts/Nexus/services/home-assistant/default.nix
+++ b/hosts/Nexus/services/home-assistant/default.nix
@@ -111,6 +111,9 @@ in
       "volvo"
       # MCP server (exposes Assist-exposed entities at /api/mcp)
       "mcp_server"
+      # Subscribes to a remote .ics feed. Configured through the UI, so the
+      # feed URL and its API key live in .storage and stay out of this repo.
+      "remote_calendar"
     ];
     customComponents = with pkgs.home-assistant-custom-components; [
       waste_collection_schedule

--- a/hosts/Nexus/services/home-assistant/patches/smartthinq-sensors-retry-setup.patch
+++ b/hosts/Nexus/services/home-assistant/patches/smartthinq-sensors-retry-setup.patch
@@ -1,0 +1,46 @@
+Restore ConfigEntryNotReady on setup failure.
+
+Upstream raised ConfigEntryNotReady here for years, until PR #965
+("Configurable scan interval", first released in v0.43.0) replaced it with
+`return True`. That PR's goal was to survive LG's 24 hour ban for polling more
+often than every 300 s: keeping the entry loaded leaves number.scan_interval
+usable, so a banned user can lower their polling rate without editing YAML.
+
+That trade does not apply here. LG returns UseOfficialAPIError transiently at
+startup and an immediate reload of the same entry succeeds, so this account is
+not banned. With `return True` the entry is marked loaded and Home Assistant
+never retries, which left every washer entity unavailable from the 02:02 nightly
+restart until the next one: seven outages of exactly 24.0 h in 30 days, 25% of
+the month. Raising ConfigEntryNotReady restores the built in retry with
+exponential backoff and recovers within minutes instead.
+
+Cost of this patch: while the entry is retrying, number.scan_interval does not
+exist. Our interval is already the 300 s default that PR #965 made safe, and the
+same value stays editable through the integration's options flow, so we do not
+need the entity to be present during an outage.
+
+Revisit on every version bump: if upstream reinstates the retry, or ties it to
+an option, drop this patch.
+
+--- a/custom_components/smartthinq_sensors/__init__.py
++++ b/custom_components/smartthinq_sensors/__init__.py
+@@ -284,9 +284,7 @@
+             _LOGGER.warning(
+                 "Connection not available. ThinQ platform not ready", exc_info=exc
+             )
+-        # Keep the entry loaded so the number entity is usable and the user
+-        # can adjust scan_interval; reload the entry once LG is reachable.
+-        return True
++        raise ConfigEntryNotReady("ThinQ platform not ready") from exc
+
+     if not client.has_devices:
+         _LOGGER.error("No ThinQ devices found. Component setup aborted")
+@@ -304,7 +302,7 @@
+                 "Connection not available. ThinQ platform not ready", exc_info=exc
+             )
+         await client.close()
+-        return True
++        raise ConfigEntryNotReady("ThinQ platform not ready") from exc
+
+     if discovered_devices is None:
+         await client.close()

--- a/hosts/Nexus/services/home-assistant/patches/smartthinq-sensors-retry-setup.patch
+++ b/hosts/Nexus/services/home-assistant/patches/smartthinq-sensors-retry-setup.patch
@@ -14,6 +14,11 @@ restart until the next one: seven outages of exactly 24.0 h in 30 days, 25% of
 the month. Raising ConfigEntryNotReady restores the built in retry with
 exponential backoff and recovers within minutes instead.
 
+Platform.NUMBER is forwarded earlier in async_setup_entry, before the first LG
+call, and Home Assistant does not call async_unload_entry when setup raises. So
+both branches unload it before raising, otherwise the retry dies with
+"Config entry ... for smartthinq_sensors.number has already been setup!".
+
 Cost of this patch: while the entry is retrying, number.scan_interval does not
 exist. Our interval is already the 300 s default that PR #965 made safe, and the
 same value stays editable through the integration's options flow, so we do not
@@ -24,22 +29,24 @@ an option, drop this patch.
 
 --- a/custom_components/smartthinq_sensors/__init__.py
 +++ b/custom_components/smartthinq_sensors/__init__.py
-@@ -284,9 +284,7 @@
+@@ -284,9 +284,8 @@
              _LOGGER.warning(
                  "Connection not available. ThinQ platform not ready", exc_info=exc
              )
 -        # Keep the entry loaded so the number entity is usable and the user
 -        # can adjust scan_interval; reload the entry once LG is reachable.
 -        return True
++        await hass.config_entries.async_unload_platforms(entry, [Platform.NUMBER])
 +        raise ConfigEntryNotReady("ThinQ platform not ready") from exc
 
      if not client.has_devices:
          _LOGGER.error("No ThinQ devices found. Component setup aborted")
-@@ -304,7 +302,7 @@
+@@ -304,7 +303,8 @@
                  "Connection not available. ThinQ platform not ready", exc_info=exc
              )
          await client.close()
 -        return True
++        await hass.config_entries.async_unload_platforms(entry, [Platform.NUMBER])
 +        raise ConfigEntryNotReady("ThinQ platform not ready") from exc
 
      if discovered_devices is None:

--- a/hosts/Nexus/services/postgresql.nix
+++ b/hosts/Nexus/services/postgresql.nix
@@ -35,6 +35,7 @@ in
       # Sonarr databases (main + log)
       "sonarr-main"
       "sonarr-log"
+      "grafana"
     ];
     ensureUsers = [
       {
@@ -56,6 +57,10 @@ in
       # Sonarr user (ownership set via script, db names don't match username)
       {
         name = "sonarr";
+      }
+      {
+        name = "grafana";
+        ensureDBOwnership = true;
       }
     ];
   };

--- a/hosts/Nexus/services/victoriametrics.nix
+++ b/hosts/Nexus/services/victoriametrics.nix
@@ -1,0 +1,22 @@
+{ ... }:
+{
+  # Long-term metrics archive for Home Assistant.
+  #
+  # HA's Postgres recorder costs roughly 60 MB/day for raw states; the same
+  # series in VictoriaMetrics cost about 0.7 MB/day. The recorder still backs
+  # the UI (history, logbook, more-info graphs) and keeps long-term statistics
+  # forever, so this is a parallel archive, not a replacement — see the
+  # `influxdb` block and the short `purge_keep_days` in home-assistant.nix.
+  services.victoriametrics = {
+    enable = true;
+
+    # Loopback only. Home Assistant writes and Grafana reads over localhost;
+    # nothing external should reach the unauthenticated write endpoint.
+    listenAddress = "127.0.0.1:8428";
+
+    # Mandatory. Upstream defaults to one month and prunes older partitions on
+    # first compaction, which would silently destroy the archive this exists
+    # to keep.
+    retentionPeriod = "100y";
+  };
+}

--- a/secrets/nexus/grafana-admin-password.age
+++ b/secrets/nexus/grafana-admin-password.age
@@ -1,0 +1,6 @@
+age-encryption.org/v1
+-> ssh-ed25519 IsuDgA W6WUfJ3xZsC/FqvUUSnKZxr27X8g+0P2we2ZEF1Gblk
+78EjUQYOWXDRBKGX4+6m1HMz420Z1q4aLgvw6I5/z+I
+--- 4YdBiw5Badvp9JpuWXtn5Cu6J8tdbI+8bm4lJ333Xo0
+Ба(	D
+jцv¬dУ©!йыч6”BЋ„Jјg?Ю%!#Я"NСЭ?1‡= ХЧњЌ"

--- a/secrets/nexus/grafana-secret-key.age
+++ b/secrets/nexus/grafana-secret-key.age
@@ -1,0 +1,5 @@
+age-encryption.org/v1
+-> ssh-ed25519 IsuDgA EdWqoNDhcQJ2JGYLYW577jiuWeseevKEEqnhlaeYElg
+9dN+EcmJcbbL9eHN+vTEJxtlTgH7KexMHdnyGpip1sI
+--- 8tMdJJ3P4kqoIgamDM+mY/tLideZ9AbfOYgf4CT2H4c
+{ß·ÄÁÀó±`åî@ù"n‘ÎÖÒÀÂÿÖ|ÜÌGütv:ÎS5X/aÁ6t¡ÈRô“0rãã”dûzâjòê´RwŒ°ù,“špW%Ó

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -34,6 +34,8 @@ in
   "nexus/restic-env.age".publicKeys = [ nexus ];
   "nexus/restic-password.age".publicKeys = [ nexus ];
   "nexus/route53-env.age".publicKeys = [ nexus ];
+  "nexus/grafana-admin-password.age".publicKeys = [ nexus ];
+  "nexus/grafana-secret-key.age".publicKeys = [ nexus ];
   "nexus/zigbee2mqtt.env.age".publicKeys = [ nexus ];
   "nexus/nextcloud-admin-password.age".publicKeys = [ nexus ];
   "nexus/geoip-license-key.age".publicKeys = [ nexus ];


### PR DESCRIPTION
Postgres holds 10 GB of HA recorder data for only 164 days — ~22 GB once the 365-day window fills. The same series cost ~0.7 MB/day in VictoriaMetrics (133 MB for 7 months, measured from the surviving archive).

- **victoriametrics.nix** — loopback-only, `retentionPeriod = "100y"`. Upstream defaults to one month and prunes older partitions on first compaction.
- **grafana.nix** — loopback-only behind Caddy, Postgres backend, VM datasource. VictoriaLogs dropped; it was enabled but nothing fed it.
- **caddy** — `grafana.matteopacini.me`, gated to LAN + tailnet by source IP, same pattern as `photos.matteopacini.me`. Cert via existing Route53 DNS-01.
- **home-assistant** — `influxdb` export to VM; `purge_keep_days` 365 → 30. Long-term statistics live in separate tables and are never purged, so year-scale trends are unaffected.
- **backup** — `/var/lib/victoriametrics` was never in `backup.nix`.

`hvac_action` is deliberately kept in the export (it was in the old `ignore_attributes`). `binary_sensor.needs_heating` keys off it, and its absence is why past heating behaviour could not be reconstructed.

Requires the two new agenix secrets, already committed encrypted to the Nexus host key.