### PR TITLE
chore: weekly flake update - 2026-09-03T20:49:05Z

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,16 +26,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1786945682,
-        "narHash": "sha256-VBESSoJccikdhxh3vp3SQeG7cZXTOulMvVkoSqNDEhs=",
+        "lastModified": 1787796349,
+        "narHash": "sha256-5s+MJAFyemD6lvrtL2c0jQ7P/XChdx1MPXzoCaQY+ic=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "5b90e281d4e0c8fbd6ca4d8358276fb305b8d0bd",
+        "rev": "3e3da86e4eaccd23f4ce43df9b0a31b16c707347",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.18",
+        "ref": "6.0.20",
         "repo": "brew",
         "type": "github"
       }
@@ -271,11 +271,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788355065,
-        "narHash": "sha256-gAz5oTI7ur34CfuakQduiQd/2ZhO62Bn2XXg08nZYYQ=",
+        "lastModified": 1788487777,
+        "narHash": "sha256-Ro/e1N4ZR8/XaFF+sF9SgfPK79HM5YNEppzFj8p+0Ak=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d9d750e4fc11c10cab2da677bdd31e427f3a3a71",
+        "rev": "693e8ce0fb240a73c116a03cfd7b19269c87af88",
         "type": "github"
       },
       "original": {
@@ -287,11 +287,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1788417012,
-        "narHash": "sha256-GoCF/TK7txU0zPIrSkXXzJHXos1cgYqmsu13iYy3/cs=",
+        "lastModified": 1788485729,
+        "narHash": "sha256-srNdPeWsRvt1GwSD1ISFx/C7iWSq5PHfg02JJRk5Pyw=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "7dbb3bb22da39a0d1df92b2fe609aab1214eaf53",
+        "rev": "b25098d91b0a86319582275d3c959abb3b22c0ed",
         "type": "github"
       },
       "original": {
@@ -303,11 +303,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1788418327,
-        "narHash": "sha256-15xarBNFrAvk1t86d+QLkwGj4EkfG66bdVbbCMVR0k0=",
+        "lastModified": 1788488297,
+        "narHash": "sha256-+WUsxkGPuU/pjBDRh6P39BU1tmRRiFF+ydIVXcinfL8=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "a5a810921bccf1539047aa60c4d70825e7a72f31",
+        "rev": "40b3357b6168601f8353d0078114c29cd92ed51f",
         "type": "github"
       },
       "original": {
@@ -403,11 +403,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1787330919,
-        "narHash": "sha256-LslMncqN7uOOH5S88WZtO/EVt2HwD8ltUnfyANk+mC0=",
+        "lastModified": 1788444135,
+        "narHash": "sha256-ChwTDZPvTmEgZdS30dUfgdXlzAPtZAUWwEH/PfDXZmg=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "b00218e4aec0e5bf07d61a0bb13f842faa582d7b",
+        "rev": "ec8417a617de4d3c739aed40837e308ebd667165",
         "type": "github"
       },
       "original": {
@@ -469,11 +469,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1788422941,
-        "narHash": "sha256-JkX1/UHjz5U0zEsTRCG3sxJ9GCk7imvrXG/1+JuMAZA=",
+        "lastModified": 1788487333,
+        "narHash": "sha256-W6IkK/+oWinFNqd6ZJFMdzGI3FN4Gg2jhr8kzi4xZi0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a718ac06264a6eb180294b577aa9067c3f69e7e8",
+        "rev": "5fca99feb07a88140cde3e91dfb3da7886830e11",
         "type": "github"
       },
       "original": {
@@ -555,11 +555,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788423189,
-        "narHash": "sha256-Q9CHQ3RQOOkpA2FdTZOUlJwajXogAA0m2zhtboNFpgI=",
+        "lastModified": 1788488036,
+        "narHash": "sha256-uPbR0FRfmliAtvwrN5ipHdIEkdIHWII5IfynCQLRLKY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6448f06dc033c08d2c665e74f77b5dfbba5a8a37",
+        "rev": "04b3f7fce27d3bef3fe2b50d916a35afd509ec63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake inputs updated

Automated weekly `nix flake update` — refreshes all inputs.

### Changes:
```
unpacking 'github:ryantm/agenix/b027ee29d959fda4b60b57566d64c98a202e0feb' into the Git cache...
unpacking 'github:dracula/colorls/b8396e57df3406d231764f6561eef7d006367e18' into the Git cache...
unpacking 'github:nix-community/disko/ff8702b4de27f72b4c78573dfb89ec74e36abdf1' into the Git cache...
unpacking 'github:dracula/wallpaper/f2b8cc4223bcc2dfd5f165ab80f701bbb84e3303' into the Git cache...
unpacking 'github:rafaelmardojai/firefox-gnome-theme/5602ed62d638142c1ab31dccd01dfbfb28841225' into the Git cache...
unpacking 'github:nix-community/home-manager/693e8ce0fb240a73c116a03cfd7b19269c87af88' into the Git cache...
unpacking 'github:homebrew/homebrew-cask/b25098d91b0a86319582275d3c959abb3b22c0ed' into the Git cache...
unpacking 'github:homebrew/homebrew-core/40b3357b6168601f8353d0078114c29cd92ed51f' into the Git cache...
unpacking 'github:hraban/mac-app-util/039f33deef21782d4db97087f426504951239887' into the Git cache...
unpacking 'github:matteo-pacini/Magunetto/00319169f3b9326859eb8a04c4be4e4ad1bf57de' into the Git cache...
unpacking 'github:lnl7/nix-darwin/4cff07de74b50e64bdd68cd4e722ab5b6b35ee48' into the Git cache...
unpacking 'github:zhaofengli/nix-homebrew/ec8417a617de4d3c739aed40837e308ebd667165' into the Git cache...
unpacking 'github:nix-community/nix-index-database/dbb978fa87faf13398e90ccbc52c343d21c7dd6d' into the Git cache...
unpacking 'github:NixOS/nixpkgs/3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2' into the Git cache...
unpacking 'github:NixOS/nixpkgs/5fca99feb07a88140cde3e91dfb3da7886830e11' into the Git cache...
unpacking 'github:nix-community/NUR/04b3f7fce27d3bef3fe2b50d916a35afd509ec63' into the Git cache...
unpacking 'github:NotAShelf/nvf/f33afa7a878cfac9bebab42d8eccc7680c389cd6' into the Git cache...
unpacking 'github:dracula/sublime/d490b57c08f3d110ff61a07ec6edcc1ed9e24a63' into the Git cache...
unpacking 'github:dracula/xcode/fa045e9b1a47d348e8938ad6f14d3ee8a3b40788' into the Git cache...
• Updated input 'home-manager':
    'github:nix-community/home-manager/d9d750e4fc11c10cab2da677bdd31e427f3a3a71?narHash=sha256-gAz5oTI7ur34CfuakQduiQd/2ZhO62Bn2XXg08nZYYQ%3D' (2026-09-02)
  → 'github:nix-community/home-manager/693e8ce0fb240a73c116a03cfd7b19269c87af88?narHash=sha256-Ro/e1N4ZR8/XaFF%2BsF9SgfPK79HM5YNEppzFj8p%2B0Ak%3D' (2026-09-04)
• Updated input 'homebrew-cask':
    'github:homebrew/homebrew-cask/7dbb3bb22da39a0d1df92b2fe609aab1214eaf53?narHash=sha256-GoCF/TK7txU0zPIrSkXXzJHXos1cgYqmsu13iYy3/cs%3D' (2026-09-03)
  → 'github:homebrew/homebrew-cask/b25098d91b0a86319582275d3c959abb3b22c0ed?narHash=sha256-srNdPeWsRvt1GwSD1ISFx/C7iWSq5PHfg02JJRk5Pyw%3D' (2026-09-04)
• Updated input 'homebrew-core':
    'github:homebrew/homebrew-core/a5a810921bccf1539047aa60c4d70825e7a72f31?narHash=sha256-15xarBNFrAvk1t86d%2BQLkwGj4EkfG66bdVbbCMVR0k0%3D' (2026-09-03)
  → 'github:homebrew/homebrew-core/40b3357b6168601f8353d0078114c29cd92ed51f?narHash=sha256-%2BWUsxkGPuU/pjBDRh6P39BU1tmRRiFF%2BydIVXcinfL8%3D' (2026-09-04)
• Updated input 'nix-homebrew':
    'github:zhaofengli/nix-homebrew/b00218e4aec0e5bf07d61a0bb13f842faa582d7b?narHash=sha256-LslMncqN7uOOH5S88WZtO/EVt2HwD8ltUnfyANk%2BmC0%3D' (2026-08-21)
  → 'github:zhaofengli/nix-homebrew/ec8417a617de4d3c739aed40837e308ebd667165?narHash=sha256-ChwTDZPvTmEgZdS30dUfgdXlzAPtZAUWwEH/PfDXZmg%3D' (2026-09-03)
• Updated input 'nix-homebrew/brew-src':
    'github:Homebrew/brew/5b90e281d4e0c8fbd6ca4d8358276fb305b8d0bd?narHash=sha256-VBESSoJccikdhxh3vp3SQeG7cZXTOulMvVkoSqNDEhs%3D' (2026-08-17)
  → 'github:Homebrew/brew/3e3da86e4eaccd23f4ce43df9b0a31b16c707347?narHash=sha256-5s%2BMJAFyemD6lvrtL2c0jQ7P/XChdx1MPXzoCaQY%2Bic%3D' (2026-08-27)
• Updated input 'nixpkgs-master':
    'github:NixOS/nixpkgs/a718ac06264a6eb180294b577aa9067c3f69e7e8?narHash=sha256-JkX1/UHjz5U0zEsTRCG3sxJ9GCk7imvrXG/1%2BJuMAZA%3D' (2026-09-03)
  → 'github:NixOS/nixpkgs/5fca99feb07a88140cde3e91dfb3da7886830e11?narHash=sha256-W6IkK/%2BoWinFNqd6ZJFMdzGI3FN4Gg2jhr8kzi4xZi0%3D' (2026-09-04)
• Updated input 'nur':
    'github:nix-community/NUR/6448f06dc033c08d2c665e74f77b5dfbba5a8a37?narHash=sha256-Q9CHQ3RQOOkpA2FdTZOUlJwajXogAA0m2zhtboNFpgI%3D' (2026-09-03)
  → 'github:nix-community/NUR/04b3f7fce27d3bef3fe2b50d916a35afd509ec63?narHash=sha256-uPbR0FRfmliAtvwrN5ipHdIEkdIHWII5IfynCQLRLKY%3D' (2026-09-04)
```
