### PR TITLE
fix(nexus): restrict n8n to LAN and tailnet

### DIFF
--- a/hosts/Nexus/services/caddy.nix
+++ b/hosts/Nexus/services/caddy.nix
@@ -71,6 +71,15 @@ in
             Strict-Transport-Security "max-age=31536000; includeSubDomains"
           }
 
+          # LAN + tailnet only. n8n's UI has its own login, but the Paperless
+          # document agent is reached through webhook paths that take no
+          # credentials, so without this gate the archive is queryable by
+          # anyone who learns the URL. Home Assistant calls n8n over loopback
+          # (webhook_conversation -> 127.0.0.1:5678), so nothing here needs to
+          # be reachable from outside.
+          @external not remote_ip 192.168.10.0/24 192.168.20.0/24 100.64.0.0/10 127.0.0.1/8
+          respond @external 403
+
           # Larger limit for workflow imports/exports and webhook payloads
           request_body {
             max_size 16MB


### PR DESCRIPTION
Gates the `n8n.matteopacini.me` vhost by source IP, using the same pattern `grafana` and `photos` already use.

## Why

n8n's UI sits behind its own login, but the Paperless document agent is reached through **webhook paths that take no credentials**. Anyone who learned a URL could query the document archive from the internet.

## What changed

```
@external not remote_ip 192.168.10.0/24 192.168.20.0/24 100.64.0.0/10 127.0.0.1/8
respond @external 403
```

LAN, IoT VLAN, tailnet and loopback only.

## Blast radius

- **Home Assistant is untouched** and stays public — it must remain reachable.
- HA no longer depends on n8n being public: the document agent now runs through the `webhook_conversation` integration over loopback (`127.0.0.1:5678`), replacing the old DocumentAssistant iframe, which has been removed.
- Accessing the n8n editor from outside the LAN now needs Tailscale.

## Verified

- `nix build .#nixosConfigurations.Nexus.config.system.build.toplevel` passes
- Diff is one file, one hunk, comments only plus the two gate lines — no secrets

https://claude.ai/code/session_01Cc622nm2JVPx5R2ieuCtUf